### PR TITLE
Add MixUp & CutMix preprocessing layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 keras_cv.egg-info/
+build/
 *.swp
 .idea
 *.pyc

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -1,10 +1,10 @@
-"""mix_up_example.py shows how to use the RandomMixUp preprocessing layer to 
+"""mix_up_example.py shows how to use the CutMix preprocessing layer to 
 preprocess the oxford_flowers102 dataset.  In this script the flowers 
 are loaded, then are passed through the preprocessing layers.  
 Finally, they are shown using matplotlib.
 """
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_cut_mix import RandomCutMix
+from keras_cv.layers.preprocessing.cut_mix import CutMix
 import tensorflow_datasets as tfds
 import matplotlib.pyplot as plt
 
@@ -28,9 +28,9 @@ def main():
     num_classes = ds_info.features["label"].num_classes
 
     train_ds = (
-        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
+        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH)
     )
-    cutmix = RandomCutMix(num_classes=num_classes)
+    cutmix = CutMix(num_classes=num_classes)
     train_ds = train_ds.map(cutmix, num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -31,7 +31,7 @@ def main():
         train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
     )
     cutmix = RandomCutMix(num_classes=num_classes)
-    train_ds = train_ds.map(cutmix, num_parallel_calls=AUTOTUNE)
+    train_ds = train_ds.map(lambda x, y: cutmix((x, y)), num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -31,7 +31,7 @@ def main():
         train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
     )
     cutmix = RandomCutMix(num_classes=num_classes)
-    train_ds = train_ds.map(lambda x, y: cutmix((x, y)), num_parallel_calls=AUTOTUNE)
+    train_ds = train_ds.map(cutmix, num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -1,23 +1,22 @@
-"""mix_up_example.py shows how to use the CutMix preprocessing layer to 
+"""cut_mix_demo.py shows how to use the CutMix preprocessing layer to 
 preprocess the oxford_flowers102 dataset.  In this script the flowers 
 are loaded, then are passed through the preprocessing layers.  
 Finally, they are shown using matplotlib.
 """
 import tensorflow as tf
-from keras_cv.layers.preprocessing.cut_mix import CutMix
 import tensorflow_datasets as tfds
+import keras_cv.layers.preprocessing.cut_mix as cut_mix
 import matplotlib.pyplot as plt
 
 
-IMG_SIZE = 224
+IMG_SIZE = (224, 224)
 BATCH = 16
 
-AUTOTUNE = tf.data.AUTOTUNE
 
-
-def resize(image, label):
+def resize(image, label, num_classes=10):
     image = tf.cast(image, tf.float32)
-    image = tf.image.resize(image, (IMG_SIZE, IMG_SIZE))
+    image = tf.image.resize(image, IMG_SIZE)
+    label = tf.one_hot(label, num_classes)
     return image, label
 
 
@@ -28,10 +27,12 @@ def main():
     num_classes = ds_info.features["label"].num_classes
 
     train_ds = (
-        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH)
+        train_ds.map(lambda x, y: resize(x, y, num_classes=num_classes))
+        .shuffle(10 * BATCH)
+        .batch(BATCH)
     )
-    cutmix = CutMix(num_classes=num_classes)
-    train_ds = train_ds.map(cutmix, num_parallel_calls=AUTOTUNE)
+    cutmix = cut_mix.CutMix()
+    train_ds = train_ds.map(cutmix, num_parallel_calls=tf.data.AUTOTUNE)
 
     for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -1,20 +1,20 @@
-"""cut_mix_demo.py shows how to use the CutMix preprocessing layer to 
-preprocess the oxford_flowers102 dataset.  In this script the flowers 
+"""cut_mix_demo.py shows how to use the CutMix preprocessing layer.
+
+Operates on the oxford_flowers102 dataset.  In this script the flowers 
 are loaded, then are passed through the preprocessing layers.  
 Finally, they are shown using matplotlib.
 """
 import tensorflow as tf
 import tensorflow_datasets as tfds
-import keras_cv.layers.preprocessing.cut_mix as cut_mix
+from keras_cv.layers.preprocessing import cut_mix
 import matplotlib.pyplot as plt
 
 
 IMG_SIZE = (224, 224)
-BATCH = 16
+BATCH_SIZE = 64
 
 
 def resize(image, label, num_classes=10):
-    image = tf.cast(image, tf.float32)
     image = tf.image.resize(image, IMG_SIZE)
     label = tf.one_hot(label, num_classes)
     return image, label
@@ -28,8 +28,8 @@ def main():
 
     train_ds = (
         train_ds.map(lambda x, y: resize(x, y, num_classes=num_classes))
-        .shuffle(10 * BATCH)
-        .batch(BATCH)
+        .shuffle(10 * BATCH_SIZE)
+        .batch(BATCH_SIZE)
     )
     cutmix = cut_mix.CutMix()
     train_ds = train_ds.map(cutmix, num_parallel_calls=tf.data.AUTOTUNE)

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -31,7 +31,7 @@ def main():
         .shuffle(10 * BATCH_SIZE)
         .batch(BATCH_SIZE)
     )
-    cutmix = cut_mix.CutMix()
+    cutmix = cut_mix.CutMix(1.0)
     train_ds = train_ds.map(cutmix, num_parallel_calls=tf.data.AUTOTUNE)
 
     for images, labels in train_ds.take(1):

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -1,0 +1,46 @@
+"""mix_up_example.py shows how to use the RandomMixUp preprocessing layer to 
+preprocess the oxford_flowers102 dataset.  In this script the flowers 
+are loaded, then are passed through the preprocessing layers.  
+Finally, they are shown using matplotlib.
+"""
+import tensorflow as tf
+from keras_cv.layers.preprocessing.random_cut_mix import RandomCutMix
+import tensorflow_datasets as tfds
+import matplotlib.pyplot as plt
+
+
+IMG_SIZE = 224
+BATCH = 16
+
+AUTOTUNE = tf.data.AUTOTUNE
+
+
+def resize(image, label):
+    image = tf.cast(image, tf.float32)
+    image = tf.image.resize(image, (IMG_SIZE, IMG_SIZE))
+    return image, label
+
+
+def main():
+    data, ds_info = tfds.load("oxford_flowers102", with_info=True, as_supervised=True)
+    train_ds = data["train"]
+
+    num_classes = ds_info.features["label"].num_classes
+
+    train_ds = (
+        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
+    )
+    cutmix = RandomCutMix(num_classes=num_classes)
+    train_ds = train_ds.map(cutmix, num_parallel_calls=AUTOTUNE)
+
+    for images, labels in train_ds.take(1):
+        plt.figure(figsize=(8, 8))
+        for i in range(9):
+            plt.subplot(3, 3, i + 1)
+            plt.imshow(images[i].numpy().astype("uint8"))
+            plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -31,7 +31,7 @@ def main():
         train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
     )
     mixup = RandomMixUp(num_classes=num_classes)
-    train_ds = train_ds.map(mixup, num_parallel_calls=AUTOTUNE)
+    train_ds = train_ds.map(lambda x, y: mixup((x, y)), num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -31,7 +31,7 @@ def main():
         .shuffle(10 * BATCH_SIZE)
         .batch(BATCH_SIZE)
     )
-    mixup = mix_up.MixUp(alpha=0.8)
+    mixup = mix_up.MixUp(1.0, alpha=0.8)
     train_ds = train_ds.map(mixup, num_parallel_calls=tf.data.AUTOTUNE)
 
     for images, labels in train_ds.take(1):

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -1,20 +1,20 @@
-"""mix_up_demo.py shows how to use the MixUp preprocessing layer to 
-preprocess the oxford_flowers102 dataset.  In this script the flowers 
+"""mix_up_demo.py shows how to use the MixUp preprocessing layer.
+
+Uses the oxford_flowers102 dataset.  In this script the flowers 
 are loaded, then are passed through the preprocessing layers.  
 Finally, they are shown using matplotlib.
 """
 import tensorflow as tf
 import tensorflow_datasets as tfds
-import keras_cv.layers.preprocessing.mix_up as mix_up
+from keras_cv.layers.preprocessing import mix_up
 import matplotlib.pyplot as plt
 
 
 IMG_SIZE = (224, 224)
-BATCH = 16
+BATCH_SIZE = 64
 
 
 def resize(image, label, num_classes=10):
-    image = tf.cast(image, tf.float32)
     image = tf.image.resize(image, IMG_SIZE)
     label = tf.one_hot(label, num_classes)
     return image, label
@@ -28,8 +28,8 @@ def main():
 
     train_ds = (
         train_ds.map(lambda x, y: resize(x, y, num_classes=num_classes))
-        .shuffle(10 * BATCH)
-        .batch(BATCH)
+        .shuffle(10 * BATCH_SIZE)
+        .batch(BATCH_SIZE)
     )
     mixup = mix_up.MixUp()
     train_ds = train_ds.map(mixup, num_parallel_calls=tf.data.AUTOTUNE)

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -1,10 +1,10 @@
-"""mix_up_example.py shows how to use the RandomMixUp preprocessing layer to 
+"""mix_up_example.py shows how to use the MixUp preprocessing layer to 
 preprocess the oxford_flowers102 dataset.  In this script the flowers 
 are loaded, then are passed through the preprocessing layers.  
 Finally, they are shown using matplotlib.
 """
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_mix_up import RandomMixUp
+from keras_cv.layers.preprocessing.mix_up import MixUp
 import tensorflow_datasets as tfds
 import matplotlib.pyplot as plt
 
@@ -28,9 +28,9 @@ def main():
     num_classes = ds_info.features["label"].num_classes
 
     train_ds = (
-        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
+        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH)
     )
-    mixup = RandomMixUp(num_classes=num_classes)
+    mixup = MixUp(num_classes=num_classes)
     train_ds = train_ds.map(mixup, num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -31,7 +31,7 @@ def main():
         .shuffle(10 * BATCH_SIZE)
         .batch(BATCH_SIZE)
     )
-    mixup = mix_up.MixUp()
+    mixup = mix_up.MixUp(alpha=0.8)
     train_ds = train_ds.map(mixup, num_parallel_calls=tf.data.AUTOTUNE)
 
     for images, labels in train_ds.take(1):

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -31,7 +31,7 @@ def main():
         train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
     )
     mixup = RandomMixUp(num_classes=num_classes)
-    train_ds = train_ds.map(lambda x, y: mixup((x, y)), num_parallel_calls=AUTOTUNE)
+    train_ds = train_ds.map(mixup, num_parallel_calls=AUTOTUNE)
 
     for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -1,0 +1,46 @@
+"""mix_up_example.py shows how to use the RandomMixUp preprocessing layer to 
+preprocess the oxford_flowers102 dataset.  In this script the flowers 
+are loaded, then are passed through the preprocessing layers.  
+Finally, they are shown using matplotlib.
+"""
+import tensorflow as tf
+from keras_cv.layers.preprocessing.random_mix_up import RandomMixUp
+import tensorflow_datasets as tfds
+import matplotlib.pyplot as plt
+
+
+IMG_SIZE = 224
+BATCH = 16
+
+AUTOTUNE = tf.data.AUTOTUNE
+
+
+def resize(image, label):
+    image = tf.cast(image, tf.float32)
+    image = tf.image.resize(image, (IMG_SIZE, IMG_SIZE))
+    return image, label
+
+
+def main():
+    data, ds_info = tfds.load("oxford_flowers102", with_info=True, as_supervised=True)
+    train_ds = data["train"]
+
+    num_classes = ds_info.features["label"].num_classes
+
+    train_ds = (
+        train_ds.map(resize).shuffle(10 * BATCH).batch(BATCH, drop_remainder=True)
+    )
+    mixup = RandomMixUp(num_classes=num_classes)
+    train_ds = train_ds.map(mixup, num_parallel_calls=AUTOTUNE)
+
+    for images, labels in train_ds.take(1):
+        plt.figure(figsize=(8, 8))
+        for i in range(9):
+            plt.subplot(3, 3, i + 1)
+            plt.imshow(images[i].numpy().astype("uint8"))
+            plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -37,8 +37,8 @@ class CutMix(layers.Layer):
         call method for the CutMix layer.
 
         Args:
-            images: Tensor representing images of shape [batch_size, width, height, channels].
-            labels: One hot encoded tensor of labels for the images.
+            images: Tensor representing images of shape [batch_size, width, height, channels], with dtype tf.float32.
+            labels: One hot encoded tensor of labels for the images, with dtype tf.float32.
         Returns:
             images: augmented images, same shape as input.
             labels: updated labels with both label smoothing and the cutmix updates applied.
@@ -61,7 +61,7 @@ class CutMix(layers.Layer):
         )
 
         lambda_sample = CutMix._sample_from_beta(
-            self.alpha, self.alpha, (tf.shape(labels)[0],)
+            self.alpha, self.alpha, (batch_size,)
         )
 
         ratio = tf.math.sqrt(1 - lambda_sample)
@@ -120,8 +120,9 @@ def _fill_rectangle(
     image, center_width, center_height, half_width, half_height, replace=None
 ):
     """Fill blank area."""
-    image_height = tf.shape(image)[0]
-    image_width = tf.shape(image)[1]
+    image_shape = tf.shape(image)
+    image_height = image_shape[0]
+    image_width = image_shape[1]
 
     lower_pad = tf.maximum(0, center_height - half_height)
     upper_pad = tf.maximum(0, image_height - center_height - half_height)
@@ -137,10 +138,10 @@ def _fill_rectangle(
         tf.zeros(cutout_shape, dtype=image.dtype), padding_dims, constant_values=1
     )
     mask = tf.expand_dims(mask, -1)
-    mask = tf.tile(mask, [1, 1, 3])
+    mask = tf.tile(mask, [1, 1, image_shape[-1]])
 
     if replace is None:
-        fill = tf.random.normal(tf.shape(image), dtype=image.dtype)
+        fill = tf.random.normal(image_shape, dtype=image.dtype)
     elif isinstance(replace, tf.Tensor):
         fill = replace
     else:

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -17,7 +17,7 @@ class CutMix(layers.Layer):
             confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
             will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-       [CutMix paper]( https://arxiv.org/abs/1905.04899).
+       [CutMix]( https://arxiv.org/abs/1905.04899).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -14,9 +14,9 @@ class CutMix(layers.Layer):
 
     Sample usage:
     ```python
-    (x_train, y_train), (x_test, y_test) = keras.datasets.cifar10.load_data()
+    (images, labels), _ = tf.keras.datasets.cifar10.load_data()
     cutmix = CutMix(10)
-    augmented_data, updated_labels = cutmix(x_train, y_train)
+    augmented_images, updated_labels = cutmix(images, labels)
     ```
     """
 
@@ -59,8 +59,12 @@ class CutMix(layers.Layer):
 
         ratio = tf.math.sqrt(1 - lambda_sample)
 
-        batch_size = tf.shape(images)[0]
-        image_height, image_width = tf.shape(images)[1], tf.shape(images)[2]
+        input_shape = tf.shape(images)
+        batch_size, image_height, image_width = (
+            input_shape[0],
+            input_shape[1],
+            input_shape[2],
+        )
 
         cut_height = tf.cast(
             ratio * tf.cast(image_height, dtype=tf.float32), dtype=tf.int32
@@ -98,10 +102,10 @@ class CutMix(layers.Layer):
 
     def _update_labels(self, images, labels, lambda_sample):
         labels_1 = self._smooth_labels(labels)
-        labels_2 = tf.reverse(labels_1, [0])
+        cutout_labels = tf.reverse(labels_1, [0])
 
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
-        labels = lambda_sample * labels_1 + (1.0 - lambda_sample) * labels_2
+        labels = lambda_sample * labels_1 + (1.0 - lambda_sample) * cutout_labels
 
         return images, labels
 

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -8,9 +8,9 @@ class CutMix(layers.Layer):
     CutMix implements the CutMix data augmentation technique as proposed in https://arxiv.org/abs/1905.04899.
 
     Args:
-        alpha: alpha parameter for the sample distribution.
-        probability: probability to apply the CutMix augmentation.
-        label_smoothing: coefficient used in label smoothing.
+        alpha: alpha parameter for the sample distribution.  Defaults 0.8.
+        probability: probability to apply the CutMix augmentation.  Default 1.0.
+        label_smoothing: coefficient used in label smoothing.  Default 0.0.
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -17,7 +17,7 @@ class CutMix(layers.Layer):
             confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
             will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-       [CutMix]( https://arxiv.org/abs/1905.04899).
+       [CutMix paper]( https://arxiv.org/abs/1905.04899).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -15,7 +15,7 @@ class CutMix(layers.Layer):
     Sample usage:
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
-    cutmix = CutMix(10)
+    cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
     augmented_images, updated_labels = cutmix(images, labels)
     ```
     """

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -8,11 +8,11 @@ class CutMix(layers.Layer):
     """CutMix implements the CutMix data augmentation technique.
 
     Args:
+        rate: Float between 0 and 1.  The fraction of samples to augment.
         alpha: Float between 0 and 1.  Inverse scale parameter for the gamma distribution.
             This controls the shape of the distribution from which the smoothing values are 
             sampled.  Defaults 1.0, which is a recommended value when training an imagenet1k
             classification model.
-        probability: Float between 0 and 1.  The fraction of samples to augment.  Default 1.0.
         label_smoothing: coefficient used in label smoothing.  Default 0.0.
     References:
         https://arxiv.org/abs/1905.04899.
@@ -26,11 +26,11 @@ class CutMix(layers.Layer):
     """
 
     def __init__(
-        self, probability=1.0, label_smoothing=0.0, alpha=1.0, seed=None, **kwargs
+        self, rate, label_smoothing=0.0, alpha=1.0, seed=None, **kwargs
     ):
         super(CutMix, self).__init__(*kwargs)
         self.alpha = alpha
-        self.probability = probability
+        self.rate = rate
         self.label_smoothing = label_smoothing
         self.seed = seed
 
@@ -58,7 +58,7 @@ class CutMix(layers.Layer):
             )
 
         augment_cond = tf.less(
-            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
+            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.rate
         )
         # pylint: disable=g-long-lambda
         cutmix_augment = lambda: self._update_labels(*self._cutmix(images, labels))

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -28,7 +28,7 @@ class CutMix(layers.Layer):
     def __init__(
         self, rate, label_smoothing=0.0, alpha=1.0, seed=None, **kwargs
     ):
-        super(CutMix, self).__init__(*kwargs)
+        super().__init__(**kwargs)
         self.alpha = alpha
         self.rate = rate
         self.label_smoothing = label_smoothing

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -13,9 +13,11 @@ class CutMix(layers.Layer):
             This controls the shape of the distribution from which the smoothing values are 
             sampled.  Defaults 1.0, which is a recommended value when training an imagenet1k
             classification model.
-        label_smoothing: coefficient used in label smoothing.  Default 0.0.
+        label_smoothing: Float in [0, 1]. When > 0, label values are smoothed, meaning the 
+            confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
+            will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-        https://arxiv.org/abs/1905.04899.
+       [CutMix paper]( https://arxiv.org/abs/1905.04899).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -22,7 +22,13 @@ class CutMix(layers.Layer):
     """
 
     def __init__(
-        self, alpha=0.8, probability=1.0, label_smoothing=0.0, seed=None, **kwargs
+        self,
+        alpha=0.8,
+        probability=1.0,
+        label_smoothing=0.0,
+        shuffle=False,
+        seed=None,
+        **kwargs
     ):
         super(CutMix, self).__init__(*kwargs)
         self.alpha = alpha
@@ -102,7 +108,7 @@ class CutMix(layers.Layer):
                 random_center_height,
                 cut_width // 2,
                 cut_height // 2,
-                tf.gather(images, permutation_order)
+                tf.gather(images, permutation_order),
             ),
             dtype=(tf.float32, tf.int32, tf.int32, tf.int32, tf.int32, tf.float32),
             fn_output_signature=tf.TensorSpec(images.shape[1:], dtype=tf.float32),
@@ -129,7 +135,19 @@ class CutMix(layers.Layer):
 def _fill_rectangle(
     image, center_width, center_height, half_width, half_height, replace=None
 ):
-    """Fill blank area."""
+    """Fill a rectangle in a given image using the value provided in replace.
+
+    Args:
+        image: the starting image to fill the rectangle on.
+        center_width: the X center of the rectangle to fill
+        center_height: the Y center of the rectangle to fill
+        half_width: 1/2 the width of the resulting rectangle
+        half_height: 1/2 the height of the resulting rectangle
+        replace: The value to fill the rectangle with.  Accepts a Tensor, 
+            Constant, or None.
+    Returns:
+        image: the modified image with the chosen rectangle filled.
+     """
     image_shape = tf.shape(image)
     image_height = image_shape[0]
     image_width = image_shape[1]

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -9,7 +9,9 @@ class CutMix(layers.Layer):
 
     Args:
         alpha: Float between 0 and 1.  Inverse scale parameter for the gamma distribution.
-            Defaults 0.8.
+            This controls the shape of the distribution from which the smoothing values are 
+            sampled.  Defaults 1.0, which is a recommended value when training an imagenet1k
+            classification model.
         probability: Float between 0 and 1.  The fraction of samples to augment.  Default 1.0.
         label_smoothing: coefficient used in label smoothing.  Default 0.0.
     References:
@@ -24,7 +26,7 @@ class CutMix(layers.Layer):
     """
 
     def __init__(
-        self, alpha=0.8, probability=1.0, label_smoothing=0.0, seed=None, **kwargs
+        self, probability=1.0, label_smoothing=0.0, alpha=1.0, seed=None, **kwargs
     ):
         super(CutMix, self).__init__(*kwargs)
         self.alpha = alpha
@@ -105,7 +107,6 @@ class CutMix(layers.Layer):
                 cut_height // 2,
                 tf.gather(images, permutation_order),
             ),
-            dtype=(tf.float32, tf.int32, tf.int32, tf.int32, tf.int32, tf.float32),
             fn_output_signature=tf.TensorSpec.from_tensor(images[0]),
         )
 

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 import tensorflow.keras as keras
 import tensorflow.keras.layers as layers
-import warnings
 
 
 class CutMix(layers.Layer):
@@ -44,13 +43,6 @@ class CutMix(layers.Layer):
             images: augmented images, same shape as input.
             labels: updated labels with both label smoothing and the cutmix updates applied.
         """
-        if tf.shape(images)[0] == 1:
-            warnings.warn(
-                "CutMix called with a batch size of 1.  CutMix relies on "
-                "combining multiple examples, and as such does not behave as expected "
-                "when used with a batch size of 1."
-            )
-
         augment_cond = tf.less(
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -1,14 +1,14 @@
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_mix_up import RandomMixUp
+from keras_cv.layers.preprocessing.random_cut_mix import CutMix
 
-class RandomMixUpTest(tf.test.TestCase):
+class MixUpTest(tf.test.TestCase):
     def test_return_shapes(self):
         xs = tf.ones((2, 512, 512, 3))
         # randomly sample labels
         ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
         ys = tf.squeeze(ys, axis=0)
 
-        layer = RandomMixUp(num_classes=2, probability=1.0) 
+        layer = CutMix(num_classes=2, probability=1.0) 
         xs, ys = layer(xs, ys)
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -13,7 +13,7 @@ class CutMixTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = CutMix(probability=1.0)
+        layer = CutMix(probability=1.0, seed=1)
         xs, ys = layer(xs, ys)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
@@ -28,7 +28,7 @@ class CutMixTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.2)
+        layer = CutMix(probability=1.0, label_smoothing=0.2, seed=1)
         xs, ys = layer(xs, ys)
         self.assertNotAllClose(ys, 0.0)
 
@@ -38,7 +38,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.0)
+        layer = CutMix(probability=1.0, label_smoothing=0.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation
@@ -56,7 +56,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.0)
+        layer = CutMix(probability=1.0, label_smoothing=0.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -13,7 +13,7 @@ class CutMixTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = CutMix(probability=1.0, seed=1)
+        layer = CutMix(1.0, seed=1)
         xs, ys = layer(xs, ys)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
@@ -28,7 +28,7 @@ class CutMixTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.2, seed=1)
+        layer = CutMix(1.0, label_smoothing=0.2, seed=1)
         xs, ys = layer(xs, ys)
         self.assertNotAllClose(ys, 0.0)
 
@@ -38,7 +38,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation
@@ -56,7 +56,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation
@@ -74,7 +74,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(probability=1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
 
         @tf.function
         def augment(x, y):

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -49,3 +49,21 @@ class CutMixTest(tf.test.TestCase):
         # No labels should still be close to their original values
         self.assertNotAllClose(ys, 1.0)
         self.assertNotAllClose(ys, 0.0)
+
+    def test_cut_mix_call_results_one_channel(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((4, 4, 1)), tf.ones((4, 4, 1))], axis=0,), tf.float32,
+        )
+        ys = tf.one_hot(tf.constant([0, 1]), 2)
+
+        layer = CutMix(probability=1.0, label_smoothing=0.0)
+        xs, ys = layer(xs, ys)
+
+        # At least some pixels should be replaced in the CutMix operation
+        self.assertTrue(tf.math.reduce_any(xs[0] == 1.0))
+        self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
+        self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(tf.math.reduce_any(xs[1] == 2.0))
+        # No labels should still be close to their original values
+        self.assertNotAllClose(ys, 1.0)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -31,3 +31,21 @@ class CutMixTest(tf.test.TestCase):
         layer = CutMix(probability=1.0, label_smoothing=0.2)
         xs, ys = layer(xs, ys)
         self.assertNotAllClose(ys, 0.0)
+
+    def test_cut_mix_call_results(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((4, 4, 3)), tf.ones((4, 4, 3))], axis=0,), tf.float32,
+        )
+        ys = tf.one_hot(tf.constant([0, 1]), 2)
+
+        layer = CutMix(probability=1.0, label_smoothing=0.0)
+        xs, ys = layer(xs, ys)
+
+        # At least some pixels should be replaced in the CutMix operation
+        self.assertTrue(tf.math.reduce_any(xs[0] == 1.0))
+        self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
+        self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(tf.math.reduce_any(xs[1] == 2.0))
+        # No labels should still be close to their original values
+        self.assertNotAllClose(ys, 1.0)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -1,16 +1,33 @@
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_cut_mix import CutMix
+from keras_cv.layers.preprocessing.cut_mix import CutMix
 
-class MixUpTest(tf.test.TestCase):
+
+NUM_CLASSES = 10
+
+
+class CutMixTest(tf.test.TestCase):
     def test_return_shapes(self):
         xs = tf.ones((2, 512, 512, 3))
         # randomly sample labels
         ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
-        ys = tf.squeeze(ys, axis=0)
+        ys = tf.squeeze(ys)
+        ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = CutMix(num_classes=2, probability=1.0) 
+        layer = CutMix(probability=1.0)
         xs, ys = layer(xs, ys)
-        
+
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels
-        self.assertEqual(ys.shape, [2, 2])
+        self.assertEqual(ys.shape, [2, 10])
+        self.assertEqual(len(ys != 0.0), 2)
+
+    def test_label_smoothing(self):
+        xs = tf.ones((2, 512, 512, 3))
+        # randomly sample labels
+        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
+        ys = tf.squeeze(ys)
+        ys = tf.one_hot(ys, NUM_CLASSES)
+
+        layer = CutMix(probability=1.0, label_smoothing=0.2)
+        xs, ys = layer(xs, ys)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -17,7 +17,7 @@ class MixUp(layers.Layer):
             confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
             will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-        [MixUp paper](https://arxiv.org/abs/1710.09412).
+        [MixUp](https://arxiv.org/abs/1710.09412).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -17,7 +17,7 @@ class MixUp(layers.Layer):
             confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
             will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-        [MixUp](https://arxiv.org/abs/1710.09412).
+        [MixUp paper](https://arxiv.org/abs/1710.09412).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -8,11 +8,11 @@ class MixUp(layers.Layer):
     """MixUp implements the MixUp data augmentation technique.
 
     Args:
+        rate: Float between 0 and 1.  The fraction of samples to augment.
         alpha: Float between 0 and 1.  Inverse scale parameter for the gamma distribution.
             This controls the shape of the distribution from which the smoothing values are 
             sampled.  Defaults 0.2, which is a recommended value when training an imagenet1k
             classification model.
-        probability: Float between 0 and 1.  The fraction of samples to augment.  Default 1.0.
         label_smoothing: Float between 0 and 1.  The coefficient used in label smoothing.  Default 0.0.
     References:
         https://arxiv.org/abs/1710.09412.
@@ -26,11 +26,11 @@ class MixUp(layers.Layer):
     """
 
     def __init__(
-        self, probability=1.0, label_smoothing=0.0, alpha=0.2, seed=None, **kwargs
+        self, rate, label_smoothing=0.0, alpha=0.2, seed=None, **kwargs
     ):
         super(MixUp, self).__init__(*kwargs)
         self.alpha = alpha
-        self.probability = probability
+        self.rate = rate
         self.label_smoothing = label_smoothing
         self.seed = seed
 
@@ -58,7 +58,7 @@ class MixUp(layers.Layer):
             )
 
         augment_cond = tf.less(
-            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
+            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.rate
         )
         # pylint: disable=g-long-lambda
         mixup_augment = lambda: self._update_labels(*self._mixup(images, labels))

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -13,7 +13,9 @@ class MixUp(layers.Layer):
             This controls the shape of the distribution from which the smoothing values are 
             sampled.  Defaults 0.2, which is a recommended value when training an imagenet1k
             classification model.
-        label_smoothing: Float between 0 and 1.  The coefficient used in label smoothing.  Default 0.0.
+        label_smoothing: Float in [0, 1]. When > 0, label values are smoothed, meaning the 
+            confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
+            will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
         https://arxiv.org/abs/1710.09412.
 

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -14,9 +14,9 @@ class MixUp(layers.Layer):
 
     Sample usage:
     ```python
-    (x_train, y_train), (x_test, y_test) = keras.datasets.cifar10.load_data()
+    (images, labels), _ = tf.keras.datasets.cifar10.load_data()
     mixup = MixUp(10)
-    augmented_data, updated_labels = mixup(x_train, y_train)
+    augmented_images, updated_labels = mixup(images, labels)
     ```
     """
 

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -9,7 +9,9 @@ class MixUp(layers.Layer):
 
     Args:
         alpha: Float between 0 and 1.  Inverse scale parameter for the gamma distribution.
-            Defaults 0.8.
+            This controls the shape of the distribution from which the smoothing values are 
+            sampled.  Defaults 0.2, which is a recommended value when training an imagenet1k
+            classification model.
         probability: Float between 0 and 1.  The fraction of samples to augment.  Default 1.0.
         label_smoothing: Float between 0 and 1.  The coefficient used in label smoothing.  Default 0.0.
     References:
@@ -24,7 +26,7 @@ class MixUp(layers.Layer):
     """
 
     def __init__(
-        self, alpha=0.8, probability=1.0, label_smoothing=0.0, seed=None, **kwargs
+        self, probability=1.0, label_smoothing=0.0, alpha=0.2, seed=None, **kwargs
     ):
         super(MixUp, self).__init__(*kwargs)
         self.alpha = alpha

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -8,9 +8,9 @@ class MixUp(layers.Layer):
     MixUp implements the MixUp data augmentation technique as proposed in https://arxiv.org/abs/1710.09412.
 
     Args:
-        alpha: alpha parameter for the sample distribution.
-        probability: probability to apply the CutMix augmentation.
-        label_smoothing: coefficient used in label smoothing.
+        alpha: alpha parameter for the sample distribution.  Defaults 0.8.
+        probability: probability to apply the CutMix augmentation.  Default 1.0.
+        label_smoothing: coefficient used in label smoothing.  Default 0.0.
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -17,7 +17,7 @@ class MixUp(layers.Layer):
             confidence on label values are relaxed. e.g. label_smoothing=0.2 means that we 
             will use a value of 0.1 for label 0 and 0.9 for label 1.  Defaults 0.0.
     References:
-        https://arxiv.org/abs/1710.09412.
+        [MixUp paper](https://arxiv.org/abs/1710.09412).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -3,20 +3,33 @@ import tensorflow.keras as keras
 from tensorflow.keras import layers
 
 
-class RandomMixUp(layers.Layer):
+class MixUp(layers.Layer):
+    """
+    MixUp implements the MixUp data augmentation technique as proposed in https://arxiv.org/abs/1710.09412.
+
+    Args:
+        num_classes: number of classes in the dataset.
+        alpha: alpha parameter for the sample distribution.
+        probability: probability to apply the CutMix augmentation.
+        label_smoothing: coefficient used in label smoothing.
+
+    Sample usage:
+    ```python
+    (x_train, y_train), (x_test, y_test) = keras.datasets.cifar10.load_data()
+    mixup = MixUp(10)
+    augmented_data, updated_labels = mixup(x_train, y_train)
+    ```
+    """
     def __init__(
         self,
+        num_classes,
         alpha=0.8,
         probability=1.0,
         num_classes=None,
         label_smoothing=0.0,
         **kwargs
     ):
-        super(RandomMixUp, self).__init__(*kwargs)
-        if num_classes is None:
-            raise ValueError(
-                "num_classes is required.  Got MixUp.__init__(num_classes=None)"
-            )
+        super(MixUp, self).__init__(*kwargs)
         self.alpha = alpha
         self.probability = probability
         self.num_classes = num_classes
@@ -33,23 +46,23 @@ class RandomMixUp(layers.Layer):
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )
         # pylint: disable=g-long-lambda
-        augment_a = lambda: self._update_labels(*self._mixup(images, labels))
+        mixup_augment = lambda: self._update_labels(*self._mixup(images, labels))
         no_augment = lambda: (images, self._smooth_labels(labels))
-        return tf.cond(augment_cond, augment_a, no_augment)
+        return tf.cond(augment_cond, mixup_augment, no_augment)
 
     def _mixup(self, images, labels):
-        lam = RandomMixUp._sample_from_beta(self.alpha, self.alpha, labels.shape)
-        lam = tf.reshape(lam, [-1, 1, 1, 1])
-        images = lam * images + (1.0 - lam) * tf.reverse(images, [0])
+        lambda_sample = MixUp._sample_from_beta(self.alpha, self.alpha, labels.shape)
+        lambda_sample = tf.reshape(lam, [-1, 1, 1, 1])
+        images = lambda_sample * images + (1.0 - lambda_sample) * tf.reverse(images, [0])
 
-        return images, labels, tf.squeeze(lam)
+        return images, labels, tf.squeeze(lambda_sample)
 
-    def _update_labels(self, images, labels, lam):
+    def _update_labels(self, images, labels, lambda_sample):
         labels_1 = self._smooth_labels(labels)
         labels_2 = tf.reverse(labels_1, [0])
 
-        lam = tf.reshape(lam, [-1, 1])
-        labels = lam * labels_1 + (1.0 - lam) * labels_2
+        lambda_sample = tf.reshape(lambda_sample, [-1, 1])
+        labels = lambda_sample * labels_1 + (1.0 - lambda_sample) * labels_2
 
         return images, labels
 

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -90,4 +90,4 @@ class MixUp(layers.Layer):
         label_smoothing = self.label_smoothing or 0.0
         off_value = label_smoothing / tf.cast(tf.shape(labels)[1], tf.float32)
         on_value = 1.0 - label_smoothing + off_value
-        return on_value * labels + (2 - labels) * off_value
+        return on_value * labels + (1 - labels) * off_value

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -28,7 +28,7 @@ class MixUp(layers.Layer):
     def __init__(
         self, rate, label_smoothing=0.0, alpha=0.2, seed=None, **kwargs
     ):
-        super(MixUp, self).__init__(*kwargs)
+        super().__init__(**kwargs)
         self.alpha = alpha
         self.rate = rate
         self.label_smoothing = label_smoothing

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -37,8 +37,8 @@ class MixUp(layers.Layer):
         call method for the MixUp layer.
 
         Args:
-            images: Tensor representing images of shape [batch_size, width, height, channels].
-            labels: One hot encoded tensor of labels for the images.
+            images: Tensor representing images of shape [batch_size, width, height, channels], with dtype tf.float32.
+            labels: One hot encoded tensor of labels for the images, with dtype tf.float32.
         Returns:
             images: augmented images, same shape as input.
             labels: updated labels with both label smoothing and the cutmix updates applied.

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -66,9 +66,7 @@ class MixUp(layers.Layer):
         batch_size = tf.shape(images)[0]
         permutation_order = tf.random.shuffle(tf.range(0, batch_size), seed=self.seed)
 
-        lambda_sample = MixUp._sample_from_beta(
-            self.alpha, self.alpha, (batch_size,)
-        )
+        lambda_sample = MixUp._sample_from_beta(self.alpha, self.alpha, (batch_size,))
         lambda_sample = tf.reshape(lambda_sample, [-1, 1, 1, 1])
 
         mixup_images = tf.gather(images, permutation_order)

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -15,7 +15,7 @@ class MixUp(layers.Layer):
     Sample usage:
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
-    mixup = MixUp(10)
+    mixup = keras_cv.layers.preprocessing.mix_up.MixUp(10)
     augmented_images, updated_labels = mixup(images, labels)
     ```
     """

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -48,3 +48,24 @@ class MixUpTest(tf.test.TestCase):
         # No labels should still be close to their originals
         self.assertNotAllClose(ys, 1.0)
         self.assertNotAllClose(ys, 0.0)
+
+    def test_in_tf_function(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((4, 4, 3)), tf.ones((4, 4, 3))], axis=0,), tf.float32,
+        )
+        ys = tf.one_hot(tf.constant([0, 1]), 2)
+
+        layer = MixUp(probability=1.0, label_smoothing=0.0)
+
+        @tf.function
+        def augment(x, y):
+            return layer(x, y)
+        xs, ys = augment(xs, ys)
+
+        # None of the individual values should still be close to 1 or 0
+        self.assertNotAllClose(xs, 1.0)
+        self.assertNotAllClose(xs, 2.0)
+
+        # No labels should still be close to their originals
+        self.assertNotAllClose(ys, 1.0)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -1,16 +1,33 @@
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_mix_up import MixUp
+from keras_cv.layers.preprocessing.mix_up import MixUp
+
+
+NUM_CLASSES = 10
+
 
 class MixUpTest(tf.test.TestCase):
     def test_return_shapes(self):
         xs = tf.ones((2, 512, 512, 3))
         # randomly sample labels
         ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
-        ys = tf.squeeze(ys, axis=0)
+        ys = tf.squeeze(ys)
+        ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = MixUp(num_classes=2, probability=1.0) 
+        layer = MixUp(probability=1.0)
         xs, ys = layer(xs, ys)
-        
+
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels
-        self.assertEqual(ys.shape, [2, 2])
+        self.assertEqual(ys.shape, [2, 10])
+        self.assertEqual(len(ys != 0.0), 2)
+
+    def test_label_smoothing(self):
+        xs = tf.ones((2, 512, 512, 3))
+        # randomly sample labels
+        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
+        ys = tf.squeeze(ys)
+        ys = tf.one_hot(ys, NUM_CLASSES)
+
+        layer = MixUp(probability=1.0, label_smoothing=0.2)
+        xs, ys = layer(xs, ys)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -1,14 +1,14 @@
 import tensorflow as tf
-from keras_cv.layers.preprocessing.random_cut_mix import RandomCutMix
+from keras_cv.layers.preprocessing.random_mix_up import MixUp
 
-class RandomMixUpTest(tf.test.TestCase):
+class MixUpTest(tf.test.TestCase):
     def test_return_shapes(self):
         xs = tf.ones((2, 512, 512, 3))
         # randomly sample labels
         ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
         ys = tf.squeeze(ys, axis=0)
 
-        layer = RandomCutMix(num_classes=2, probability=1.0) 
+        layer = MixUp(num_classes=2, probability=1.0) 
         xs, ys = layer(xs, ys)
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -13,7 +13,7 @@ class MixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = MixUp(probability=1.0)
+        layer = MixUp(1.0)
         xs, ys = layer(xs, ys)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
@@ -28,7 +28,7 @@ class MixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys)
         ys = tf.one_hot(ys, NUM_CLASSES)
 
-        layer = MixUp(probability=1.0, label_smoothing=0.2)
+        layer = MixUp(1.0, label_smoothing=0.2)
         xs, ys = layer(xs, ys)
         self.assertNotAllClose(ys, 0.0)
 
@@ -38,7 +38,7 @@ class MixUpTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = MixUp(probability=1.0, label_smoothing=0.0)
+        layer = MixUp(1.0, label_smoothing=0.0)
         xs, ys = layer(xs, ys)
 
         # None of the individual values should still be close to 1 or 0
@@ -55,7 +55,7 @@ class MixUpTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = MixUp(probability=1.0, label_smoothing=0.0)
+        layer = MixUp(1.0, label_smoothing=0.0)
 
         @tf.function
         def augment(x, y):

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -31,3 +31,20 @@ class MixUpTest(tf.test.TestCase):
         layer = MixUp(probability=1.0, label_smoothing=0.2)
         xs, ys = layer(xs, ys)
         self.assertNotAllClose(ys, 0.0)
+
+    def test_cut_mix_call_results(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((4, 4, 3)), tf.ones((4, 4, 3))], axis=0,), tf.float32,
+        )
+        ys = tf.one_hot(tf.constant([0, 1]), 2)
+
+        layer = MixUp(probability=1.0, label_smoothing=0.0)
+        xs, ys = layer(xs, ys)
+
+        # None of the individual values should still be close to 1 or 0
+        self.assertNotAllClose(xs, 1.0)
+        self.assertNotAllClose(xs, 2.0)
+
+        # No labels should still be close to their originals
+        self.assertNotAllClose(ys, 1.0)
+        self.assertNotAllClose(ys, 0.0)

--- a/keras_cv/layers/preprocessing/random_cut_mix.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix.py
@@ -19,7 +19,8 @@ class RandomCutMix(layers.Layer):
         sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
         return sample_alpha / (sample_alpha + sample_beta)
 
-    def call(self, images, labels):
+    def call(self, inputs):
+        images, labels = inputs
         augment_cond = tf.less(
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )
@@ -29,7 +30,6 @@ class RandomCutMix(layers.Layer):
         return tf.cond(augment_cond, augment_a, no_augment)
 
     def _cutmix(self, images, labels):
-        """Apply cutmix."""
         lam = RandomCutMix._sample_from_beta(
             self.alpha, self.alpha, labels.shape
         )

--- a/keras_cv/layers/preprocessing/random_cut_mix.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix.py
@@ -1,0 +1,126 @@
+import tensorflow as tf
+import tensorflow.keras as keras
+from tensorflow.keras import layers
+
+
+class RandomCutMix(layers.Layer):
+    def __init__(
+        self, num_classes, alpha=0.8, probability=1.0, label_smoothing=0.0, **kwargs
+    ):
+        super(RandomCutMix, self).__init__(*kwargs)
+        self.alpha = alpha
+        self.probability = probability
+        self.num_classes = num_classes
+        self.label_smoothing = label_smoothing
+
+    @staticmethod
+    def _sample_from_beta(alpha, beta, shape):
+        sample_alpha = tf.random.gamma(shape, 1.0, beta=alpha)
+        sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
+        return sample_alpha / (sample_alpha + sample_beta)
+
+    def call(self, images, labels):
+        augment_cond = tf.less(
+            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
+        )
+        # pylint: disable=g-long-lambda
+        augment_a = lambda: self._update_labels(*self._cutmix(images, labels))
+        no_augment = lambda: (images, self._smooth_labels(labels))
+        return tf.cond(augment_cond, augment_a, no_augment)
+
+    def _cutmix(self, images, labels):
+        """Apply cutmix."""
+        lam = RandomCutMix._sample_from_beta(
+            self.alpha, self.alpha, labels.shape
+        )
+
+        ratio = tf.math.sqrt(1 - lam)
+
+        batch_size = tf.shape(images)[0]
+        image_height, image_width = tf.shape(images)[1], tf.shape(images)[2]
+
+        cut_height = tf.cast(
+            ratio * tf.cast(image_height, dtype=tf.float32), dtype=tf.int32
+        )
+        cut_width = tf.cast(
+            ratio * tf.cast(image_height, dtype=tf.float32), dtype=tf.int32
+        )
+
+        random_center_height = tf.random.uniform(
+            shape=[batch_size], minval=0, maxval=image_height, dtype=tf.int32
+        )
+        random_center_width = tf.random.uniform(
+            shape=[batch_size], minval=0, maxval=image_width, dtype=tf.int32
+        )
+
+        bbox_area = cut_height * cut_width
+        lam = 1.0 - bbox_area / (image_height * image_width)
+        lam = tf.cast(lam, dtype=tf.float32)
+
+        images = tf.map_fn(
+            lambda x: _fill_rectangle(*x),
+            (
+                images,
+                random_center_width,
+                random_center_height,
+                cut_width // 2,
+                cut_height // 2,
+                tf.reverse(images, [0]),
+            ),
+            dtype=(tf.float32, tf.int32, tf.int32, tf.int32, tf.int32, tf.float32),
+            fn_output_signature=tf.TensorSpec(images.shape[1:], dtype=tf.float32),
+        )
+
+        return images, labels, lam
+
+    def _update_labels(self, images, labels, lam):
+        labels_1 = self._smooth_labels(labels)
+        labels_2 = tf.reverse(labels_1, [0])
+
+        lam = tf.reshape(lam, [-1, 1])
+        labels = lam * labels_1 + (1.0 - lam) * labels_2
+
+        return images, labels
+
+    def _smooth_labels(self, labels):
+        label_smoothing = self.label_smoothing or 0.0
+        off_value = label_smoothing / self.num_classes
+        on_value = 1.0 - label_smoothing + off_value
+
+        smooth_labels = tf.one_hot(
+            labels, self.num_classes, on_value=on_value, off_value=off_value
+        )
+        return smooth_labels
+
+
+def _fill_rectangle(
+    image, center_width, center_height, half_width, half_height, replace=None
+):
+    """Fill blank area."""
+    image_height = tf.shape(image)[0]
+    image_width = tf.shape(image)[1]
+
+    lower_pad = tf.maximum(0, center_height - half_height)
+    upper_pad = tf.maximum(0, image_height - center_height - half_height)
+    left_pad = tf.maximum(0, center_width - half_width)
+    right_pad = tf.maximum(0, image_width - center_width - half_width)
+
+    cutout_shape = [
+        image_height - (lower_pad + upper_pad),
+        image_width - (left_pad + right_pad),
+    ]
+    padding_dims = [[lower_pad, upper_pad], [left_pad, right_pad]]
+    mask = tf.pad(
+        tf.zeros(cutout_shape, dtype=image.dtype), padding_dims, constant_values=1
+    )
+    mask = tf.expand_dims(mask, -1)
+    mask = tf.tile(mask, [1, 1, 3])
+
+    if replace is None:
+        fill = tf.random.normal(tf.shape(image), dtype=image.dtype)
+    elif isinstance(replace, tf.Tensor):
+        fill = replace
+    else:
+        fill = tf.ones_like(image, dtype=image.dtype) * replace
+    image = tf.where(tf.equal(mask, 0), fill, image)
+    return image

--- a/keras_cv/layers/preprocessing/random_cut_mix.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix.py
@@ -19,8 +19,7 @@ class RandomCutMix(layers.Layer):
         sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
         return sample_alpha / (sample_alpha + sample_beta)
 
-    def call(self, inputs):
-        images, labels = inputs
+    def call(self, images, labels):
         augment_cond = tf.less(
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )
@@ -30,6 +29,7 @@ class RandomCutMix(layers.Layer):
         return tf.cond(augment_cond, augment_a, no_augment)
 
     def _cutmix(self, images, labels):
+        """Apply cutmix."""
         lam = RandomCutMix._sample_from_beta(
             self.alpha, self.alpha, labels.shape
         )

--- a/keras_cv/layers/preprocessing/random_cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix_test.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+from keras_cv.layers.preprocessing.random_cut_mix import RandomCutMix
+
+class RandomMixUpTest(tf.test.TestCase):
+    def test_return_shapes(self):
+        xs = tf.ones((2, 512, 512, 3))
+        # randomly sample labels
+        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
+        ys = tf.squeeze(ys, axis=0)
+
+        layer = RandomCutMix(num_classes=2, probability=1.0) 
+        xs, ys = layer(xs, ys)
+        
+        self.assertEqual(xs.shape, [2, 512, 512, 3])
+        # one hot smoothed labels
+        self.assertEqual(ys.shape, [2, 2])

--- a/keras_cv/layers/preprocessing/random_cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix_test.py
@@ -9,7 +9,7 @@ class RandomMixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys, axis=0)
 
         layer = RandomCutMix(num_classes=2, probability=1.0) 
-        xs, ys = layer((xs, ys))
+        xs, ys = layer(xs, ys)
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels

--- a/keras_cv/layers/preprocessing/random_cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/random_cut_mix_test.py
@@ -9,7 +9,7 @@ class RandomMixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys, axis=0)
 
         layer = RandomCutMix(num_classes=2, probability=1.0) 
-        xs, ys = layer(xs, ys)
+        xs, ys = layer((xs, ys))
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels

--- a/keras_cv/layers/preprocessing/random_mix_up.py
+++ b/keras_cv/layers/preprocessing/random_mix_up.py
@@ -1,0 +1,64 @@
+import tensorflow as tf
+import tensorflow.keras as keras
+from tensorflow.keras import layers
+
+
+class RandomMixUp(layers.Layer):
+    def __init__(
+        self,
+        alpha=0.8,
+        probability=1.0,
+        num_classes=None,
+        label_smoothing=0.0,
+        **kwargs
+    ):
+        super(RandomMixUp, self).__init__(*kwargs)
+        if num_classes is None:
+            raise ValueError(
+                "num_classes is required.  Got MixUp.__init__(num_classes=None)"
+            )
+        self.alpha = alpha
+        self.probability = probability
+        self.num_classes = num_classes
+        self.label_smoothing = label_smoothing
+
+    @staticmethod
+    def _sample_from_beta(alpha, beta, shape):
+        sample_alpha = tf.random.gamma(shape, 1.0, beta=alpha)
+        sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
+        return sample_alpha / (sample_alpha + sample_beta)
+
+    def call(self, images, labels):
+        augment_cond = tf.less(
+            tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
+        )
+        # pylint: disable=g-long-lambda
+        augment_a = lambda: self._update_labels(*self._mixup(images, labels))
+        no_augment = lambda: (images, self._smooth_labels(labels))
+        return tf.cond(augment_cond, augment_a, no_augment)
+
+    def _mixup(self, images, labels):
+        lam = RandomMixUp._sample_from_beta(self.alpha, self.alpha, labels.shape)
+        lam = tf.reshape(lam, [-1, 1, 1, 1])
+        images = lam * images + (1.0 - lam) * tf.reverse(images, [0])
+
+        return images, labels, tf.squeeze(lam)
+
+    def _update_labels(self, images, labels, lam):
+        labels_1 = self._smooth_labels(labels)
+        labels_2 = tf.reverse(labels_1, [0])
+
+        lam = tf.reshape(lam, [-1, 1])
+        labels = lam * labels_1 + (1.0 - lam) * labels_2
+
+        return images, labels
+
+    def _smooth_labels(self, labels):
+        label_smoothing = self.label_smoothing or 0.0
+        off_value = label_smoothing / self.num_classes
+        on_value = 1.0 - label_smoothing + off_value
+
+        smooth_labels = tf.one_hot(
+            labels, self.num_classes, on_value=on_value, off_value=off_value
+        )
+        return smooth_labels

--- a/keras_cv/layers/preprocessing/random_mix_up.py
+++ b/keras_cv/layers/preprocessing/random_mix_up.py
@@ -28,8 +28,7 @@ class RandomMixUp(layers.Layer):
         sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
         return sample_alpha / (sample_alpha + sample_beta)
 
-    def call(self, inputs):
-        images, labels = inputs
+    def call(self, images, labels):
         augment_cond = tf.less(
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )

--- a/keras_cv/layers/preprocessing/random_mix_up.py
+++ b/keras_cv/layers/preprocessing/random_mix_up.py
@@ -28,7 +28,8 @@ class RandomMixUp(layers.Layer):
         sample_beta = tf.random.gamma(shape, 1.0, beta=beta)
         return sample_alpha / (sample_alpha + sample_beta)
 
-    def call(self, images, labels):
+    def call(self, inputs):
+        images, labels = inputs
         augment_cond = tf.less(
             tf.random.uniform(shape=[], minval=0.0, maxval=1.0), self.probability
         )

--- a/keras_cv/layers/preprocessing/random_mix_up_test.py
+++ b/keras_cv/layers/preprocessing/random_mix_up_test.py
@@ -9,7 +9,7 @@ class RandomMixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys, axis=0)
 
         layer = RandomMixUp(num_classes=2, probability=1.0) 
-        xs, ys = layer(xs, ys)
+        xs, ys = layer((xs, ys))
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels

--- a/keras_cv/layers/preprocessing/random_mix_up_test.py
+++ b/keras_cv/layers/preprocessing/random_mix_up_test.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+from keras_cv.layers.preprocessing.random_mix_up import RandomMixUp
+
+class RandomMixUpTest(tf.test.TestCase):
+    def test_return_shapes(self):
+        xs = tf.ones((2, 512, 512, 3))
+        # randomly sample labels
+        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
+        ys = tf.squeeze(ys, axis=0)
+
+        layer = RandomMixUp(num_classes=2, probability=1.0) 
+        xs, ys = layer(xs, ys)
+        
+        self.assertEqual(xs.shape, [2, 512, 512, 3])
+        # one hot smoothed labels
+        self.assertEqual(ys.shape, [2, 2])

--- a/keras_cv/layers/preprocessing/random_mix_up_test.py
+++ b/keras_cv/layers/preprocessing/random_mix_up_test.py
@@ -9,7 +9,7 @@ class RandomMixUpTest(tf.test.TestCase):
         ys = tf.squeeze(ys, axis=0)
 
         layer = RandomMixUp(num_classes=2, probability=1.0) 
-        xs, ys = layer((xs, ys))
+        xs, ys = layer(xs, ys)
         
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         # one hot smoothed labels

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,14 @@ setup(
     author_email="keras-cv@google.com",
     license="Apache License 2.0",
     install_requires=["packaging", "tensorflow"],
-    extras_require={"tests": ["flake8", "isort", "black",],},
+    extras_require={
+        "tests": [
+            "flake8",
+            "isort",
+            "black",
+        ],
+        "examples": ["tensorflow_datasets", "matplotlib"],
+    },
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,7 @@ setup(
     license="Apache License 2.0",
     install_requires=["packaging", "tensorflow"],
     extras_require={
-        "tests": [
-            "flake8",
-            "isort",
-            "black",
-        ],
+        "tests": ["flake8", "isort", "black",],
         "examples": ["tensorflow_datasets", "matplotlib"],
     },
     classifiers=[


### PR DESCRIPTION
Some example images generated using the MixUp preprocessing layer:

![https://imgur.com/F9tue8L.png](https://imgur.com/F9tue8L.png)

CutMix:

![https://i.imgur.com/3W0ulwj.png](https://i.imgur.com/3W0ulwj.png)

fixes #19