### PR TITLE
[Canary test] GridMask: Vectorized function call on the batch dimension

### DIFF
--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -213,7 +213,7 @@ class GridMask(layers.Layer):
             images = tf.expand_dims(images, axis=0)
 
         # TODO: Make the batch operation vectorize.
-        output = tf.map_fn(lambda image: self._grid_mask(image), images)
+        output = tf.vectorized_map(lambda image: self._grid_mask(image), images, False)
 
         if unbatched:
             output = tf.squeeze(output, axis=0)

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -213,7 +213,7 @@ class GridMask(layers.Layer):
             images = tf.expand_dims(images, axis=0)
 
         # TODO: Make the batch operation vectorize.
-        output = tf.vectorized_map(lambda image: self._grid_mask(image), images, True)
+        output = tf.vectorized_map(lambda image: self._grid_mask(image), images, fallback_to_while_loop=True)
 
         if unbatched:
             output = tf.squeeze(output, axis=0)

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -213,7 +213,7 @@ class GridMask(layers.Layer):
             images = tf.expand_dims(images, axis=0)
 
         # TODO: Make the batch operation vectorize.
-        output = tf.vectorized_map(lambda image: self._grid_mask(image), images, False)
+        output = tf.vectorized_map(lambda image: self._grid_mask(image), images, True)
 
         if unbatched:
             output = tf.squeeze(output, axis=0)


### PR DESCRIPTION
As we have discussed in https://github.com/keras-team/keras-cv/pull/143#issuecomment-1047215737 this is just a canary (failing) test  (check the CI):
```
ValueError: Input "maxval" of op 'RandomUniformInt' expected to be loop invariant.
```

As I've mentioned in the thread we really need to understand if we want to have randomness inside the batch or between the batches and what kind of impact we have between the computing overhead, contributing speed/code readability  and  network convergence.

Also I don't know if @joker-eph  or @qlzh727 could expose us a little bit the pro and cons of `jit_compile` a function vs using the `vectorized_map` or if they are orthogonal. 

With many CV transformations  we cannot compile the function as the underline `tf.raw_ops.ImageProjectiveTransformV3` op isn't supported by XLA.

/cc @chjort 