### PR TITLE
Bounding box support in MixUp augmentation

### DIFF
--- a/examples/layers/preprocessing/mix_up_demo.py
+++ b/examples/layers/preprocessing/mix_up_demo.py
@@ -45,9 +45,13 @@ def main():
         .batch(BATCH_SIZE)
     )
     mixup = preprocessing.MixUp(alpha=0.8)
-    train_ds = train_ds.map(mixup, num_parallel_calls=tf.data.AUTOTUNE)
+    train_ds = train_ds.map(
+        lambda x, y: mixup({'images': x, 'labels': y}),
+        num_parallel_calls=tf.data.AUTOTUNE
+    )
 
-    for images, labels in train_ds.take(1):
+    for batch in train_ds.take(1):
+        images = batch["images"]
         plt.figure(figsize=(8, 8))
         for i in range(9):
             plt.subplot(3, 3, i + 1)

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -22,16 +22,27 @@ class MixUpTest(tf.test.TestCase):
     def test_return_shapes(self):
         xs = tf.ones((2, 512, 512, 3))
         # randomly sample labels
-        ys = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
-        ys = tf.squeeze(ys)
-        ys = tf.one_hot(ys, NUM_CLASSES)
+        ys_labels = tf.random.categorical(tf.math.log([[0.5, 0.5]]), 2)
+        ys_labels = tf.squeeze(ys_labels)
+        ys_labels = tf.one_hot(ys_labels, NUM_CLASSES)
+
+        # randomly sample bounding boxes
+        ys_bounding_boxes = tf.random.uniform((2, 3, 5), 0, 1)
 
         layer = MixUp()
-        outputs = layer({"images": xs, "labels": ys})
-        xs, ys = outputs["images"], outputs["labels"]
+        # mixup on labels
+        outputs = layer(
+            {"images": xs, "labels": ys_labels, "bounding_boxes": ys_bounding_boxes}
+        )
+        xs, ys_labels, ys_bounding_boxes = (
+            outputs["images"],
+            outputs["labels"],
+            outputs["bounding_boxes"],
+        )
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
-        self.assertEqual(ys.shape, [2, 10])
+        self.assertEqual(ys_labels.shape, [2, 10])
+        self.assertEqual(ys_bounding_boxes.shape, [2, 6, 5])
 
     def test_mix_up_call_results(self):
         xs = tf.cast(


### PR DESCRIPTION
closes #261 
also edits the mix_up_demo.py to support `BaseImageAugmentationLayer`

The mixup is simply executed as a concatenation of bounding boxes across the mixed images. 

One possible issue is the repetition of bounding boxes on images that get mixed with themselves. Another thing to note (which probably is true by convention), the layer will expect the number of bounding boxes per image to be the same. This may require padding.