### PR TITLE
Align developer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG VARIANT
 
-FROM tensorflow/tensorflow:nightly${VARIANT}
+FROM tensorflow/tensorflow:2.9rc2${VARIANT}
 
 RUN pip install flake8 isort black pytest


### PR DESCRIPTION
@LukeWood Just a reminder when you do changes like https://github.com/keras-team/keras-cv/pull/434/commits/fb3628054e86d70c9f5795d29b73f824c16cf41f

It is better to align also the developer container to the same version as it represents the version on which we want the developer to work on `Keras-cv` master to prepare PRs

It is important to align CI and developers environments.