### PR TITLE
Fix COCOMeanAveragePrecision ragged support

### DIFF
--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -189,8 +189,6 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                 ground_truths = utils.filter_boxes(
                     ground_truths, value=category_id, axis=bounding_box.CLASS
                 )
-                if tf.shape(ground_truths)[0] == 0:
-                    continue
 
                 detections = utils.filter_boxes(
                     detections, value=category_id, axis=bounding_box.CLASS

--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -135,12 +135,20 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
         self.false_positive_buckets.assign(tf.zeros_like(self.false_positive_buckets))
         self.ground_truths.assign(tf.zeros_like(self.ground_truths))
 
-    @tf.function()
+    @tf.function(experimental_relax_shapes=True)
     def update_state(self, y_true, y_pred, sample_weight=None):
         if sample_weight is not None:
             warnings.warn(
                 "sample_weight is not yet supported in keras_cv COCO metrics."
             )
+
+        if isinstance(y_true, tf.RaggedTensor):
+            y_true = y_true.to_tensor(default_value=-1)
+        if isinstance(y_pred, tf.RaggedTensor):
+            y_pred = y_pred.to_tensor(default_value=-1)
+
+        y_true = tf.cast(y_true, self.compute_dtype)
+        y_pred = tf.cast(y_pred, self.compute_dtype)
 
         class_ids = tf.constant(self.class_ids, dtype=self.compute_dtype)
         iou_thresholds = tf.constant(self.iou_thresholds, dtype=self.compute_dtype)
@@ -181,6 +189,8 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                 ground_truths = utils.filter_boxes(
                     ground_truths, value=category_id, axis=bounding_box.CLASS
                 )
+                if tf.shape(ground_truths[0] == 0):
+                    continue
 
                 detections = utils.filter_boxes(
                     detections, value=category_id, axis=bounding_box.CLASS
@@ -203,9 +213,11 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                     true_positives = pred_matches != -1
                     false_positives = pred_matches == -1
 
+                    dt_scores_clipped = tf.clip_by_value(dt_scores, 0., 1.)
                     # We must divide by 1.01 to prevent off by one errors.
                     confidence_buckets = tf.cast(
-                        tf.math.floor(self.num_buckets * (dt_scores / 1.01)), tf.int32
+
+                        tf.math.floor(self.num_buckets * (dt_scores_clipped / 1.01)), tf.int32
                     )
                     true_positives_by_bucket = tf.gather_nd(
                         confidence_buckets, indices=tf.where(true_positives)

--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -213,11 +213,11 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                     true_positives = pred_matches != -1
                     false_positives = pred_matches == -1
 
-                    dt_scores_clipped = tf.clip_by_value(dt_scores, 0., 1.)
+                    dt_scores_clipped = tf.clip_by_value(dt_scores, 0.0, 1.0)
                     # We must divide by 1.01 to prevent off by one errors.
                     confidence_buckets = tf.cast(
-
-                        tf.math.floor(self.num_buckets * (dt_scores_clipped / 1.01)), tf.int32
+                        tf.math.floor(self.num_buckets * (dt_scores_clipped / 1.01)),
+                        tf.int32,
                     )
                     true_positives_by_bucket = tf.gather_nd(
                         confidence_buckets, indices=tf.where(true_positives)

--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -189,7 +189,7 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                 ground_truths = utils.filter_boxes(
                     ground_truths, value=category_id, axis=bounding_box.CLASS
                 )
-                if tf.shape(ground_truths[0] == 0):
+                if tf.shape(ground_truths)[0] == 0:
                     continue
 
                 detections = utils.filter_boxes(

--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -135,7 +135,7 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
         self.false_positive_buckets.assign(tf.zeros_like(self.false_positive_buckets))
         self.ground_truths.assign(tf.zeros_like(self.ground_truths))
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function()
     def update_state(self, y_true, y_pred, sample_weight=None):
         if sample_weight is not None:
             warnings.warn(

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -202,3 +202,32 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
         mean_average_precision.false_positive_buckets.assign(false_positives)
 
         self.assertEqual(mean_average_precision.result(), 0.625)
+
+    def test_runs_with_confidence_over_1(self):
+        mean_average_precision = COCOMeanAveragePrecision(
+            iou_thresholds=[0.33],
+            class_ids=[1, 2],
+            max_detections=100,
+            num_buckets=3,
+            recall_thresholds=[0.3, 0.5],
+        )
+
+
+        y_true = tf.ragged.stack(
+            [
+                tf.constant([[0, 0, 10, 10, 1], [5, 5, 10, 10, 1]], tf.float32),
+                tf.constant([[0, 0, 10, 10, 1]], tf.float32),
+            ]
+        )
+        y_pred = tf.ragged.stack(
+            [
+                tf.constant([[5, 5, 10, 10, 1, 0.9]], tf.float32),
+                # this box is out of the valid confidence range.
+                tf.constant(
+                    [[0, 0, 10, 10, 1, 1.0], [5, 5, 10, 10, 1, 1.1]], tf.float32
+                ),
+            ]
+        )
+        print('y_true_shape', y_true.shape)
+        mean_average_precision.update_state(y_true, y_pred)
+        self.assertEqual(mean_average_precision.result(), 1.0)

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -212,7 +212,6 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
             recall_thresholds=[0.3, 0.5],
         )
 
-
         y_true = tf.ragged.stack(
             [
                 tf.constant([[0, 0, 10, 10, 1], [5, 5, 10, 10, 1]], tf.float32),
@@ -229,4 +228,4 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
             ]
         )
         mean_average_precision.update_state(y_true, y_pred)
-        self.assertEqual(mean_average_precision.result(), 2/3)
+        self.assertEqual(mean_average_precision.result(), 2 / 3)

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -228,6 +228,5 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
                 ),
             ]
         )
-        print('y_true_shape', y_true.shape)
         mean_average_precision.update_state(y_true, y_pred)
-        self.assertEqual(mean_average_precision.result(), 1.0)
+        self.assertEqual(mean_average_precision.result(), 2/3)

--- a/keras_cv/metrics/coco/utils.py
+++ b/keras_cv/metrics/coco/utils.py
@@ -91,7 +91,7 @@ def sort_bounding_boxes(boxes, axis=5):
     for img in tf.range(num_images):
         preds_for_img = boxes[img, :, :]
         prediction_scores = preds_for_img[:, axis]
-        _, idx = tf.math.top_k(prediction_scores, preds_for_img.shape[0])
+        _, idx = tf.math.top_k(prediction_scores, tf.shape(preds_for_img)[0])
         boxes_sorted_list = boxes_sorted_list.write(
             img, tf.gather(preds_for_img, idx, axis=0)
         )


### PR DESCRIPTION
Previously we were relying on tensor.shape instead of tf.shape(tensor).  This does not work with Ragged Tensors.