### PR TITLE
Fix the comment about the lambda variable scope in a loop

### DIFF
--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -95,11 +95,10 @@ class RandomAugmentationPipeline(
                 (), minval=0, maxval=len(self.layers), dtype=tf.int32
             )
 
-            # Warning:
-            # Do not replace the currying function with a lambda.
-            # Originally we used a lambda, but due to Python's
-            # lack of loop level scope this causes unexpected
-            # behavior running outside of graph mode.
+            # Note:
+            # If you replace the currying function with a lambda please
+            # take care of the variable scope.
+            # https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
             branch_fns = [
                 (i, self._curry_call_layer(inputs, layer))
                 for (i, layer) in enumerate(self.layers)


### PR DESCRIPTION
This fix the comment about the right root cause of the original bug as it was not related to Tensoflow, autograph, eager or graph mode but it was a pure python bug/quirks of the original implementation:

https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result

See more at https://github.com/keras-team/keras-cv/pull/430#pullrequestreview-971282078

/cc @mdanatg @martin-gorner

As this is the 2nd PR please comment inline with a review and don't edit the string directly with a commit. 
I am happy to reproduce this with any Gist you can share and eventually contribute/extend an autograph tests in TF if confirmed.

Thanks