### PR TITLE
extend IOU test against official pycocotools

### DIFF
--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -16,31 +16,31 @@
 import numpy as np
 import tensorflow as tf
 
+from keras_cv.utils import bounding_box as bbox
 from keras_cv.utils import iou as iou_lib
 from pycocotools import mask as maskUtils
 
 
 class IoUTest(tf.test.TestCase):
     def test_compute_single_iou(self):
-        bb1_coords = [[100, 101, 200, 201]]
-        bb1_coords_off_by_1 = [[101, 102, 201, 202]]
-        bb1 = tf.constant(bb1_coords, dtype=tf.float32)
-        bb1_off_by_1 = tf.constant(bb1_coords_off_by_1, dtype=tf.float32)
-        # area of bb1 and bb1_off_by_1 are each 10000.
+        bb1 = tf.constant([[100, 101, 200, 201]], dtype=tf.float32)
+        bb1_off_by_1 = tf.constant([[101, 102, 201, 202]], dtype=tf.float32)
+        bb1_xywh = [[100, 101, 100, 100]]
+        bb1_off_by_1_xywh = [[101, 102, 100, 100]]
         # intersection area is 99*99=9801
         # iou=9801/(2*10000 - 9801)=0.96097656633
+
         print(iou_lib.compute_ious_for_image(bb1, bb1_off_by_1))
         iou = iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)
-        pycocotools_iou_crowd = maskUtils.iou(bb1_coords, 
-            bb1_coords_off_by_1,[True])[0][0]
-        pycocotools_iou_not_crowd = maskUtils.iou(bb1_coords,
-            bb1_coords_off_by_1,[False])[0][0]
-        with self.subTest(msg='Compare with pycocotools_iou_crowd'):
-            self.assertAlmostEqual(iou[0].numpy()[0], pycocotools_iou_crowd)
+
+        pycocotools_iou_crowd = maskUtils.iou(bb1_xywh,
+            bb1_off_by_1_xywh, [True])[0][0]
+        pycocotools_iou_not_crowd = maskUtils.iou(bb1_xywh,
+            bb1_off_by_1_xywh, [False])[0][0]
+
         with self.subTest(msg='Compare with pycocotools_iou_not crowd'):
             self.assertAlmostEqual(iou[0].numpy()[0], 
                 pycocotools_iou_not_crowd)
-        
         self.assertAlmostEqual(
             iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)[0], 0.96097656633
         )

--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -16,8 +16,8 @@
 import numpy as np
 import tensorflow as tf
 
-from pycocotools import mask as maskUtils
 from keras_cv.utils import iou as iou_lib
+from pycocotools import mask as maskUtils
 
 
 class IoUTest(tf.test.TestCase):

--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -15,10 +15,10 @@
 
 import numpy as np
 import tensorflow as tf
+from pycocotools import mask as maskUtils
 
 from keras_cv.utils import bounding_box as bbox
 from keras_cv.utils import iou as iou_lib
-from pycocotools import mask as maskUtils
 
 
 class IoUTest(tf.test.TestCase):
@@ -33,12 +33,12 @@ class IoUTest(tf.test.TestCase):
         print(iou_lib.compute_ious_for_image(bb1, bb1_off_by_1))
         iou = iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)
 
-        pycocotools_iou_not_crowd = maskUtils.iou(bb1_xywh,
-            bb1_off_by_1_xywh, [False])[0][0]
+        pycocotools_iou_not_crowd = maskUtils.iou(bb1_xywh, bb1_off_by_1_xywh, [False])[
+            0
+        ][0]
 
-        with self.subTest(msg='Compare with pycocotools_iou_not crowd'):
-            self.assertAlmostEqual(iou[0].numpy()[0], 
-                pycocotools_iou_not_crowd)
+        with self.subTest(msg="Compare with pycocotools_iou_not crowd"):
+            self.assertAlmostEqual(iou[0].numpy()[0], pycocotools_iou_not_crowd)
         self.assertAlmostEqual(
             iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)[0], 0.96097656633
         )

--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -17,16 +17,30 @@ import numpy as np
 import tensorflow as tf
 
 from keras_cv.utils import iou as iou_lib
+from pycocotools import mask as maskUtils
 
 
 class IoUTest(tf.test.TestCase):
     def test_compute_single_iou(self):
-        bb1 = tf.constant([[100, 101, 200, 201]], dtype=tf.float32)
-        bb1_off_by_1 = tf.constant([[101, 102, 201, 202]], dtype=tf.float32)
+        bb1_coords = [[100, 101, 200, 201]]
+        bb1_coords_off_by_1 = [[101, 102, 201, 202]]
+        bb1 = tf.constant(bb1_coords, dtype=tf.float32)
+        bb1_off_by_1 = tf.constant(bb1_coords_off_by_1, dtype=tf.float32)
         # area of bb1 and bb1_off_by_1 are each 10000.
         # intersection area is 99*99=9801
         # iou=9801/(2*10000 - 9801)=0.96097656633
         print(iou_lib.compute_ious_for_image(bb1, bb1_off_by_1))
+        iou = iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)
+        pycocotools_iou_crowd = maskUtils.iou(bb1_coords, 
+            bb1_coords_off_by_1,[True])[0][0]
+        pycocotools_iou_not_crowd = maskUtils.iou(bb1_coords,
+            bb1_coords_off_by_1,[False])[0][0]
+        with self.subTest(msg='Compare with pycocotools_iou_crowd'):
+            self.assertAlmostEqual(iou[0].numpy()[0], pycocotools_iou_crowd)
+        with self.subTest(msg='Compare with pycocotools_iou_not crowd'):
+            self.assertAlmostEqual(iou[0].numpy()[0], 
+                pycocotools_iou_not_crowd)
+        
         self.assertAlmostEqual(
             iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)[0], 0.96097656633
         )

--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -33,8 +33,6 @@ class IoUTest(tf.test.TestCase):
         print(iou_lib.compute_ious_for_image(bb1, bb1_off_by_1))
         iou = iou_lib.compute_ious_for_image(bb1, bb1_off_by_1)
 
-        pycocotools_iou_crowd = maskUtils.iou(bb1_xywh,
-            bb1_off_by_1_xywh, [True])[0][0]
         pycocotools_iou_not_crowd = maskUtils.iou(bb1_xywh,
             bb1_off_by_1_xywh, [False])[0][0]
 

--- a/keras_cv/utils/iou_test.py
+++ b/keras_cv/utils/iou_test.py
@@ -16,8 +16,8 @@
 import numpy as np
 import tensorflow as tf
 
-from keras_cv.utils import iou as iou_lib
 from pycocotools import mask as maskUtils
+from keras_cv.utils import iou as iou_lib
 
 
 class IoUTest(tf.test.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     # Temporarily require tf-nightly until tf 2.9
     install_requires=["packaging", "tf-nightly", "absl-py"],
     extras_require={
-        "tests": ["flake8", "isort", "black", "pytest". "pytest-subtests", "pycocotools"],
+        "tests": ["flake8", "isort", "black", "pytest", "pytest-subtests", "pycocotools"],
         "examples": ["tensorflow_datasets", "matplotlib"],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     # Temporarily require tf-nightly until tf 2.9
     install_requires=["packaging", "tf-nightly", "absl-py"],
     extras_require={
-        "tests": ["flake8", "isort", "black", "pytest"],
+        "tests": ["flake8", "isort", "black", "pytest". "pytest-subtests", "pycocotools"],
         "examples": ["tensorflow_datasets", "matplotlib"],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,14 @@ setup(
     # Temporarily require tf-nightly until tf 2.9
     install_requires=["packaging", "tf-nightly", "absl-py"],
     extras_require={
-        "tests": ["flake8", "isort", "black", "pytest", "pytest-subtests", "pycocotools"],
+        "tests": [
+            "flake8",
+            "isort",
+            "black",
+            "pytest",
+            "pytest-subtests",
+            "pycocotools",
+        ],
         "examples": ["tensorflow_datasets", "matplotlib"],
     },
     classifiers=[


### PR DESCRIPTION
This is going to temp check some low level utils comparing keras_cv results with the reference implementation. 

It will start with IOU but I don't if it is failing know cuase the bbox coords order are expressed differntly bettween keras_cv and the reference implementation.

https://github.com/keras-team/keras-cv/issues/222

Note: This is not going to be merged as it is going to be used as a public/shared debug session.