### PR TITLE
RandomChoice layer

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-name: Tests
+nane: Tests
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tf-nightly
+        pip install tensorflow==2.9.0rc2
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       run: |
@@ -60,7 +60,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tf-nightly
+        pip install tensorflow==2.9.0rc2
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Lint
       run: bash shell/lint.sh
@@ -76,7 +76,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install tf-nightly
+        pip install tensorflow==2.9.0rc2
         python -m pip install --upgrade pip setuptools wheel twine
     - name: Build and publish
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-nane: Tests
+name: Tests
 
 on:
   push:

--- a/examples/layers/preprocessing/random_augmentation_pipeline_demo.py
+++ b/examples/layers/preprocessing/random_augmentation_pipeline_demo.py
@@ -41,6 +41,7 @@ def create_custom_pipeline():
     return preprocessing.RandomAugmentationPipeline(
         layers=layers, augmentations_per_image=3
     )
+    # return preprocessing.RandomChoice(layers=layers)
 
 
 def main():

--- a/examples/layers/preprocessing/random_augmentation_pipeline_demo.py
+++ b/examples/layers/preprocessing/random_augmentation_pipeline_demo.py
@@ -41,7 +41,6 @@ def create_custom_pipeline():
     return preprocessing.RandomAugmentationPipeline(
         layers=layers, augmentations_per_image=3
     )
-    # return preprocessing.RandomChoice(layers=layers)
 
 
 def main():

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -39,6 +39,7 @@ from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,
 )
 from keras_cv.layers.preprocessing.random_channel_shift import RandomChannelShift
+from keras_cv.layers.preprocessing.random_choice import RandomChoice
 from keras_cv.layers.preprocessing.random_color_degeneration import (
     RandomColorDegeneration,
 )

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -43,6 +43,7 @@ from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,
 )
 from keras_cv.layers.preprocessing.random_channel_shift import RandomChannelShift
+from keras_cv.layers.preprocessing.random_choice import RandomChoice
 from keras_cv.layers.preprocessing.random_color_degeneration import (
     RandomColorDegeneration,
 )

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -79,7 +79,9 @@ class RandomAugmentationPipeline(
         self.auto_vectorize = auto_vectorize
         self.seed = seed
 
-        self._random_choice = preprocessing.RandomChoice(layers=layers, seed=seed)
+        self._random_choice = preprocessing.RandomChoice(
+            layers=layers, auto_vectorize=auto_vectorize, seed=seed
+        )
 
     def _augment(self, inputs):
         result = inputs

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -23,7 +23,7 @@ class RandomAugmentationPipeline(
     """RandomAugmentationPipeline constructs a pipeline based on provided arguments.
 
     The implemented policy does the following: for each inputs provided in `call`(), the
-    policy first inputss a random number, if the number is < rate, the policy then
+    policy first inputs a random number, if the number is < rate, the policy then
     selects a random layer from the provided list of `layers`.  It then calls the
     `layer()` on the inputs.  This is done `augmentations_per_image` times.
 
@@ -49,16 +49,16 @@ class RandomAugmentationPipeline(
 
     Args:
         layers: a list of `keras.Layers`.  These are randomly inputs during
-            augmentation to augment the inputss passed in `call()`.  The layers passed
+            augmentation to augment the inputs passed in `call()`.  The layers passed
             should subclass `BaseImageAugmentationLayer`.
         augmentations_per_image: the number of layers to apply to each inputs in the
             `call()` method.
         rate: the rate at which to apply each augmentation.  This is applied on a per
             augmentation bases, so if `augmentations_per_image=3` and `rate=0.5`, the
             odds an image will receive no augmentations is 0.5^3, or 0.5*0.5*0.5.
-        auto_vectorize: whether or not to use `tf.vectorized_map` or `tf.map_fn` to
+        auto_vectorize: whether to use `tf.vectorized_map` or `tf.map_fn` to
             apply the augmentations.  This offers a significant performance boost, but
-            can only be used if all of the layers provided to the `layers` argument
+            can only be used if all the layers provided to the `layers` argument
             support auto vectorization.
         seed: Integer. Used to create a random seed.
     """
@@ -90,7 +90,7 @@ class RandomAugmentationPipeline(
             result = tf.cond(
                 skip_augment > self.rate,
                 lambda: inputs,
-                lambda: self._random_choice(inputs),
+                lambda: self._random_choice(result),
             )
         return result
 

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -15,13 +15,11 @@ import tensorflow as tf
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
-class RandomChoice(
-    tf.keras.__internal__.layers.BaseImageAugmentationLayer
-):
+class RandomChoice(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     """RandomChoice constructs a pipeline based on provided arguments.
 
     The implemented policy does the following: for each inputs provided in `call`(), the
-    selects a random layer from the provided list of `layers`.  It then calls the
+    policy selects a random layer from the provided list of `layers`.  It then calls the
     `layer()` on the inputs.
 
     Usage:
@@ -43,9 +41,9 @@ class RandomChoice(
         layers: a list of `keras.Layers`.  These are randomly inputs during
             augmentation to augment the inputs passed in `call()`.  The layers passed
             should subclass `BaseImageAugmentationLayer`.
-        auto_vectorize: whether or not to use `tf.vectorized_map` or `tf.map_fn` to
+        auto_vectorize: whether to use `tf.vectorized_map` or `tf.map_fn` to
             apply the augmentations.  This offers a significant performance boost, but
-            can only be used if all of the layers provided to the `layers` argument
+            can only be used if all the layers provided to the `layers` argument
             support auto vectorization.
         seed: Integer. Used to create a random seed.
     """
@@ -87,7 +85,6 @@ class RandomChoice(
             (i, self._curry_call_layer(inputs, layer))
             for (i, layer) in enumerate(self.layers)
         ]
-
         return tf.switch_case(
             branch_index=selected_op,
             branch_fns=branch_fns,

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -13,22 +13,16 @@
 # limitations under the License.
 import tensorflow as tf
 
-from keras_cv.layers import preprocessing
-
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
-class RandomAugmentationPipeline(
+class RandomChoice(
     tf.keras.__internal__.layers.BaseImageAugmentationLayer
 ):
-    """RandomAugmentationPipeline constructs a pipeline based on provided arguments.
+    """RandomChoice constructs a pipeline based on provided arguments.
 
     The implemented policy does the following: for each inputs provided in `call`(), the
-    policy first inputss a random number, if the number is < rate, the policy then
     selects a random layer from the provided list of `layers`.  It then calls the
-    `layer()` on the inputs.  This is done `augmentations_per_image` times.
-
-    This layer can be used to create custom policies resembling `RandAugment` or
-    `AutoAugment`.
+    `layer()` on the inputs.
 
     Usage:
     ```python
@@ -40,22 +34,15 @@ class RandomAugmentationPipeline(
     layers = layers + [keras_cv.layers.GridMask()]
 
     # create the pipeline.
-    pipeline = keras_cv.layers.RandomAugmentationPipeline(
-        layers=layers, augmentations_per_image=3
-    )
+    pipeline = keras_cv.layers.RandomChoice(layers=layers)
 
     augmented_images = pipeline(images)
     ```
 
     Args:
         layers: a list of `keras.Layers`.  These are randomly inputs during
-            augmentation to augment the inputss passed in `call()`.  The layers passed
+            augmentation to augment the inputs passed in `call()`.  The layers passed
             should subclass `BaseImageAugmentationLayer`.
-        augmentations_per_image: the number of layers to apply to each inputs in the
-            `call()` method.
-        rate: the rate at which to apply each augmentation.  This is applied on a per
-            augmentation bases, so if `augmentations_per_image=3` and `rate=0.5`, the
-            odds an image will receive no augmentations is 0.5^3, or 0.5*0.5*0.5.
         auto_vectorize: whether or not to use `tf.vectorized_map` or `tf.map_fn` to
             apply the augmentations.  This offers a significant performance boost, but
             can only be used if all of the layers provided to the `layers` argument
@@ -66,40 +53,51 @@ class RandomAugmentationPipeline(
     def __init__(
         self,
         layers,
-        augmentations_per_image,
-        rate=1.0,
         auto_vectorize=False,
         seed=None,
         **kwargs,
     ):
         super().__init__(**kwargs, seed=seed, force_generator=True)
-        self.augmentations_per_image = augmentations_per_image
-        self.rate = rate
         self.layers = layers
         self.auto_vectorize = auto_vectorize
         self.seed = seed
 
-        self._random_choice = preprocessing.RandomChoice(layers=layers, seed=seed)
+    def _curry_call_layer(self, inputs, layer):
+        def call_layer():
+            return layer(inputs)
 
-    def _augment(self, inputs):
-        result = inputs
-        for _ in range(self.augmentations_per_image):
-            skip_augment = self._random_generator.random_uniform(
-                shape=(), minval=0.0, maxval=1.0, dtype=tf.float32
-            )
-            result = tf.cond(
-                skip_augment > self.rate,
-                lambda: inputs,
-                lambda: self._random_choice(inputs),
-            )
-        return result
+        return call_layer
+
+    def _augment(self, inputs, *args, **kwargs):
+        selected_op = self._random_generator.random_uniform(
+            (), minval=0, maxval=len(self.layers), dtype=tf.int32
+        )
+
+        # Warning:
+        # Do not replace the currying function with a lambda.
+        # Originally we used a lambda, but due to Python's
+        # lack of loop level scope this causes unexpected
+        # behavior running outside of graph mode.
+        #
+        # Autograph has an edge case where the behavior of Python for loop
+        # variables is inconsistent between Python and graph execution.
+        # By using a list comprehension and currying, we mitigate
+        # our code against both of these cases.
+        branch_fns = [
+            (i, self._curry_call_layer(inputs, layer))
+            for (i, layer) in enumerate(self.layers)
+        ]
+
+        return tf.switch_case(
+            branch_index=selected_op,
+            branch_fns=branch_fns,
+            default=lambda: inputs,
+        )
 
     def get_config(self):
         config = super().get_config()
         config.update(
             {
-                "augmentations_per_image": self.augmentations_per_image,
-                "rate": self.rate,
                 "layers": self.layers,
                 "seed": self.seed,
             }

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -96,6 +96,7 @@ class RandomChoice(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
         config.update(
             {
                 "layers": self.layers,
+                "auto_vectorize": self.auto_vectorize,
                 "seed": self.seed,
             }
         )

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -1,0 +1,71 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv import layers
+
+
+class AddOneToInputs(tf.keras.layers.Layer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.call_counter = tf.Variable(initial_value=0)
+
+    def call(self, inputs):
+        result = inputs.copy()
+        result["images"] = inputs["images"] + 1
+        self.call_counter.assign_add(1)
+        return result
+
+
+class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
+    def test_calls_layer_augmentation_per_image(self):
+        layer = AddOneToInputs()
+        pipeline = layers.RandomChoice(layers=[layer])
+        xs = tf.random.uniform((2, 5, 5, 3), 0, 100, dtype=tf.float32)
+        os = pipeline(xs)
+
+        self.assertAllClose(xs + 1, os)
+
+    def test_calls_layer_augmentation_in_graph(self):
+        layer = AddOneToInputs()
+        pipeline = layers.RandomChoice(layers=[layer])
+
+        @tf.function()
+        def call_pipeline(xs):
+            return pipeline(xs)
+
+        xs = tf.random.uniform((2, 5, 5, 3), 0, 100, dtype=tf.float32)
+        os = call_pipeline(xs)
+
+        self.assertAllClose(xs + 1, os)
+
+    def test_calls_layer_augmentation_single_image(self):
+        layer = AddOneToInputs()
+        pipeline = layers.RandomChoice(layers=[layer])
+        xs = tf.random.uniform((5, 5, 3), 0, 100, dtype=tf.float32)
+        os = pipeline(xs)
+
+        self.assertAllClose(xs + 1, os)
+
+    def test_calls_choose_one_layer_augmentation(self):
+        batch_size = 10
+        pipeline = layers.RandomChoice(layers=[AddOneToInputs(), AddOneToInputs()])
+        xs = tf.random.uniform((batch_size, 5, 5, 3), 0, 100, dtype=tf.float32)
+        os = pipeline(xs)
+
+        self.assertAllClose(xs + 1, os)
+
+        total_calls = pipeline.layers[0].call_counter + pipeline.layers[1].call_counter
+        self.assertEqual(total_calls, batch_size)

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -105,6 +105,15 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
             },
         ),
         (
+            "RandomChoice",
+            preprocessing.RandomChoice,
+            {
+                "layers": [],
+                "seed": 3,
+                "auto_vectorize": False,
+            },
+        ),
+        (
             "RandomColorJitter",
             preprocessing.RandomColorJitter,
             {


### PR DESCRIPTION
Implementation of a `RandomChoice` layer. Closes #408.

* `RandomChoice` will at each call _uniformly_ sample a _single_ layer from a list of layers, and call it on the inputs.
* `RandomAugmentationPipeline` has been refactored to use `RandomChoice` internally.

Right now `RandomChoice` is placed under the `keras_cv.layers.preprocessing` module, however it is not really a preprocessing layer, so it might be worth thinking about if it should be located elsewhere.