### PR TITLE
Add Random Snow

### DIFF
--- a/examples/layers/preprocessing/random_snow_demo.py
+++ b/examples/layers/preprocessing/random_snow_demo.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""random_snow_demo.py shows how to use the RandomSnow preprocessing layer.
+Operates on the oxford_flowers102 dataset.  In this script the flowers
+are loaded, then are passed through the preprocessing layers.
+Finally, they are shown using matplotlib.
+"""
+import matplotlib.pyplot as plt
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+from keras_cv.layers import preprocessing
+
+IMG_SIZE = (224, 224)
+BATCH_SIZE = 64
+
+
+def resize(image, label):
+    image = tf.image.resize(image, IMG_SIZE)
+    return image, label
+
+
+def main():
+    data, ds_info = tfds.load("oxford_flowers102", with_info=True, as_supervised=True)
+    train_ds = data["train"]
+
+    train_ds = train_ds.map(lambda x, y: resize(x, y)).batch(BATCH_SIZE)
+    random_snow = preprocessing.RandomSnow(factor=(0.0, 1.0), value_range=(0, 255))
+    train_ds = train_ds.map(
+        lambda x, y: (random_snow(x), y), num_parallel_calls=tf.data.AUTOTUNE
+    )
+
+    for images, labels in train_ds.take(1):
+        plt.figure(figsize=(8, 8))
+        for i in range(9):
+            plt.subplot(3, 3, i + 1)
+            plt.imshow(images[i].numpy().astype("uint8"))
+            plt.axis("off")
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -50,6 +50,7 @@ from keras_cv.layers.preprocessing.random_color_jitter import RandomColorJitter
 from keras_cv.layers.preprocessing.random_cutout import RandomCutout
 from keras_cv.layers.preprocessing.random_gaussian_blur import RandomGaussianBlur
 from keras_cv.layers.preprocessing.random_hue import RandomHue
+from keras_cv.layers.preprocessing.random_snow import RandomSnow
 from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear

--- a/keras_cv/layers/preprocessing/random_snow.py
+++ b/keras_cv/layers/preprocessing/random_snow.py
@@ -1,0 +1,96 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+
+from keras_cv.utils import preprocessing
+
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class RandomSnow(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
+    """Randomly adjusts the hue on given images.
+
+    This layer will randomly add snow effect on the input RGB
+    images. At inference time, the output will be identical to the input.
+
+    Snow is added on the image by converting image to HSV and rotating
+    channel (V) in order to get snow effect on image.
+
+    Args:
+        factor: A tuple of two floats, a single float or `keras_cv.FactorSampler`.
+            `factor` controls the extent to which the snow effect is impacted.
+            `factor=0.0` makes this layer perform a no-op operation, while a value of
+            1.0 performs the most aggressive contrast adjustment available.  If a tuple
+            is used, a `factor` is sampled between the two values for every image
+            augmented.  If a single float is used, a value between `0.0` and the passed
+            float is sampled.  In order to ensure the value is always the same, please
+            pass a tuple with two identical floats: `(0.5, 0.5)`.
+        value_range:  the range of values the incoming images will have.
+            Represented as a two number tuple written [low, high].
+            This is typically either `[0, 1]` or `[0, 255]` depending
+            on how your preprocessing pipeline is setup.
+        seed: Integer. Used to create a random seed.
+
+    """
+
+    def __init__(self, factor, value_range, seed=None, **kwargs):
+        super().__init__(seed=seed, **kwargs)
+        self.factor = preprocessing.parse_factor(
+            factor,
+        )
+        self.value_range = value_range
+        self.seed = seed
+
+    def get_random_transformation(self, image=None, label=None, bounding_box=None):
+        return self.factor()
+
+    def augment_image(self, image, transformation=None):
+        image = preprocessing.transform_value_range(image, self.value_range, (0, 1))
+
+        image_HSV = tf.image.rgb_to_hsv(image)
+        image_HSV = tf.cast(image_HSV, tf.float64)
+
+        # scale transformation to find snow points.
+        transformation *= 255 / 2
+        transformation += 255 / 3
+
+        brightness_coefficient = tf.constant(2.5, tf.float64)
+        transformed_image_V = tf.where(
+            image_HSV[:, :, 2] < transformation,
+            image_HSV[:, :, 2] * brightness_coefficient,
+            image_HSV[:, :, 2],
+        )
+
+        # channel (V) should have range [0-255].
+        transformed_image_V = tf.clip_by_value(
+            transformed_image_V, clip_value_min=0, clip_value_max=255
+        )
+        image_HSV = tf.stack(
+            [image_HSV[:, :, 0], image_HSV[:, :, 1], transformed_image_V], axis=-1
+        )
+        image_RGB = tf.image.hsv_to_rgb(image_HSV)
+
+        image = preprocessing.transform_value_range(image_RGB, (0, 1), self.value_range)
+        return image
+
+    def augment_label(self, label, transformation=None):
+        return label
+
+    def get_config(self):
+        config = {
+            "factor": self.factor,
+            "value_range": self.value_range,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/preprocessing/random_snow.py
+++ b/keras_cv/layers/preprocessing/random_snow.py
@@ -50,6 +50,7 @@ class RandomSnow(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
         )
         self.value_range = value_range
         self.seed = seed
+        self.brightness_coefficient = tf.constant(2.5)
 
     def get_random_transformation(self, image=None, label=None, bounding_box=None):
         return self.factor()
@@ -64,22 +65,33 @@ class RandomSnow(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
         transformation *= 255 / 2
         transformation += 255 / 3
 
-        brightness_coefficient = tf.constant(2.5, tf.float64)
-        transformed_image_V = tf.where(
-            image_HSV[:, :, 2] < transformation,
-            image_HSV[:, :, 2] * brightness_coefficient,
-            image_HSV[:, :, 2],
-        )
+        # Saturation or channel (S).
+        image_S = image_HSV[:, :, 1]
 
-        # channel (V) should have range [0-255].
-        transformed_image_V = tf.clip_by_value(
-            transformed_image_V, clip_value_min=0, clip_value_max=255
+        # Value or Brightness channel.
+        image_V = image_HSV[:, :, 2]
+
+        # Calculate lightness in HSL color space and scale.
+        image_L = (
+            tf.math.reduce_min(image, axis=-1) + tf.math.reduce_max(image, axis=-1)
+        ) / tf.constant(2, tf.float32)
+        image_L = tf.where(
+            image_L < transformation, image_L * self.brightness_coefficient, image_L
         )
-        image_HSV = tf.stack(
-            [image_HSV[:, :, 0], image_HSV[:, :, 1], transformed_image_V], axis=-1
+        image_L = tf.clip_by_value(image_L, clip_value_min=0, clip_value_max=255)
+
+        # Get corresponding channel (V) in HSV space.
+        image_V = image_L / (1 - (image_S / tf.constant(2, tf.float32)))
+        image_V = tf.clip_by_value(image_V, clip_value_min=0, clip_value_max=255)
+
+        # Get corresponding channel (S) in HSV space.
+        image_S = tf.where(
+            image_V == 0, 0.0, tf.constant(2.0) * (tf.constant(1.0) - image_L / image_V)
         )
+        image_S = tf.clip_by_value(image_S, clip_value_min=0, clip_value_max=1.0)
+
+        image_HSV = tf.stack([image_HSV[:, :, 0], image_S, image_V], axis=-1)
         image_RGB = tf.image.hsv_to_rgb(image_HSV)
-
         image = preprocessing.transform_value_range(image_RGB, (0, 1), self.value_range)
         return image
 


### PR DESCRIPTION
closes
#357 


Details:

## Original implementation requires

RGB to HLS conversion

H - hue
L - lightness
S - saturation

Original implementation scale `L` channel with appropriate value on some defined points

## Our Implementation

#### Im converting RGB to HSV

H - hue
S - sat
V - Value / Brightness

calculating `L` lightness in HSL space
with formula (min(RGB) + max(RGB) ) / 2

Scaling `L` on snow points with corresponding scalar (i.e brightness coefficient)

Now, 
there is not function as HSL to RGB in tensorflow hence
need to get corresponding 

`S` and `V` values from the new scaled `L` by using some maths.
@LukeWood please check it, need your review!


official formulas:
https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
![image](https://user-images.githubusercontent.com/38289341/165960566-9f51a587-2f29-4e4c-a6d9-3402dd9f0a7a.png)
