### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/keras_cv/layers/deeplab.py
+++ b/keras_cv/layers/deeplab.py
@@ -42,7 +42,7 @@ class SpatialPyramidPooling(tf.keras.layers.Layer):
       **kwargs):
     """Initializes `SpatialPyramidPooling`.
 
-    Arguments:
+    Args:
       output_channels: Number of channels produced by SpatialPyramidPooling.
       dilation_rates: A list of integers for parallel dilated conv.
       pool_kernel_size: A list of integers or None. If None, global average

--- a/keras_cv/losses/focal_loss.py
+++ b/keras_cv/losses/focal_loss.py
@@ -31,7 +31,7 @@ class FocalLoss(tf.keras.losses.Loss):
                name=None):
     """Initializes `FocalLoss`.
 
-    Arguments:
+    Args:
       alpha: The `alpha` weight factor for binary class imbalance.
       gamma: The `gamma` focusing parameter to re-weight loss.
       reduction: (Optional) Type of `tf.keras.losses.Reduction` to apply to
@@ -52,7 +52,7 @@ class FocalLoss(tf.keras.losses.Loss):
   def call(self, y_true, y_pred):
     """Invokes the `FocalLoss`.
 
-    Arguments:
+    Args:
       y_true: A tensor of size [batch, num_anchors, num_classes]
       y_pred: A tensor of size [batch, num_anchors, num_classes]
 

--- a/keras_cv/losses/loss_utils.py
+++ b/keras_cv/losses/loss_utils.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 def multi_level_flatten(multi_level_inputs, last_dim=None):
   """Flattens a multi-level input.
 
-  Arguments:
+  Args:
     multi_level_inputs: Ordered Dict with level to [batch, d1, ..., dm].
     last_dim: Whether the output should be [batch_size, None], or [batch_size,
       None, last_dim]. Defaults to `None`.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420