### PR TITLE
add missing get_config methods to layers

### DIFF
--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -126,3 +126,11 @@ class CutMix(layers.Layer):
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
         labels = lambda_sample * labels + (1.0 - lambda_sample) * cutout_labels
         return images, labels
+
+    def get_config(self):
+        config = {
+            "alpha": self.alpha,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -94,3 +94,11 @@ class MixUp(layers.Layer):
         labels = lambda_sample * labels + (1.0 - lambda_sample) * labels_for_mixup
 
         return images, labels
+
+    def get_config(self):
+        config = {
+            "alpha": self.alpha,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))


### PR DESCRIPTION
Added missing `get_config` methods to `CutMix` and `MixUp` layers. Since `CutMix` serves as a sample for new layer contributions, it is important that `get_config` methods are also in place.