### PR TITLE
Gaussian blur

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -41,3 +41,4 @@ from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.solarization import Solarization
 from keras_cv.layers.regularization.dropblock_2d import DropBlock2D
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -29,6 +29,7 @@ from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle
 from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.equalization import Equalization
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.mix_up import MixUp
@@ -41,4 +42,3 @@ from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.solarization import Solarization
 from keras_cv.layers.regularization.dropblock_2d import DropBlock2D
-from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -44,3 +44,4 @@ from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.solarization import Solarization
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -31,6 +31,7 @@ from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle
 from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.equalization import Equalization
+from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.mix_up import MixUp
@@ -44,4 +45,3 @@ from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.solarization import Solarization
-from keras_cv.layers.preprocessing.gaussian_blur import GaussianBlur

--- a/keras_cv/layers/preprocessing/gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur.py
@@ -23,9 +23,9 @@ class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
         kernel_size: int, 2 element tuple or 2 element list. x and y dimensions for
             the kernel used. If tuple or list, first element is used for the x dimension
             and second element is used for y dimension. If int, kernel will be squared.
-        sigma: float, 2 element tuple or 2 element list. Interval in which sigma should be
-            sampled from. If float, interval is going to be [0, float), else the first
-            element represents the lower bound and the second element the upper
+        sigma: float, 2 element tuple or 2 element list. Interval in which sigma should
+            be sampled from. If float, interval is going to be [0, float), else the
+            first element represents the lower bound and the second element the upper
             bound of the sampling interval.
     """
 

--- a/keras_cv/layers/preprocessing/gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur.py
@@ -1,0 +1,131 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
+    """Applies a Gaussian Blur with random sigma to an image.
+
+    Args:
+        kernel_size: int, 2 element tuple or 2 element list. x and y dimensions for
+            the kernel used. If tuple or list, first element is used for the x dimension
+            and second element is used for y dimension. If int, kernel will be squared.
+        sigma: float, 2 element tuple or 2 element list. Interval in which sigma should be
+            sampled from. If float, interval is going to be [0, float), else the first
+            element represents the lower bound and the second element the upper
+            bound of the sampling interval.
+    """
+
+    def __init__(self,
+                 kernel_size,
+                 sigma,
+                 **kwargs
+                 ):
+        super().__init__(**kwargs)
+        self.kernel_size = kernel_size
+        self.sigma = sigma
+
+        if isinstance(kernel_size, (tuple, list)):
+            self.x = kernel_size[0]
+            self.y = kernel_size[1]
+        else:
+            if isinstance(kernel_size, int):
+                self.x = self.y = kernel_size
+            else:
+                raise ValueError(
+                    "`kernel_size` must be list, tuple or integer "
+                    ", got {} ".format(
+                        type(self.kernel_size))
+                    )
+
+        if isinstance(sigma, (tuple, list)):
+            self.sigma_min = sigma[0]
+            self.sigma_max = sigma[1]
+        else:
+            self.sigma_min = type(sigma)(0)
+            self.sigma_max = sigma
+
+        if not isinstance(self.sigma_min, type(self.sigma_max)):
+            raise ValueError(
+                "`sigma` must have lower bound and upper bound "
+                "with same type, got {} and {}".format(
+                    type(self.width_lower), type(self.width_upper)
+                )
+            )
+
+        if self.sigma_max < self.sigma_min:
+            raise ValueError(
+                "`sigma` cannot have upper bound less than "
+                "lower bound, got {}".format(sigma)
+            )
+
+        self._sigma_is_float = isinstance(self.sigma, float)
+        if self._sigma_is_float:
+            if not self.sigma_min >= 0.0:
+                raise ValueError(
+                    "`sigma` must be higher than 0"
+                    "when is float, got {}".format(sigma)
+                )
+
+    def get_random_transformation(self, image=None, label=None, bounding_box=None):
+        sigma = self.get_sigma()
+        blur_v = GaussianBlur.get_kernel(sigma, self.y)
+        blur_h = GaussianBlur.get_kernel(sigma, self.x)
+        blur_v = tf.reshape(blur_v, [self.y, 1, 1, 1])
+        blur_h = tf.reshape(blur_h, [1, self.x, 1, 1])
+        return (blur_v, blur_h)
+
+    def get_sigma(self):
+        sigma = self._random_generator.random_uniform(
+            shape=(), minval=self.sigma_min, maxval=self.sigma_max)
+        return sigma
+
+    def augment_image(self, image, transformation=None):
+
+        image = tf.expand_dims(image, axis=0)
+
+        num_channels = tf.shape(image)[-1]
+        blur_v, blur_h = transformation
+        blur_h = tf.tile(blur_h, [1, 1, num_channels, 1])
+        blur_v = tf.tile(blur_v, [1, 1, num_channels, 1])
+        blurred = tf.nn.depthwise_conv2d(
+            image, blur_h, strides=[1, 1, 1, 1], padding="SAME")
+        blurred = tf.nn.depthwise_conv2d(
+            blurred, blur_v, strides=[1, 1, 1, 1], padding="SAME")
+
+        return tf.squeeze(blurred, axis=0)
+
+    @staticmethod
+    def get_kernel(sigma, filter_size):
+        x = tf.cast(tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=tf.float32)
+        blur_filter = tf.exp(-tf.pow(x, 2.0) /
+                             (2.0 * tf.pow(tf.cast(sigma, dtype=tf.float32), 2.0)))
+        blur_filter /= tf.reduce_sum(blur_filter)
+        return blur_filter
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "sigma": self.sigma,
+                "kernel_size": self.kernel_size
+            }
+        )
+        return config
+
+
+
+
+

--- a/keras_cv/layers/preprocessing/gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur.py
@@ -14,6 +14,7 @@
 
 import tensorflow as tf
 
+
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
 class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     """Applies a Gaussian Blur with random sigma to an image.
@@ -28,11 +29,7 @@ class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
             bound of the sampling interval.
     """
 
-    def __init__(self,
-                 kernel_size,
-                 sigma,
-                 **kwargs
-                 ):
+    def __init__(self, kernel_size, sigma, **kwargs):
         super().__init__(**kwargs)
         self.kernel_size = kernel_size
         self.sigma = sigma
@@ -46,9 +43,8 @@ class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
             else:
                 raise ValueError(
                     "`kernel_size` must be list, tuple or integer "
-                    ", got {} ".format(
-                        type(self.kernel_size))
-                    )
+                    ", got {} ".format(type(self.kernel_size))
+                )
 
         if isinstance(sigma, (tuple, list)):
             self.sigma_min = sigma[0]
@@ -89,7 +85,8 @@ class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
 
     def get_sigma(self):
         sigma = self._random_generator.random_uniform(
-            shape=(), minval=self.sigma_min, maxval=self.sigma_max)
+            shape=(), minval=self.sigma_min, maxval=self.sigma_max
+        )
         return sigma
 
     def augment_image(self, image, transformation=None):
@@ -101,31 +98,26 @@ class GaussianBlur(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
         blur_h = tf.tile(blur_h, [1, 1, num_channels, 1])
         blur_v = tf.tile(blur_v, [1, 1, num_channels, 1])
         blurred = tf.nn.depthwise_conv2d(
-            image, blur_h, strides=[1, 1, 1, 1], padding="SAME")
+            image, blur_h, strides=[1, 1, 1, 1], padding="SAME"
+        )
         blurred = tf.nn.depthwise_conv2d(
-            blurred, blur_v, strides=[1, 1, 1, 1], padding="SAME")
+            blurred, blur_v, strides=[1, 1, 1, 1], padding="SAME"
+        )
 
         return tf.squeeze(blurred, axis=0)
 
     @staticmethod
     def get_kernel(sigma, filter_size):
-        x = tf.cast(tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=tf.float32)
-        blur_filter = tf.exp(-tf.pow(x, 2.0) /
-                             (2.0 * tf.pow(tf.cast(sigma, dtype=tf.float32), 2.0)))
+        x = tf.cast(
+            tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=tf.float32
+        )
+        blur_filter = tf.exp(
+            -tf.pow(x, 2.0) / (2.0 * tf.pow(tf.cast(sigma, dtype=tf.float32), 2.0))
+        )
         blur_filter /= tf.reduce_sum(blur_filter)
         return blur_filter
 
     def get_config(self):
         config = super().get_config()
-        config.update(
-            {
-                "sigma": self.sigma,
-                "kernel_size": self.kernel_size
-            }
-        )
+        config.update({"sigma": self.sigma, "kernel_size": self.kernel_size})
         return config
-
-
-
-
-

--- a/keras_cv/layers/preprocessing/gaussian_blur_test.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur_test.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
-import matplotlib.pyplot as plt
+
 from keras_cv.layers import preprocessing
 
-class GaussianBlurTest(tf.test.TestCase):
 
+class GaussianBlurTest(tf.test.TestCase):
     def test_return_shapes(self):
         layer = preprocessing.GaussianBlur(kernel_size=(3, 7), sigma=(0, 2))
 
@@ -76,12 +77,3 @@ class GaussianBlurTest(tf.test.TestCase):
         xs = tf.ones((2, 512, 512, 1))
         xs = layer(xs)
         self.assertEqual(xs.shape, [2, 512, 512, 1])
-
-
-
-
-
-
-
-
-

--- a/keras_cv/layers/preprocessing/gaussian_blur_test.py
+++ b/keras_cv/layers/preprocessing/gaussian_blur_test.py
@@ -1,0 +1,87 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+import matplotlib.pyplot as plt
+from keras_cv.layers import preprocessing
+
+class GaussianBlurTest(tf.test.TestCase):
+
+    def test_return_shapes(self):
+        layer = preprocessing.GaussianBlur(kernel_size=(3, 7), sigma=(0, 2))
+
+        # RGB
+        xs = tf.ones((2, 512, 512, 3))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 512, 512, 3])
+
+        # greyscale
+        xs = tf.ones((2, 512, 512, 1))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 512, 512, 1])
+
+    def test_in_single_image(self):
+        layer = preprocessing.GaussianBlur(kernel_size=(3, 7), sigma=(0, 2))
+
+        # RGB
+        xs = tf.cast(
+            tf.ones((512, 512, 3)),
+            dtype=tf.float32,
+        )
+
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [512, 512, 3])
+
+        # greyscale
+        xs = tf.cast(
+            tf.ones((512, 512, 1)),
+            dtype=tf.float32,
+        )
+
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [512, 512, 1])
+
+    def test_non_square_images(self):
+        layer = preprocessing.GaussianBlur(kernel_size=(3, 7), sigma=(0, 2))
+
+        # RGB
+        xs = tf.ones((2, 256, 512, 3))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 256, 512, 3])
+
+        # greyscale
+        xs = tf.ones((2, 256, 512, 1))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 256, 512, 1])
+
+    def test_single_input_args(self):
+        layer = preprocessing.GaussianBlur(kernel_size=7, sigma=2)
+
+        # RGB
+        xs = tf.ones((2, 512, 512, 3))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 512, 512, 3])
+
+        # greyscale
+        xs = tf.ones((2, 512, 512, 1))
+        xs = layer(xs)
+        self.assertEqual(xs.shape, [2, 512, 512, 1])
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Implementation of randomised Gaussian Blur as discussed in #26 and #143, using BaseAugmentationLayer. 

Example: 

![blurred](https://user-images.githubusercontent.com/61812638/161246191-6a832529-44d5-48ce-a546-633983d7f2e4.png)

At the moment, only sigma is randomized. vectorized_map doesn't seem to handle kernel of different sizes when distributing depthwise_conv2d between different threads, as when I tried using random size as well I would get this error:

2022-04-01 10:53:14.692102: W tensorflow/core/framework/op_kernel.cc:1745] OP_REQUIRES failed at list_kernels.h:458 : INVALID_ARGUMENT: PartialTensorShape: Incompatible shapes during merge: [3] vs. [2]
Traceback (most recent call last):
  File "keras_cv/layers/preprocessing/gaussian_blur_test.py", line 119, in <module>
    test.test_on_real_img()
  File "keras_cv/layers/preprocessing/gaussian_blur_test.py", line 109, in test_on_real_img
    for image in blurred.take(1):
  File "/Users/arturosalmi/opt/anaconda3/lib/python3.7/site-packages/tensorflow/python/data/ops/iterator_ops.py", line 766, in __next__
    return self._next_internal()
  File "/Users/arturosalmi/opt/anaconda3/lib/python3.7/site-packages/tensorflow/python/data/ops/iterator_ops.py", line 752, in _next_internal
    output_shapes=self._flat_output_shapes)
  File "/Users/arturosalmi/opt/anaconda3/lib/python3.7/site-packages/tensorflow/python/ops/gen_dataset_ops.py", line 3017, in iterator_get_next
    _ops.raise_from_not_ok_status(e, name)
  File "/Users/arturosalmi/opt/anaconda3/lib/python3.7/site-packages/tensorflow/python/framework/ops.py", line 7164, in raise_from_not_ok_status
    raise core._status_to_exception(e) from None  # pylint: disable=protected-access
tensorflow.python.framework.errors_impl.InvalidArgumentError: PartialTensorShape: Incompatible shapes during merge: [3] vs. [2]
	 [[{{node gaussian_blur/loop_body/range/pfor/TensorListConcatV2}}]] [Op:IteratorGetNext]


