### PR TITLE
Remove layers that don't belong in RandAugment from RandAugment

### DIFF
--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -58,10 +58,11 @@ class RandAugment(RandomAugmentationPipeline):
             Defaults to `0.15`.
         rate:  the rate at which to apply each augmentation.  This parameter is applied
             on a per-distortion layer, per image.  Should be in the range `[0, 1]`.
-            Defaults to `10/11`, as the original `RandAugment` paper includes an
-            Identity transform.  By setting the rate to 10/11 in our implementation, the
-            behavior is identical to sampling an Identity augmentation 10/11th of the
-            time.
+            To reproduce the original RandAugment paper results, set this to `10/11`.
+            The original `RandAugment` paper includes an Identity transform.  By setting
+            the rate to 10/11 in our implementation, the behavior is identical to
+            sampling an Identity augmentation 10/11th of the time.
+            Defaults to `1.0`.
 
     Usage:
     ```python

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -58,9 +58,9 @@ class RandAugment(RandomAugmentationPipeline):
             Defaults to `0.15`.
         rate:  the rate at which to apply each augmentation.  This parameter is applied
             on a per-distortion layer, per image.  Should be in the range `[0, 1]`.
-            Defaults to `1/11`, as the original `RandAugment` paper includes an
-            Identity transform.  By setting the rate to 1/11 in our implementation, the
-            behavior is identical to sampling an Identity augmentation 1/11th of the
+            Defaults to `10/11`, as the original `RandAugment` paper includes an
+            Identity transform.  By setting the rate to 10/11 in our implementation, the
+            behavior is identical to sampling an Identity augmentation 10/11th of the
             time.
 
     Usage:

--- a/keras_cv/layers/preprocessing/rand_augment_test.py
+++ b/keras_cv/layers/preprocessing/rand_augment_test.py
@@ -39,7 +39,7 @@ class RandAugmentTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_runs_with_value_range(self, low, high):
         rand_augment = layers.RandAugment(
-            augmentations_per_image=3, magnitude=0.5, value_range=(low, high)
+            augmentations_per_image=3, magnitude=0.5, rate=1.0, value_range=(low, high)
         )
         xs = tf.random.uniform((2, 512, 512, 3), low, high, dtype=tf.float32)
         ys = rand_augment(xs)
@@ -58,7 +58,7 @@ class RandAugmentTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_runs_unbatched(self):
         rand_augment = layers.RandAugment(
-            augmentations_per_image=3, magnitude=0.5, value_range=(0, 255)
+            augmentations_per_image=3, magnitude=0.5, rate=1.0, value_range=(0, 255)
         )
         xs = tf.random.uniform((512, 512, 3), 0, 255, dtype=tf.float32)
         ys = rand_augment(xs)


### PR DESCRIPTION
Some of these are mean't to be applied BEFORE rand augment - CutOut, and some of these are just too strong (Invert).

This PR is a result of a discussion with the original RandAugment author.

Updated image:
![randaug](https://user-images.githubusercontent.com/12191303/163030115-f7ad842f-0a2d-4635-af5a-1b350921b4d5.png)

