### PR TITLE
cut_mix example: tf.cast label from int to float

### DIFF
--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -45,13 +45,14 @@ def main():
         .batch(BATCH_SIZE)
     )
     cutmix = preprocessing.CutMix()
-    train_ds = train_ds.map(cutmix, num_parallel_calls=tf.data.AUTOTUNE)
+    train_ds = train_ds.map(lambda image, label: cutmix({'images':image, 'labels':label}), num_parallel_calls=tf.data.AUTOTUNE)
 
-    for images, labels in train_ds.take(1):
+
+    for data in train_ds.take(1):
         plt.figure(figsize=(8, 8))
         for i in range(9):
             plt.subplot(3, 3, i + 1)
-            plt.imshow(images[i].numpy().astype("uint8"))
+            plt.imshow(data['images'][i].numpy().astype("uint8"))
             plt.axis("off")
         plt.show()
 

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -45,8 +45,9 @@ def main():
         .batch(BATCH_SIZE)
     )
     cutmix = preprocessing.CutMix()
-    train_ds = train_ds.map(lambda image, label: cutmix({'images':image, 'labels':label}), num_parallel_calls=tf.data.AUTOTUNE)
-
+    train_ds = train_ds.map(lambda image, label: 
+                            cutmix({'images': image, 'labels': label}), 
+                            num_parallel_calls=tf.data.AUTOTUNE)
 
     for data in train_ds.take(1):
         plt.figure(figsize=(8, 8))

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -48,11 +48,11 @@ def main():
     train_ds = train_ds.map(lambda image, label: cutmix({'images':image, 'labels':label}), num_parallel_calls=tf.data.AUTOTUNE)
 
 
-    for images, labels in train_ds.take(1):
+    for data in train_ds.take(1):
         plt.figure(figsize=(8, 8))
         for i in range(9):
             plt.subplot(3, 3, i + 1)
-            plt.imshow(images[i].numpy().astype("uint8"))
+            plt.imshow(data['images'][i].numpy().astype("uint8"))
             plt.axis("off")
         plt.show()
 

--- a/examples/layers/preprocessing/cut_mix_demo.py
+++ b/examples/layers/preprocessing/cut_mix_demo.py
@@ -48,11 +48,11 @@ def main():
     train_ds = train_ds.map(lambda image, label: cutmix({'images':image, 'labels':label}), num_parallel_calls=tf.data.AUTOTUNE)
 
 
-    for data in train_ds.take(1):
+    for images, labels in train_ds.take(1):
         plt.figure(figsize=(8, 8))
         for i in range(9):
             plt.subplot(3, 3, i + 1)
-            plt.imshow(data['images'][i].numpy().astype("uint8"))
+            plt.imshow(images[i].numpy().astype("uint8"))
             plt.axis("off")
         plt.show()
 

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -35,7 +35,7 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     labels = tf.one_hot(labels.squeeze(), 10)
 
     cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
-    cutmix({"images": images[:32], "labels": labels[:32]})
+    output = cutmix({"images": images[:32], "labels": labels[:32]})
     # output == {'images': updated_images, 'labels': updated_labels}
     ```
     """

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -33,7 +33,7 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
     cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
-    output = cutmix({'images': images, 'labels': labels})
+    output = cutmix({'images': images, 'labels': tf.cast(labels, dtype = tf.float32)})
     # output == {'images': updated_images, 'labels': updated_labels}
     ```
     """

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -32,9 +32,10 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     Sample usage:
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+    labels = tf.one_hot(labels.squeeze(), 10)
+
     cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
-    images, labels =  images[:32], labels[:32]
-    output = cutmix({'images': images, 'labels': tf.one_hot(labels, 10)})
+    cutmix({"images": images[:32], "labels": labels[:32]})
     # output == {'images': updated_images, 'labels': updated_labels}
     ```
     """

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -61,9 +61,9 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
                 f"Got: inputs = {inputs}"
             )
         images, labels = self._update_labels(*self._cutmix(images, labels))
-        #inputs["images"] = images
-        #inputs["labels"] = labels
-        return images, labels #inputs
+        inputs["images"] = images
+        inputs["labels"] = labels
+        return inputs
 
     def _augment(self, inputs):
         raise ValueError(

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -59,9 +59,9 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
                 f"Got: inputs = {inputs}"
             )
         images, labels = self._update_labels(*self._cutmix(images, labels))
-        inputs["images"] = images
-        inputs["labels"] = labels
-        return inputs
+        #inputs["images"] = images
+        #inputs["labels"] = labels
+        return images, labels #inputs
 
     def _augment(self, inputs):
         raise ValueError(

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -33,7 +33,8 @@ class CutMix(tf.keras.__internal__.layers.BaseImageAugmentationLayer):
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
     cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
-    output = cutmix({'images': images, 'labels': tf.cast(labels, dtype = tf.float32)})
+    images, labels =  images[:32], labels[:32]
+    output = cutmix({'images': images, 'labels': tf.one_hot(labels, 10)})
     # output == {'images': updated_images, 'labels': updated_labels}
     ```
     """


### PR DESCRIPTION
Hello,

I noticed that the current example for cut_mix does not work, because

the dtype is int for the label:
```
---------------------------------------------------------------------------
InvalidArgumentError                      Traceback (most recent call last)
[<ipython-input-80-2593aa7caea0>](https://localhost:8080/#) in <module>()
      1 (images, labels), _ = tf.keras.datasets.cifar10.load_data()
      2 cutmix = keras_cv.layers.preprocessing.cut_mix.CutMix(10)
----> 3 output = cutmix({'images': images, 'labels': labels})

1 frames
[/usr/local/lib/python3.7/dist-packages/keras/utils/traceback_utils.py](https://localhost:8080/#) in error_handler(*args, **kwargs)
     65     except Exception as e:  # pylint: disable=broad-except
     66       filtered_tb = _process_traceback_frames(e.__traceback__)
---> 67       raise e.with_traceback(filtered_tb) from None
     68     finally:
     69       del filtered_tb

[/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/ops.py](https://localhost:8080/#) in raise_from_not_ok_status(e, name)
   7162 def raise_from_not_ok_status(e, name):
   7163   e.message += (" name: " + name if name is not None else "")
-> 7164   raise core._status_to_exception(e) from None  # pylint: disable=protected-access
   7165 
   7166 

InvalidArgumentError: Exception encountered when calling layer "cut_mix_4" (type CutMix).

cannot compute Mul as input #1(zero-based) was expected to be a float tensor but is a uint8 tensor [Op:Mul]

Call arguments received by layer "cut_mix_4" (type CutMix):
  • inputs={'images': 'tf.Tensor(shape=(50000, 32, 32, 3), dtype=float32)', 'labels': 'tf.Tensor(shape=(50000, 1), dtype=uint8)'}
  • training=True
```

Changing the dtype of ```labels``` to ```tf.cast(labels, dtype = tf.float32)``` solves the issue.

Example notebook:
https://colab.research.google.com/drive/1k-IrSJF-DlP_o27ohr7GvYsXliGRifTF?usp=sharing

 