### PR TITLE
vectorized num_cutouts

### DIFF
--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -87,7 +87,7 @@ class CutMix(layers.Layer):
         )
 
         permutation_order = tf.random.shuffle(tf.range(0, batch_size), seed=self.seed)
-        lambda_sample = CutMix._sample_from_beta(self.alpha, self.alpha, (batch_size,))
+        lambda_sample = CutMix._sample_from_beta(self.alpha, self.alpha, (batch_size,1))
 
         ratio = tf.math.sqrt(1 - lambda_sample)
 
@@ -99,10 +99,10 @@ class CutMix(layers.Layer):
         )
 
         random_center_height = tf.random.uniform(
-            shape=[batch_size], minval=0, maxval=image_height, dtype=tf.int32
+            shape=[batch_size,1], minval=0, maxval=image_height, dtype=tf.int32
         )
         random_center_width = tf.random.uniform(
-            shape=[batch_size], minval=0, maxval=image_width, dtype=tf.int32
+            shape=[batch_size,1], minval=0, maxval=image_width, dtype=tf.int32
         )
 
         bounding_box_area = cut_height * cut_width

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -152,15 +152,17 @@ class RandomCutout(layers.Layer):
         self.fill_value = fill_value
         self.seed = seed
         self.num_cutouts = num_cutouts
-        if isinstance(num_cutouts, tuple):
-            self.num_cutouts = tf.random.uniform(
+
+    def get_random_transformation(self):
+        if isinstance(self.num_cutouts, tuple):
+            num_cutouts = tf.random.uniform(
                 shape=(1,),
                 minval=self.num_cutouts_lower,
                 maxval=self.num_cutouts_upper + 1,
                 dtype=tf.int32,
                 seed=self.seed,
             )
-            self.num_cutouts = self.num_cutouts[0]
+            self.num_cutouts = num_cutouts[0]
 
     def _parse_bounds(self, factor):
         if isinstance(factor, (tuple, list)):
@@ -172,6 +174,7 @@ class RandomCutout(layers.Layer):
         if training is None:
             training = backend.learning_phase()
 
+        self.get_random_transformation()
         augment = lambda: self._random_cutout(inputs)
         no_augment = lambda: inputs
         return tf.cond(tf.cast(training, tf.bool), augment, no_augment)

--- a/keras_cv/utils/fill_utils.py
+++ b/keras_cv/utils/fill_utils.py
@@ -40,10 +40,10 @@ def rectangle_masks(corners, mask_shape):
 
     # repeat height and width
     width, height = mask_shape
-    x0_rep = tf.repeat(x0, height, axis=2)
-    y0_rep = tf.repeat(y0, width, axis=3)
-    x1_rep = tf.repeat(x1, height, axis=2)
-    y1_rep = tf.repeat(y1, width, axis=3)
+    x0_repeat = tf.repeat(x0, height, axis=-2)
+    y0_repeat = tf.repeat(y0, width, axis=-1)
+    x1_repeat = tf.repeat(x1, height, axis=-2)
+    y1_repeat = tf.repeat(y1, width, axis=-1)
 
     # range grid
     batch_size = tf.shape(corners)[0]
@@ -57,10 +57,10 @@ def rectangle_masks(corners, mask_shape):
     )
 
     # boolean masks
-    mask_x0 = tf.less_equal(x0_rep, range_col)
-    mask_y0 = tf.less_equal(y0_rep, range_row)
-    mask_x1 = tf.less(range_col, x1_rep)
-    mask_y1 = tf.less(range_row, y1_rep)
+    mask_x0 = tf.less_equal(x0_repeat, range_col)
+    mask_y0 = tf.less_equal(y0_repeat, range_row)
+    mask_x1 = tf.less(range_col, x1_repeat)
+    mask_y1 = tf.less(range_row, y1_repeat)
 
     masks = mask_x0 & mask_y0 & mask_x1 & mask_y1
     return masks


### PR DESCRIPTION
Vectorized implementation of `num_cutouts` solves issue #134 
Might help with issue #189 PR #207 , #186 

**Note**:
The changes from this PR disrupt `RandomCutMix` as that uses `rectangle_masks` and `fill_rectangle` from `fill_utils.py` which has now been vectorized for num_cutouts. Which I think can be solved using (non-exhaustive):
- we can create **FLAG** sort of a variable to separate both of these(RandomCutout and CutMix) inside `fill_utils` 

- we can create a separate file for the vectorized `fill_utils`. 
