### PR TITLE
Move serialization_test.py to central location.

### DIFF
--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -158,6 +158,7 @@ class DropBlock2D(BaseRandomLayer):
             value=dropblock_size, n=2, name="dropblock_size", allow_zero=False
         )
         self._data_format = conv_utils.normalize_data_format(data_format)
+        self.seed = seed
 
     def call(self, x, training=None):
         if not training or self._dropout_rate == 0.0:
@@ -237,6 +238,7 @@ class DropBlock2D(BaseRandomLayer):
             "dropout_rate": self._dropout_rate,
             "dropblock_size": (self._dropblock_height, self._dropblock_width),
             "data_format": self._data_format,
+            "seed": self.seed,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/regularization/dropblock_2d_test.py
+++ b/keras_cv/layers/regularization/dropblock_2d_test.py
@@ -14,7 +14,6 @@
 
 import tensorflow as tf
 
-from keras_cv.layers.preprocessing.serialization_test import config_equals
 from keras_cv.layers.regularization.dropblock_2d import DropBlock2D
 
 
@@ -94,16 +93,3 @@ class DropBlock2DTest(tf.test.TestCase):
             return layer(x, training=True)
 
         apply(dummy_inputs)
-
-    def test_layer_serialization(self):
-        layer = DropBlock2D(dropout_rate=0.1, dropblock_size=7, seed=1234)
-
-        model = tf.keras.models.Sequential(layer)
-        model_config = model.get_config()
-
-        reconstructed_model = tf.keras.Sequential().from_config(model_config)
-        reconstructed_layer = reconstructed_model.layers[0]
-
-        self.assertTrue(
-            config_equals(layer.get_config(), reconstructed_layer.get_config())
-        )

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -16,6 +16,7 @@ from absl.testing import parameterized
 
 from keras_cv import core
 from keras_cv.layers import preprocessing
+from keras_cv.layers import regularization
 
 
 def custom_compare(obj1, obj2):
@@ -113,6 +114,15 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
                 "saturation_factor": (0.5, 0.9),
                 "hue_factor": (0.5, 0.9),
                 "seed": 1,
+            },
+        ),
+        (
+            "DropBlock2D",
+            regularization.DropBlock2D,
+            {
+                "dropout_rate": 0.1,
+                "dropblock_size": (7, 7),
+                "seed": 1234,
             },
         ),
     )


### PR DESCRIPTION
Linked issue: #345 

Changelog:
* moved `serialization_test.py` to `layers` folder, so it also refers to other layers than preprocessing.
* added `DropBlock2D` to this file and updated it's tests.

Let me know if this is ok!