### PR TITLE
Removes label smoothing from CutMix and MixUp

### DIFF
--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -28,10 +28,6 @@ class CutMix(layers.Layer):
             distribution.  This controls the shape of the distribution from which the
             smoothing values are sampled.  Defaults 1.0, which is a recommended value
             when training an imagenet1k classification model.
-        label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
-            meaning the confidence on label values are relaxed. e.g.
-            label_smoothing=0.2 means that we will use a value of 0.1 for label 0 and
-            0.9 for label 1.  Defaults 0.0.
     References:
        [CutMix paper]( https://arxiv.org/abs/1905.04899).
 
@@ -43,11 +39,10 @@ class CutMix(layers.Layer):
     ```
     """
 
-    def __init__(self, rate, label_smoothing=0.0, alpha=1.0, seed=None, **kwargs):
+    def __init__(self, rate, alpha=1.0, seed=None, **kwargs):
         super().__init__(**kwargs)
         self.alpha = alpha
         self.rate = rate
-        self.label_smoothing = label_smoothing
         self.seed = seed
 
     @staticmethod
@@ -85,7 +80,7 @@ class CutMix(layers.Layer):
         augment_cond = tf.logical_and(rate_cond, training)
         # pylint: disable=g-long-lambda
         cutmix_augment = lambda: self._update_labels(*self._cutmix(images, labels))
-        no_augment = lambda: (images, self._smooth_labels(labels))
+        no_augment = lambda: (images, labels)
         return tf.cond(augment_cond, cutmix_augment, no_augment)
 
     def _cutmix(self, images, labels):
@@ -132,15 +127,8 @@ class CutMix(layers.Layer):
         return images, labels, lambda_sample, permutation_order
 
     def _update_labels(self, images, labels, lambda_sample, permutation_order):
-        labels_smoothed = self._smooth_labels(labels)
         cutout_labels = tf.gather(labels, permutation_order)
 
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
-        labels = lambda_sample * labels_smoothed + (1.0 - lambda_sample) * cutout_labels
+        labels = lambda_sample * labels + (1.0 - lambda_sample) * cutout_labels
         return images, labels
-
-    def _smooth_labels(self, labels):
-        label_smoothing = self.label_smoothing or 0.0
-        off_value = label_smoothing / tf.cast(tf.shape(labels)[1], tf.float32)
-        on_value = 1.0 - label_smoothing + off_value
-        return labels * on_value + (1 - labels) * off_value

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -30,21 +30,7 @@ class CutMixTest(tf.test.TestCase):
         xs, ys = layer(xs, ys)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
-        # one hot smoothed labels
         self.assertEqual(ys.shape, [2, 10])
-        self.assertEqual(len(ys != 0.0), 2)
-
-    def test_label_smoothing(self):
-        xs = tf.ones((2, 512, 512, 3))
-        # randomly sample labels
-        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
-        ys = tf.squeeze(ys)
-        ys = tf.one_hot(ys, NUM_CLASSES)
-
-        layer = CutMix(1.0, label_smoothing=0.2, seed=1)
-        xs, ys = layer(xs, ys)
-        self.assertNotAllClose(ys, 0.0)
-        self.assertAllClose(tf.math.reduce_sum(ys, axis=-1), (1.0, 1.0))
 
     def test_cut_mix_call_results(self):
         xs = tf.cast(
@@ -56,7 +42,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation
@@ -78,7 +64,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, seed=1)
         xs, ys = layer(xs, ys)
 
         # At least some pixels should be replaced in the CutMix operation
@@ -97,7 +83,7 @@ class CutMixTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = CutMix(1.0, label_smoothing=0.0, seed=1)
+        layer = CutMix(1.0, seed=1)
 
         @tf.function
         def augment(x, y):

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -97,8 +97,6 @@ class MixUp(layers.Layer):
         labels_for_mixup = tf.gather(labels, permutation_order)
 
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
-        labels = (
-            lambda_sample * labels + (1.0 - lambda_sample) * labels_for_mixup
-        )
+        labels = lambda_sample * labels + (1.0 - lambda_sample) * labels_for_mixup
 
         return images, labels

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -26,10 +26,6 @@ class MixUp(layers.Layer):
             distribution.  This controls the shape of the distribution from which the
             smoothing values are sampled.  Defaults 0.2, which is a recommended value
             when training an imagenet1k classification model.
-        label_smoothing: Float in [0, 1]. When > 0, label values are smoothed,
-            meaning the confidence on label values are relaxed. e.g.
-            label_smoothing=0.2 means that we will use a value of 0.1 for label 0 and
-            0.9 for label 1.  Defaults 0.0.
     References:
         [MixUp paper](https://arxiv.org/abs/1710.09412).
 
@@ -41,11 +37,10 @@ class MixUp(layers.Layer):
     ```
     """
 
-    def __init__(self, rate, label_smoothing=0.0, alpha=0.2, seed=None, **kwargs):
+    def __init__(self, rate, alpha=0.2, seed=None, **kwargs):
         super().__init__(**kwargs)
         self.alpha = alpha
         self.rate = rate
-        self.label_smoothing = label_smoothing
         self.seed = seed
 
     @staticmethod
@@ -83,7 +78,7 @@ class MixUp(layers.Layer):
         augment_cond = tf.logical_and(rate_cond, training)
         # pylint: disable=g-long-lambda
         mixup_augment = lambda: self._update_labels(*self._mixup(images, labels))
-        no_augment = lambda: (images, self._smooth_labels(labels))
+        no_augment = lambda: (images, labels)
         return tf.cond(augment_cond, mixup_augment, no_augment)
 
     def _mixup(self, images, labels):
@@ -99,18 +94,11 @@ class MixUp(layers.Layer):
         return images, labels, tf.squeeze(lambda_sample), permutation_order
 
     def _update_labels(self, images, labels, lambda_sample, permutation_order):
-        labels_smoothed = self._smooth_labels(labels)
         labels_for_mixup = tf.gather(labels, permutation_order)
 
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
         labels = (
-            lambda_sample * labels_smoothed + (1.0 - lambda_sample) * labels_for_mixup
+            lambda_sample * labels + (1.0 - lambda_sample) * labels_for_mixup
         )
 
         return images, labels
-
-    def _smooth_labels(self, labels):
-        label_smoothing = self.label_smoothing or 0.0
-        off_value = label_smoothing / tf.cast(tf.shape(labels)[1], tf.float32)
-        on_value = 1.0 - label_smoothing + off_value
-        return on_value * labels + (1 - labels) * off_value

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -30,21 +30,7 @@ class MixUpTest(tf.test.TestCase):
         xs, ys = layer(xs, ys)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
-        # one hot smoothed labels
         self.assertEqual(ys.shape, [2, 10])
-        self.assertEqual(len(ys != 0.0), 2)
-
-    def test_label_smoothing(self):
-        xs = tf.ones((2, 512, 512, 3))
-        # randomly sample labels
-        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
-        ys = tf.squeeze(ys)
-        ys = tf.one_hot(ys, NUM_CLASSES)
-
-        layer = MixUp(1.0, label_smoothing=0.2)
-        xs, ys = layer(xs, ys)
-        self.assertNotAllClose(ys, 0.0)
-        self.assertAllClose(tf.math.reduce_sum(ys, axis=-1), (1.0, 1.0))
 
     def test_mix_up_call_results(self):
         xs = tf.cast(
@@ -56,7 +42,7 @@ class MixUpTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = MixUp(1.0, label_smoothing=0.0)
+        layer = MixUp(1.0)
         xs, ys = layer(xs, ys)
 
         # None of the individual values should still be close to 1 or 0
@@ -77,7 +63,7 @@ class MixUpTest(tf.test.TestCase):
         )
         ys = tf.one_hot(tf.constant([0, 1]), 2)
 
-        layer = MixUp(1.0, label_smoothing=0.0)
+        layer = MixUp(1.0)
 
         @tf.function
         def augment(x, y):


### PR DESCRIPTION
Currently, we can accomplish label smoothing in two ways: in CutMix/MixUp, or in the loss function.  Each approach to label smoothing yields a slightly different result.  

To me, this could be a source of confusion to users.  I foresee no functional difference to the learning process between smoothing the labels before the label update is applied by cutmix, and applying it after.  

Besides, if users really want, they can smooth labels before passing them to CutMix and MixUp.  This is pretty trivial, and I think removing the functionality from these layers greatly reduces the cognitive complexity of the code.

https://colab.research.google.com/drive/1ECNMsLHTn6_LQefE2fosQVnD-QWjtZIi?usp=sharing