### PR TITLE
Gaussian Blur layer implementation

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from keras_cv.layers.preprocessing.cut_mix import CutMix
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.random_cutout import RandomCutout
 from keras_cv.layers.preprocessing.solarization import Solarization

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -14,6 +14,7 @@
 
 from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.equalization import Equalization
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.mix_up import MixUp

--- a/keras_cv/layers/preprocessing/gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur.py
@@ -1,0 +1,81 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+import tensorflow_addons as tfa
+from tensorflow.keras import backend
+from tensorflow.keras import layers
+
+
+class GaussianBlur(layers.Layer):
+    """GaussianBlur is a preprocessing layer that applies Gaussian Blur to RGB and
+    greyscale images. Input images should have values in the range of [0,255]
+
+        Args:
+            kernel_size: An integer or tuple/list of 2 integers, specifying
+                height and weight of Gaussian kernel. If integer, this represents
+                both dimensions of a square kernel.
+            sigma: Float or tuple/list of 2 floats representing the standard deviation
+                used to calculate kernel. tuple/list can be used to apply different
+                standard deviations for height and weight.
+
+        Usage:
+        ```python
+        blur = GaussianBlur()
+
+        (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+        # Note that images are an int8 Tensor with values in the range [0, 255]
+        images = equalize(images)
+        ```
+
+        Call arguments:
+            images: Tensor of pixels in range [0, 255], in RGB or greyscale format.
+                Can be of type float or int.  Should be in NHWC format.
+    """
+
+    def __init__(self, kernel_size=5, sigma=1, **kwargs):
+        super().__init__(**kwargs)
+        self.kernel_size = kernel_size
+        self.sigma = sigma
+
+    def call(self, inputs, training=True):
+        """call method for the GaussianBlur layer.
+        Args:
+            images: Tensor representing images of shape
+                [batch_size, width, height, channels] or
+                [width, height, channels] with type float or int.
+                Pixel values should be in the range [0, 255]
+        Returns:
+            images: Blurred input images, same as input.
+        """
+        if training is None:
+            training = backend.learning_phase()
+
+        def _blur(image, kernel_size, sigma):
+            image = tfa.image.gaussian_filter2d(
+                image=image,
+                filter_shape=kernel_size,
+                sigma=sigma,
+                padding="CONSTANT",
+                constant_values=1,
+            )
+            return image
+
+        augment = lambda: _blur(inputs, self.kernel_size, self.sigma)
+        no_augment = lambda: inputs
+        return tf.cond(tf.cast(training, tf.bool), augment, no_augment)
+
+    def get_config(self):
+        config = {"kernel_size": self.kernel_size, "sigma": self.sigma}
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/preprocessing/gaussian_blur_test.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur_test.py
@@ -1,0 +1,70 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur
+
+
+class GaussianBlurTest(tf.test.TestCase):
+    def test_return_shapes(self):
+        # RGB images
+        xs_rgb = tf.ones((2, 512, 512, 3))
+        # grayscale images
+        xs_g = tf.ones((2, 512, 512, 1))
+
+        layer = GaussianBlur(kernel_size=(7, 3), sigma=1)
+        xs1 = layer(xs_rgb, training=True)
+        xs2 = layer(xs_g, training=True)
+
+        self.assertEqual(xs1.shape, [2, 512, 512, 3])
+        self.assertEqual(xs2.shape, [2, 512, 512, 1])
+
+    def test_in_tf_function(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((100, 100, 3)), tf.ones((100, 100, 3))], axis=0),
+            tf.float32,
+        )
+
+        # test 1
+        layer = GaussianBlur(kernel_size=(7, 3), sigma=1)
+
+        @tf.function
+        def augment(x):
+            return layer(x, training=True)
+
+        xs1 = augment(xs)
+
+        self.assertEqual(xs1.shape, [2, 100, 100, 3])
+
+    def test_non_square_image(self):
+        xs = tf.cast(
+            tf.stack([2 * tf.ones((512, 1024, 3)), tf.ones((512, 1024, 3))], axis=0),
+            tf.float32,
+        )
+
+        layer = GaussianBlur(kernel_size=(7, 3), sigma=1)
+        xs1 = layer(xs, training=True)
+
+        self.assertEqual(xs1.shape, [2, 512, 1024, 3])
+
+    def test_in_single_image(self):
+        xs = tf.cast(
+            tf.ones((512, 512, 3)),
+            dtype=tf.float32,
+        )
+
+        layer = GaussianBlur(kernel_size=(7, 3), sigma=1)
+        xs1 = layer(xs, training=True)
+
+        self.assertEqual(xs1.shape, [512, 512, 3])


### PR DESCRIPTION
implemented Gaussian Blur preprocessing layer using the gaussian blur implemented in tensorflow additions ([Reference](https://www.tensorflow.org/addons/api_docs/python/tfa/image/gaussian_filter2d))

[Linked Issue](https://github.com/keras-team/keras-cv/issues/26)

`layer = GaussianBlur(kernel_size=(10,7), sigma=1)`

![Figure_1](https://user-images.githubusercontent.com/61812638/154855676-0f918deb-f282-4bd8-9594-35aec8555115.png)

`layer = GaussianBlur(kernel_size=(10,7), sigma=2)`

![Figure_2](https://user-images.githubusercontent.com/61812638/154855694-4fb10e0d-b836-4be8-8e64-84bd374867a7.png)
