### PR TITLE
Make tests depend on linting

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,6 +7,7 @@ on:
     types: [created]
 jobs:
   test:
+    needs: [format]
     name: Test the code
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
With this we could minimize the tests runs when the contributor doesn't format  the code locally with the script, pre-commit hook or the VsCode integration we offer in the repository and is going to totally rely on the CI job.