### PR TITLE
Add `value_range` utilities.

### DIFF
--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tensorflow as tf
 
 

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -14,17 +14,20 @@
 import tensorflow as tf
 
 
-def transform_value_range(images, original_range, target_range):
+def transform_value_range(images, original_range, target_range, dtype=None):
     """transforms values in input tensor from original_range to target_range.
 
     This function is intended to be used in preprocessing layers that
     rely upon color values.  This allows us to assume internally that
     the input tensor is always in the range [0, 255].
 
+    Note that
+
     Args:
         images: the set of images to transform to the [0, 255] range.
         original_range: the value range to transform from.
         target_range: the value range to transform to.
+        dtype: the dtype to compute the conversion with.  Defaults to tf.float32.
     Returns:
         a new Tensor with values in the target range.
 
@@ -45,9 +48,12 @@ def transform_value_range(images, original_range, target_range):
     )
     ```
     """
-    images = tf.cast(images, dtype=tf.float32)
-    original_min_value, original_max_value = _unwrap_value_range(original_range)
-    target_min_value, target_max_value = _unwrap_value_range(target_range)
+    dtype = dtype or tf.float32
+    images = tf.cast(images, dtype=dtype)
+    original_min_value, original_max_value = _unwrap_value_range(
+        original_range, dtype=dtype
+    )
+    target_min_value, target_max_value = _unwrap_value_range(target_range, dtype=dtype)
 
     # images in the [0, 1] scale
     images = (images - original_min_value) / (original_max_value - original_min_value)
@@ -56,8 +62,9 @@ def transform_value_range(images, original_range, target_range):
     return (images * scale_factor) + target_min_value
 
 
-def _unwrap_value_range(value_range):
+def _unwrap_value_range(value_range, dtype=None):
+    dtype = dtype or tf.float32
     min_value, max_value = value_range
-    min_value = tf.cast(min_value, dtype=tf.float32)
-    max_value = tf.cast(max_value, dtype=tf.float32)
+    min_value = tf.cast(min_value, dtype=dtype)
+    max_value = tf.cast(max_value, dtype=dtype)
     return min_value, max_value

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -1,0 +1,62 @@
+import tensorflow as tf
+
+
+def transform_to_standard_range(images, value_range):
+    """transforms the input Tensor to range [0, 255].
+
+    This function is intended to be used in preprocessing layers that
+    rely upon color values.  This allows us to assume internally that
+    the input tensor is always in the range [0, 255].
+
+    Args:
+        images: the set of images to transform to the [0, 255] range
+        value_range: the value range of the images to transform
+
+    Returns:
+        a new Tensor with values in the range [0, 255]
+
+    Usage:
+    ```python
+    images = keras_cv.utils.preprocessing.transform_to_standard_range(images, value_range)
+    images = tf.math.minimum(images + 10, 255)
+    images = keras_cv.utils.transform_to_value_range(images, value_range)
+    ```
+    """
+    images = tf.cast(images, dtype=tf.float32)
+    min_value, max_value = _unwrap_value_range(value_range)
+    images = (images - min_value) / (max_value - min_value)
+    return images * 255.
+
+def transform_to_value_range(images, value_range):
+    """transforms input Tensor into value_range.
+
+    This function is intended to be used in preprocessing layers that
+    rely upon color values.  This allows us to assume internally that
+    the input tensor is always in the range [0, 255].  This function
+    should be used at the end of the function body before returning
+    the input tensor to the user.
+
+    Args:
+        images: the set of images to transform to the value range
+        value_range: the value range to transform into
+
+    Returns:
+        a new Tensor with values in the range [0, 255]
+
+    Usage:
+    ```python
+    images = keras_cv.utils.preprocessing.transform_to_standard_range(images, value_range)
+    images = tf.math.minimum(images + 10, 255)
+    images = keras_cv.utils.transform_to_value_range(images, value_range)
+    ```
+    """
+    min_value, max_value = _unwrap_value_range(value_range)
+    images = images / 255.0
+    images = images * max_value - min_value
+    return images
+
+def _unwrap_value_range(value_range):
+    min_value, max_value = value_range
+    min_value = tf.cast(min_value, dtype=tf.float32)
+    max_value = tf.cast(max_value, dtype=tf.float32)
+    return min_value, max_value

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -22,11 +22,11 @@ def transform_value_range(images, original_range, target_range):
     the input tensor is always in the range [0, 255].
 
     Args:
-        images: the set of images to transform to the [0, 255] range
-        original_range: the value range to transform from
-        target_range: the value range to transform to
+        images: the set of images to transform to the [0, 255] range.
+        original_range: the value range to transform from.
+        target_range: the value range to transform to.
     Returns:
-        a new Tensor with values in the target range
+        a new Tensor with values in the target range.
 
     Usage:
     ```python

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -17,7 +17,10 @@ def transform_to_standard_range(images, value_range):
 
     Usage:
     ```python
-    images = keras_cv.utils.preprocessing.transform_to_standard_range(images, value_range)
+    images = keras_cv.utils.preprocessing.transform_to_standard_range(
+        images,
+        value_range
+    )
     images = tf.math.minimum(images + 10, 255)
     images = keras_cv.utils.transform_to_value_range(images, value_range)
     ```
@@ -25,7 +28,8 @@ def transform_to_standard_range(images, value_range):
     images = tf.cast(images, dtype=tf.float32)
     min_value, max_value = _unwrap_value_range(value_range)
     images = (images - min_value) / (max_value - min_value)
-    return images * 255.
+    return images * 255.0
+
 
 def transform_to_value_range(images, value_range):
     """transforms input Tensor into value_range.
@@ -45,7 +49,10 @@ def transform_to_value_range(images, value_range):
 
     Usage:
     ```python
-    images = keras_cv.utils.preprocessing.transform_to_standard_range(images, value_range)
+    images = keras_cv.utils.preprocessing.transform_to_standard_range(
+        images,
+        value_range
+    )
     images = tf.math.minimum(images + 10, 255)
     images = keras_cv.utils.transform_to_value_range(images, value_range)
     ```
@@ -54,6 +61,7 @@ def transform_to_value_range(images, value_range):
     images = images / 255.0
     images = images * max_value - min_value
     return images
+
 
 def _unwrap_value_range(value_range):
     min_value, max_value = value_range

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -14,17 +14,15 @@
 import tensorflow as tf
 
 
-def transform_value_range(images, original_range, target_range, dtype=None):
+def transform_value_range(images, original_range, target_range, dtype=tf.float32):
     """transforms values in input tensor from original_range to target_range.
 
     This function is intended to be used in preprocessing layers that
     rely upon color values.  This allows us to assume internally that
     the input tensor is always in the range [0, 255].
 
-    Note that
-
     Args:
-        images: the set of images to transform to the [0, 255] range.
+        images: the set of images to transform to the target range range.
         original_range: the value range to transform from.
         target_range: the value range to transform to.
         dtype: the dtype to compute the conversion with.  Defaults to tf.float32.
@@ -41,14 +39,13 @@ def transform_value_range(images, original_range, target_range, dtype=None):
         target_range
     )
     images = tf.math.minimum(images + 10, 255)
-    images = keras_cv.utils.transform_value_range(
+    images = keras_cv.utils.preprocessing.transform_value_range(
         images,
         target_range,
         original_range
     )
     ```
     """
-    dtype = dtype or tf.float32
     images = tf.cast(images, dtype=dtype)
     original_min_value, original_max_value = _unwrap_value_range(
         original_range, dtype=dtype
@@ -62,8 +59,7 @@ def transform_value_range(images, original_range, target_range, dtype=None):
     return (images * scale_factor) + target_min_value
 
 
-def _unwrap_value_range(value_range, dtype=None):
-    dtype = dtype or tf.float32
+def _unwrap_value_range(value_range, dtype=tf.float32):
     min_value, max_value = value_range
     min_value = tf.cast(min_value, dtype=dtype)
     max_value = tf.cast(max_value, dtype=dtype)

--- a/keras_cv/utils/preprocessing_test.py
+++ b/keras_cv/utils/preprocessing_test.py
@@ -23,15 +23,21 @@ class PreprocessingTestCase(tf.test.TestCase):
 
     def test_transform_to_standard_range_neg_one_range(self):
         x = tf.constant([-1, 0, 1])
-        x = preprocessing.transform_to_standard_range(x, [-1, 1])
+        x = preprocessing.transform_value_range(
+            x, original_range=[-1, 1], target_range=[0, 255]
+        )
         self.assertAllClose(x, [0.0, 127.5, 255.0])
 
     def test_transform_to_standard_range(self):
         x = tf.constant([8 / 255, 9 / 255, 255 / 255])
-        x = preprocessing.transform_to_standard_range(x, [0, 1])
+        x = preprocessing.transform_value_range(
+            x, original_range=[0, 1], target_range=[0, 255]
+        )
         self.assertAllClose(x, [8.0, 9.0, 255.0])
 
     def test_transform_to_value_range(self):
         x = tf.constant([128.0, 255.0, 0.0])
-        x = preprocessing.transform_to_value_range(x, [0, 1])
+        x = preprocessing.transform_value_range(
+            x, original_range=[0, 255], target_range=[0, 1]
+        )
         self.assertAllClose(x, [128 / 255, 1, 0])

--- a/keras_cv/utils/test_preprocessing.py
+++ b/keras_cv/utils/test_preprocessing.py
@@ -24,14 +24,14 @@ class PreprocessingTestCase(tf.test.TestCase):
     def test_transform_to_standard_range_neg_one_range(self):
         x = tf.constant([-1, 0, 1])
         x = preprocessing.transform_to_standard_range(x, [-1, 1])
-        self.assertAllClose(x, [0., 127.5, 255.])
+        self.assertAllClose(x, [0.0, 127.5, 255.0])
 
     def test_transform_to_standard_range(self):
-        x = tf.constant([8/255, 9/255, 255/255])
+        x = tf.constant([8 / 255, 9 / 255, 255 / 255])
         x = preprocessing.transform_to_standard_range(x, [0, 1])
-        self.assertAllClose(x, [8., 9., 255.])
+        self.assertAllClose(x, [8.0, 9.0, 255.0])
 
     def test_transform_to_value_range(self):
-        x  = tf.constant([128., 255., 0.])
+        x = tf.constant([128.0, 255.0, 0.0])
         x = preprocessing.transform_to_value_range(x, [0, 1])
-        self.assertAllClose(x, [128/255, 1, 0])
+        self.assertAllClose(x, [128 / 255, 1, 0])

--- a/keras_cv/utils/test_preprocessing.py
+++ b/keras_cv/utils/test_preprocessing.py
@@ -1,0 +1,37 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.utils import preprocessing
+
+
+class PreprocessingTestCase(tf.test.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_transform_to_standard_range_neg_one_range(self):
+        x = tf.constant([-1, 0, 1])
+        x = preprocessing.transform_to_standard_range(x, [-1, 1])
+        self.assertAllClose(x, [0., 127.5, 255.])
+
+    def test_transform_to_standard_range(self):
+        x = tf.constant([8/255, 9/255, 255/255])
+        x = preprocessing.transform_to_standard_range(x, [0, 1])
+        self.assertAllClose(x, [8., 9., 255.])
+
+    def test_transform_to_value_range(self):
+        x  = tf.constant([128., 255., 0.])
+        x = preprocessing.transform_to_value_range(x, [0, 1])
+        self.assertAllClose(x, [128/255, 1, 0])


### PR DESCRIPTION
This will help us implement the `value_range` parameter
for all of our KPLs.

We can normalize our inputs at the start of each `call` method, then assume [0, 255] range internally, then transform back to the users' dtype and value range at the end. 