### PR TITLE
Introduce DropBlock2D regularization layer.

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -16,3 +16,4 @@ from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.random_cutout import RandomCutout
 from keras_cv.layers.preprocessing.solarization import Solarization
+from keras_cv.layers.regularization.dropblock_2d import DropBlock2D

--- a/keras_cv/layers/regularization/__init__.py
+++ b/keras_cv/layers/regularization/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_cv.layers.regularization.dropblock_2d import DropBlock2D

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -92,13 +92,49 @@ class DropBlock2D(BaseRandomLayer):
     #   [0.51969624 1.0780739  0.80540895 0.14002927]]], shape=(1, 4, 4),
     # dtype=float32)
 
-    ```
-    We can observe two things:
-    1. A 2x2 block has been set to zero.
-    2. The inputs have been normalized.
+    # We can observe two things:
+    # 1. A 2x2 block has been dropped
+    # 2. The inputs have been slightly scaled to account for missing values.
 
-    One must remember, that DropBlock operation is random, so bigger or smaller
-    patches can be dropped.
+    # The number of blocks dropped can vary, between the channels - sometimes no blocks
+    # will be dropped, and sometimes there will be multiple overlapping blocks.
+    # Let's present on a larger feature map:
+
+    features = tf.random.stateless_uniform((1, 4, 4, 36), seed=[0, 1])
+    layer = DropBlock2D(0.1, (2, 2), seed=123)
+    output = layer(features, training=True)
+
+    print(output[..., 0])  # no drop
+    # tf.Tensor(
+    # [[[0.09136613 0.98085546 0.15265216 0.19690938]
+    #   [0.48835075 0.52433217 0.1661478  0.7067729 ]
+    #   [0.07383626 0.9938906  0.14309917 0.06882786]
+    #   [0.43242374 0.04158871 0.24213943 0.1903095 ]]], shape=(1, 4, 4),
+    # dtype=float32)
+
+    print(output[..., 9])  # drop single block
+    # tf.Tensor(
+    # [[[0.14568178 0.01571623 0.9082305  1.0545396 ]
+    #   [0.24126057 0.86874676 0.         0.        ]
+    #   [0.44101703 0.29805306 0.         0.        ]
+    #   [0.56835717 0.04925899 0.6745584  0.20550345]]], shape=(1, 4, 4), dtype=float32)
+
+    print(output[..., 22])  # drop two blocks
+    # tf.Tensor(
+    # [[[0.69479376 0.49463132 1.0627024  0.58349967]
+    #   [0.         0.         0.36143216 0.58699244]
+    #   [0.         0.         0.         0.        ]
+    #   [0.0315055  1.0117861  0.         0.        ]]], shape=(1, 4, 4),
+    # dtype=float32)
+
+    print(output[..., 29])  # drop two blocks with overlap
+    # tf.Tensor(
+    # [[[0.2137237  0.9120104  0.9963533  0.33937347]
+    #   [0.21868704 0.44030213 0.5068906  0.20034194]
+    #   [0.         0.         0.         0.5915383 ]
+    #   [0.         0.         0.         0.9526224 ]]], shape=(1, 4, 4),
+    # dtype=float32)
+    ```
     """
 
     def __init__(

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -138,8 +138,7 @@ class DropBlock2D(BaseRandomLayer):
         dropblock_height = tf.math.minimum(self._dropblock_height, height)
         dropblock_width = tf.math.minimum(self._dropblock_width, width)
 
-        # Seed_drop_rate is the gamma parameter of DropBlock.
-        seed_drop_rate = (
+        gamma = (
             self._dropout_rate
             * tf.cast(width * height, dtype=tf.float32)
             / tf.cast(dropblock_height * dropblock_width, dtype=tf.float32)
@@ -172,7 +171,7 @@ class DropBlock2D(BaseRandomLayer):
             tf.shape(x), dtype=tf.float32
         )
         valid_block = tf.cast(valid_block, dtype=tf.float32)
-        seed_keep_rate = tf.cast(1 - seed_drop_rate, dtype=tf.float32)
+        seed_keep_rate = tf.cast(1 - gamma, dtype=tf.float32)
         block_pattern = (1 - valid_block + seed_keep_rate + random_noise) >= 1
         block_pattern = tf.cast(block_pattern, dtype=tf.float32)
 

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -105,7 +105,7 @@ class DropBlock2D(BaseRandomLayer):
         seed=None,
         name=None,
     ):
-        super().__init__(seed=seed, name=name)
+        super().__init__(seed=seed, name=name, force_generator=True)
         if not dropblock_size > 0:
             raise ValueError(
                 f"dropblock_size must be greater than 0. Received: {dropblock_size}"

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -1,0 +1,191 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+from keras.engine.base_layer import BaseRandomLayer
+from keras.utils import conv_utils
+
+
+class DropBlock2D(BaseRandomLayer):
+    """Applies DropBlock regularization to input features.
+
+    DropBlock is a form of structured dropout, where units in a contiguous
+    region of a feature map are dropped together. DropBlock works better than
+    dropout on convolutional layers due to the fact that activation units in
+    convolutional layers are spatially correlated.
+
+    It is advised to use DropBlock after activation in Conv -> BatchNorm -> Activation
+    block in further layers of the network. For example, the paper mentions using
+    DropBlock in 3rd and 4th group of ResNet blocks.
+
+    Reference:
+    - [DropBlock: A regularization method for convolutional networks](
+        https://arxiv.org/abs/1810.12890
+    )
+
+    Args:
+        keep_probability: float. Probability of keeping a unit. Defaults to 0.9.
+            Must be between 0 and 1. For best results, the value should be between
+            0.75-0.95
+        dropblock_size: integer. The size of the block to be dropped. Defaults to 7.
+            Must be bigger than 0, and should not be bigger than the input feature map
+            size. If this value is greater by 1 from the input feature map size you will
+            encounter `ZeroDivisionError`.
+        data_format: string. One of channels_last (default) or channels_first. The
+            ordering of the dimensions in the inputs. channels_last corresponds to
+            inputs with shape (batch_size, height, width, channels) while channels_first
+            corresponds to inputs with shape (batch_size, channels,height, width). It
+            defaults to the image_data_format value found in your Keras config file at
+            ~/.keras/keras.json. If you never set it, then it will be channels_last.
+        seed: integer. To use as random seed.
+        name: string. The name of the layer.
+
+    Usage:
+        DropBlock2D should be used inside a `tf.keras.Model`:
+    ```python
+        # (...)
+        x = Conv2D(32, (1, 1))(x)
+        x = BatchNormalization()(x)
+        x = ReLU()(x)
+        x = DropBlock2D()(x)
+        # (...)
+    ```
+        When used directly, the layer will zero-out some inputs in a contiguous region
+        and apply slight scaling to the values.
+
+    ```python
+        # Small feature map shape for demonstration purposes:
+        features = tf.random.stateless_uniform((1, 4, 4, 1), seed=[0, 1])
+
+        # Preview the feature map
+        print(features[..., 0])
+        # tf.Tensor(
+        # [[[0.08216608 0.40928006 0.39318466 0.3162533 ]
+        #   [0.34717774 0.73199546 0.56369007 0.9769211 ]
+        #   [0.55243933 0.13101244 0.2941643  0.5130266 ]
+        #   [0.38977218 0.80855536 0.6040567  0.10502195]]], shape=(1, 4, 4),
+        # dtype=float32)
+
+        layer = DropBlock2D(dropblock_size=2, seed=1234)  # Small size for demonstration
+        output = layer(features, training=True)
+
+        # Preview the feature map after dropblock:
+        print(output[..., 0])
+        # tf.Tensor(
+        # [[[0.10955477 0.54570675 0.5242462  0.42167106]
+        #   [0.46290365 0.97599393 0.75158674 1.3025614 ]
+        #   [0.         0.         0.39221907 0.6840355 ]
+        #   [0.         0.         0.80540895 0.14002927]]], shape=(1, 4, 4),
+        # dtype=float32)
+
+    ```
+        We can observe two things:
+        1. A 2x2 block has been set to zero.
+        2. The inputs have been scaled as mentioned in the paper.
+
+        One must remember, that DropBlock operation is random, so bigger or smaller
+        patches can be dropped.
+    """
+
+    def __init__(
+        self,
+        keep_probability=0.9,
+        dropblock_size=7,
+        data_format=None,
+        seed=None,
+        name=None,
+    ):
+        super().__init__(seed=seed, name=name)
+        if not dropblock_size > 0:
+            raise ValueError(
+                f"dropblock_size must be greater than 0. Received: {dropblock_size}"
+            )
+        if not 0.0 <= keep_probability <= 1.0:
+            raise ValueError(
+                f"keep_probability must be a number between 0 and 1. "
+                f"Received: {keep_probability}"
+            )
+
+        self._keep_probability = keep_probability
+        self._dropblock_size = dropblock_size
+        self._data_format = conv_utils.normalize_data_format(data_format)
+
+    def call(self, x, training=False):
+        if not training or self._keep_probability == 1.0:
+            return x
+
+        if self._data_format == "channels_last":
+            _, height, width, _ = x.get_shape().as_list()
+        else:
+            _, _, height, width = x.get_shape().as_list()
+
+        total_size = width * height
+        dropblock_size = min(self._dropblock_size, width, height)
+
+        # Seed_drop_rate is the gamma parameter of DropBlock.
+        seed_drop_rate = (
+            (1.0 - self._keep_probability)
+            * total_size
+            / dropblock_size**2
+            / ((width - self._dropblock_size + 1) * (height - self._dropblock_size + 1))
+        )
+
+        # Forces the block to be inside the feature map.
+        w_i, h_i = tf.meshgrid(tf.range(width), tf.range(height))
+        valid_block = tf.logical_and(
+            tf.logical_and(
+                w_i >= int(dropblock_size // 2), w_i < width - (dropblock_size - 1) // 2
+            ),
+            tf.logical_and(
+                h_i >= int(dropblock_size // 2), h_i < width - (dropblock_size - 1) // 2
+            ),
+        )
+
+        if self._data_format == "channels_last":
+            valid_block = tf.reshape(valid_block, [1, height, width, 1])
+        else:
+            valid_block = tf.reshape(valid_block, [1, 1, height, width])
+
+        randnoise = self._random_generator.random_uniform(tf.shape(x), dtype=tf.float32)
+        valid_block = tf.cast(valid_block, dtype=tf.float32)
+        seed_keep_rate = tf.cast(1 - seed_drop_rate, dtype=tf.float32)
+        block_pattern = (1 - valid_block + seed_keep_rate + randnoise) >= 1
+        block_pattern = tf.cast(block_pattern, dtype=tf.float32)
+
+        if self._data_format == "channels_last":
+            ksize = [1, self._dropblock_size, self._dropblock_size, 1]
+        else:
+            ksize = [1, 1, self._dropblock_size, self._dropblock_size]
+
+        block_pattern = -tf.nn.max_pool(
+            -block_pattern,
+            ksize=ksize,
+            strides=[1, 1, 1, 1],
+            padding="SAME",
+            data_format="NHWC" if self._data_format == "channels_last" else "NCHW",
+        )
+
+        percent_ones = tf.cast(tf.reduce_sum(block_pattern), tf.float32) / tf.cast(
+            tf.size(block_pattern), tf.float32
+        )
+
+        return x / tf.cast(percent_ones, x.dtype) * tf.cast(block_pattern, x.dtype)
+
+    def get_config(self):
+        config = {
+            "keep_probability": self._keep_probability,
+            "dropblock_size": self._dropblock_size,
+            "data_format": self._data_format,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -87,9 +87,9 @@ class DropBlock2D(BaseRandomLayer):
     print(output[..., 0])
     # tf.Tensor(
     # [[[0.10955477 0.54570675 0.5242462  0.42167106]
-    #   [0.46290365 0.97599393 0.75158674 1.3025614 ]
-    #   [0.         0.         0.39221907 0.6840355 ]
-    #   [0.         0.         0.80540895 0.14002927]]], shape=(1, 4, 4),
+    #   [0.46290365 0.97599393 0.         0.        ]
+    #   [0.7365858  0.17468326 0.         0.        ]
+    #   [0.51969624 1.0780739  0.80540895 0.14002927]]], shape=(1, 4, 4),
     # dtype=float32)
 
     ```
@@ -127,9 +127,13 @@ class DropBlock2D(BaseRandomLayer):
             return x
 
         if self._data_format == "channels_last":
-            _, height, width, _ = x.get_shape().as_list()
+            _, height, width, _ = tf.split(tf.shape(x), 4)
         else:
-            _, _, height, width = x.get_shape().as_list()
+            _, _, height, width = tf.split(tf.shape(x), 4)
+
+        # Unnest scalar values
+        height = tf.squeeze(height)
+        width = tf.squeeze(width)
 
         dropblock_height = tf.math.minimum(self._dropblock_height, height)
         dropblock_width = tf.math.minimum(self._dropblock_width, width)
@@ -139,9 +143,10 @@ class DropBlock2D(BaseRandomLayer):
             self._dropout_rate
             * tf.cast(width * height, dtype=tf.float32)
             / tf.cast(dropblock_height * dropblock_width, dtype=tf.float32)
-            / (
+            / tf.cast(
                 (width - self._dropblock_width + 1)
-                * (height - self._dropblock_height + 1)
+                * (height - self._dropblock_height + 1),
+                tf.float32,
             )
         )
 

--- a/keras_cv/layers/regularization/dropblock_2d_test.py
+++ b/keras_cv/layers/regularization/dropblock_2d_test.py
@@ -38,7 +38,7 @@ class DropBlock2DTest(tf.test.TestCase):
 
         output = layer(dummy_inputs, training=False)
 
-        tf.debugging.assert_near(dummy_inputs, output)
+        self.assertAllClose(dummy_inputs, output)
 
     def test_input_unchanged_with_dropout_rate_equal_to_zero(self):
         dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)
@@ -46,7 +46,7 @@ class DropBlock2DTest(tf.test.TestCase):
 
         output = layer(dummy_inputs, training=True)
 
-        tf.debugging.assert_near(dummy_inputs, output)
+        self.assertAllClose(dummy_inputs, output)
 
     def test_input_gets_partially_zeroed_out_in_train_mode(self):
         dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)

--- a/keras_cv/layers/regularization/dropblock_2d_test.py
+++ b/keras_cv/layers/regularization/dropblock_2d_test.py
@@ -78,4 +78,4 @@ class DropBlock2DTest(tf.test.TestCase):
         def apply(x):
             return layer(x, training=True)
 
-        layer(dummy_inputs)
+        apply(dummy_inputs)

--- a/keras_cv/layers/regularization/dropblock_2d_test.py
+++ b/keras_cv/layers/regularization/dropblock_2d_test.py
@@ -1,0 +1,81 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+
+from keras_cv.layers.regularization.dropblock_2d import DropBlock2D
+
+
+class DropBlock2DTest(tf.test.TestCase):
+    FEATURE_SHAPE = (1, 14, 14, 256)  # Shape of ResNet block group 3
+    rng = tf.random.Generator.from_non_deterministic_state()
+
+    def test_layer_not_created_with_invalid_block_size(self):
+        with self.assertRaises(ValueError):
+            DropBlock2D(dropblock_size=0)
+
+    def test_layer_not_created_with_invalid_keep_probability(self):
+        for keep_probability in [1.1, -0.1]:
+            with self.assertRaises(ValueError):
+                DropBlock2D(keep_probability=keep_probability)
+
+    def test_input_unchanged_in_eval_mode(self):
+        dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)
+        layer = DropBlock2D()
+
+        output = layer(dummy_inputs, training=False)
+
+        tf.debugging.assert_near(dummy_inputs, output)
+
+    def test_input_unchanged_with_keep_probability_equal_to_one(self):
+        dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)
+        layer = DropBlock2D(keep_probability=1.0)
+
+        output = layer(dummy_inputs, training=True)
+
+        tf.debugging.assert_near(dummy_inputs, output)
+
+    def test_input_gets_partially_zeroed_out_in_train_mode(self):
+        dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)
+        layer = DropBlock2D()
+
+        output = layer(dummy_inputs, training=True)
+        num_input_zeros = self._count_zeros(dummy_inputs)
+        num_output_zeros = self._count_zeros(output)
+
+        self.assertGreater(num_output_zeros, num_input_zeros)
+
+    def test_batched_input_gets_partially_zeroed_out_in_train_mode(self):
+        batched_shape = (4, *self.FEATURE_SHAPE[1:])
+        dummy_inputs = self.rng.uniform(shape=batched_shape)
+        layer = DropBlock2D()
+
+        output = layer(dummy_inputs, training=True)
+        num_input_zeros = self._count_zeros(dummy_inputs)
+        num_output_zeros = self._count_zeros(output)
+
+        self.assertGreater(num_output_zeros, num_input_zeros)
+
+    @staticmethod
+    def _count_zeros(tensor: tf.Tensor) -> tf.Tensor:
+        return tf.reduce_sum(tf.cast(tensor == 0, dtype=tf.int32))
+
+    def test_works_with_xla(self):
+        dummy_inputs = self.rng.uniform(shape=self.FEATURE_SHAPE)
+        layer = DropBlock2D()
+
+        @tf.function(jit_compile=True)
+        def apply(x):
+            return layer(x, training=True)
+
+        layer(dummy_inputs)

--- a/keras_cv/utils/conv_utils.py
+++ b/keras_cv/utils/conv_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tensorflow as tf
 
 

--- a/keras_cv/utils/conv_utils.py
+++ b/keras_cv/utils/conv_utils.py
@@ -24,3 +24,59 @@ def normalize_data_format(value):
             f'"channels_first", "channels_last". Received: {value}'
         )
     return data_format
+
+
+def normalize_tuple(value, n, name, allow_zero=False):
+    """Transforms non-negative/positive integer/integers into an integer tuple.
+    Args:
+      value: The value to validate and convert. Could an int, or any iterable of
+        ints.
+      n: The size of the tuple to be returned.
+      name: The name of the argument being validated, e.g. "strides" or
+        "kernel_size". This is only used to format error messages.
+      allow_zero: Default to False. A ValueError will raised if zero is received
+        and this param is False.
+    Returns:
+      A tuple of n integers.
+    Raises:
+      ValueError: If something else than an int/long or iterable thereof or a
+      negative value is
+        passed.
+    """
+    error_msg = (
+        f"The `{name}` argument must be a tuple of {n} " f"integers. Received: {value}"
+    )
+
+    if isinstance(value, int):
+        value_tuple = (value,) * n
+    else:
+        try:
+            value_tuple = tuple(value)
+        except TypeError:
+            raise ValueError(error_msg)
+        if len(value_tuple) != n:
+            raise ValueError(error_msg)
+        for single_value in value_tuple:
+            try:
+                int(single_value)
+            except (ValueError, TypeError):
+                error_msg += (
+                    f"including element {single_value} of " f"type {type(single_value)}"
+                )
+                raise ValueError(error_msg)
+
+    if allow_zero:
+        unqualified_values = {v for v in value_tuple if v < 0}
+        req_msg = ">= 0"
+    else:
+        unqualified_values = {v for v in value_tuple if v <= 0}
+        req_msg = "> 0"
+
+    if unqualified_values:
+        error_msg += (
+            f" including {unqualified_values}"
+            f" that does not satisfy the requirement `{req_msg}`."
+        )
+        raise ValueError(error_msg)
+
+    return value_tuple

--- a/keras_cv/utils/conv_utils.py
+++ b/keras_cv/utils/conv_utils.py
@@ -1,0 +1,13 @@
+import tensorflow as tf
+
+
+def normalize_data_format(value):
+    if value is None:
+        value = tf.keras.backend.image_data_format()
+    data_format = value.lower()
+    if data_format not in {"channels_first", "channels_last"}:
+        raise ValueError(
+            "The `data_format` argument must be one of "
+            f'"channels_first", "channels_last". Received: {value}'
+        )
+    return data_format


### PR DESCRIPTION
DropBlock2d is a regularization layer (similar to Dropout), more suitable for Convolutional networks.

Linked Issue: https://github.com/keras-team/keras-cv/issues/137 

This is mostly a Keras Layer wrapper around [original implementation](https://github.com/tensorflow/tpu/blob/b24729de804fdb751b06467d3dce0637fa652060/models/official/detection/modeling/architecture/nn_ops.py#L191).