### PR TITLE
Fix major numerical issue in COCOMeanAveragePrecision

### DIFF
--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -215,13 +215,17 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
                     detections, value=category_id, axis=bounding_box.XYXY.CLASS
                 )
                 if self.max_detections < tf.shape(detections_by_category)[0]:
-                    detections_by_category = detections_by_category[: self.max_detections]
+                    detections_by_category = detections_by_category[
+                        : self.max_detections
+                    ]
 
                 ground_truths_update = ground_truths_update.write(
                     c_i, tf.shape(ground_truths_by_category)[0]
                 )
 
-                ious = iou_lib.compute_ious_for_image(ground_truths_by_category, detections_by_category)
+                ious = iou_lib.compute_ious_for_image(
+                    ground_truths_by_category, detections_by_category
+                )
 
                 for iou_i in tf.range(self.num_iou_thresholds):
                     iou_threshold = iou_thresholds[iou_i]

--- a/keras_cv/metrics/coco/mean_average_precision.py
+++ b/keras_cv/metrics/coco/mean_average_precision.py
@@ -208,26 +208,26 @@ class COCOMeanAveragePrecision(tf.keras.metrics.Metric):
 
             for c_i in tf.range(self.num_class_ids):
                 category_id = class_ids[c_i]
-                ground_truths = utils.filter_boxes(
+                ground_truths_by_category = utils.filter_boxes(
                     ground_truths, value=category_id, axis=bounding_box.XYXY.CLASS
                 )
-                detections = utils.filter_boxes(
+                detections_by_category = utils.filter_boxes(
                     detections, value=category_id, axis=bounding_box.XYXY.CLASS
                 )
-                if self.max_detections < tf.shape(detections)[0]:
-                    detections = detections[: self.max_detections]
+                if self.max_detections < tf.shape(detections_by_category)[0]:
+                    detections_by_category = detections_by_category[: self.max_detections]
 
                 ground_truths_update = ground_truths_update.write(
-                    c_i, tf.shape(ground_truths)[0]
+                    c_i, tf.shape(ground_truths_by_category)[0]
                 )
 
-                ious = iou_lib.compute_ious_for_image(ground_truths, detections)
+                ious = iou_lib.compute_ious_for_image(ground_truths_by_category, detections_by_category)
 
                 for iou_i in tf.range(self.num_iou_thresholds):
                     iou_threshold = iou_thresholds[iou_i]
                     pred_matches = utils.match_boxes(ious, iou_threshold)
 
-                    dt_scores = detections[:, bounding_box.XYXY.CONFIDENCE]
+                    dt_scores = detections_by_category[:, bounding_box.XYXY.CONFIDENCE]
 
                     true_positives = pred_matches != -1
                     false_positives = pred_matches == -1

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -197,25 +197,22 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
         self.assertEqual(mean_average_precision.result(), 0.625)
 
     def test_counting_with_missing_class_present_in_data(self):
-        mean_average_precision = COCOMeanAveragePrecision(
+        y_true = tf.constant([[
+            [0, 0, 100, 100, 1],
+        ]], dtype=tf.float64)
+        y_pred = tf.constant([[[0, 50, 100, 150, 1, 1.0]]], dtype=tf.float32)
+
+        y_true = bounding_box.pad_batch_to_shape(y_true, (1, 20, 5))
+        metric = COCOMeanAveragePrecision(
             bounding_box_format="xyxy",
-            iou_thresholds=[0.33],
-            class_ids=[1000, 1, 2],
-            max_detections=100,
-            num_buckets=3,
-            recall_thresholds=[0.3, 0.5],
+            iou_thresholds=[0.15],
+            class_ids=[1000, 1],
+            max_detections=1,
         )
-
-        # Result should be the same as above.
-        ground_truths = tf.constant(ground_truths, tf.int32)
-        true_positives = tf.constant(true_positives, tf.int32)
-        false_positives = tf.constant(false_positives, tf.int32)
-
-        mean_average_precision.ground_truths.assign(ground_truths)
-        mean_average_precision.true_positive_buckets.assign(true_positives)
-        mean_average_precision.false_positive_buckets.assign(false_positives)
-
-        self.assertEqual(mean_average_precision.result(), 0.625)
+        metric.update_state(y_true, y_pred)
+        self.assertEqual(metric.ground_truths, [0, 1])
+        metric.update_state(y_true, y_pred)
+        self.assertEqual(metric.ground_truths, [0, 2])
 
     def test_bounding_box_counting(self):
         y_true = tf.constant([[[0, 0, 100, 100, 1]]], dtype=tf.float64)

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -197,9 +197,14 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
         self.assertEqual(mean_average_precision.result(), 0.625)
 
     def test_counting_with_missing_class_present_in_data(self):
-        y_true = tf.constant([[
-            [0, 0, 100, 100, 1],
-        ]], dtype=tf.float64)
+        y_true = tf.constant(
+            [
+                [
+                    [0, 0, 100, 100, 1],
+                ]
+            ],
+            dtype=tf.float64,
+        )
         y_pred = tf.constant([[[0, 50, 100, 150, 1, 1.0]]], dtype=tf.float32)
 
         y_true = bounding_box.pad_batch_to_shape(y_true, (1, 20, 5))

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -196,6 +196,27 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
 
         self.assertEqual(mean_average_precision.result(), 0.625)
 
+    def test_counting_with_missing_class_present_in_data(self):
+        mean_average_precision = COCOMeanAveragePrecision(
+            bounding_box_format="xyxy",
+            iou_thresholds=[0.33],
+            class_ids=[1000, 1, 2],
+            max_detections=100,
+            num_buckets=3,
+            recall_thresholds=[0.3, 0.5],
+        )
+
+        # Result should be the same as above.
+        ground_truths = tf.constant(ground_truths, tf.int32)
+        true_positives = tf.constant(true_positives, tf.int32)
+        false_positives = tf.constant(false_positives, tf.int32)
+
+        mean_average_precision.ground_truths.assign(ground_truths)
+        mean_average_precision.true_positive_buckets.assign(true_positives)
+        mean_average_precision.false_positive_buckets.assign(false_positives)
+
+        self.assertEqual(mean_average_precision.result(), 0.625)
+
     def test_bounding_box_counting(self):
         y_true = tf.constant([[[0, 0, 100, 100, 1]]], dtype=tf.float64)
         y_pred = tf.constant([[[0, 50, 100, 150, 1, 1.0]]], dtype=tf.float32)

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -200,12 +200,15 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
         y_true = tf.constant(
             [
                 [
+                    [0, 0, 100, 100, 15],
                     [0, 0, 100, 100, 1],
                 ]
             ],
             dtype=tf.float64,
         )
-        y_pred = tf.constant([[[0, 50, 100, 150, 1, 1.0]]], dtype=tf.float32)
+        y_pred = tf.constant(
+            [[[0, 50, 100, 150, 1, 1.0], [0, 50, 100, 150, 33, 1.0]]], dtype=tf.float32
+        )
 
         y_true = bounding_box.pad_batch_to_shape(y_true, (1, 20, 5))
         metric = COCOMeanAveragePrecision(
@@ -215,9 +218,9 @@ class COCOMeanAveragePrecisionTest(tf.test.TestCase):
             max_detections=1,
         )
         metric.update_state(y_true, y_pred)
-        self.assertEqual(metric.ground_truths, [0, 1])
+        self.assertAllEqual(metric.ground_truths, [0, 1])
         metric.update_state(y_true, y_pred)
-        self.assertEqual(metric.ground_truths, [0, 2])
+        self.assertAllEqual(metric.ground_truths, [0, 2])
 
     def test_bounding_box_counting(self):
         y_true = tf.constant([[[0, 0, 100, 100, 1]]], dtype=tf.float64)

--- a/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
@@ -110,7 +110,6 @@ class MeanAveragePrecisionTest(tf.test.TestCase):
         result = mean_average_precision.result().numpy()
         self.assertAlmostEqual(result, 0.610, delta=delta)
 
-
     def test_mean_average_precision_correctness_small(self):
         y_true, y_pred, categories = load_samples(SAMPLE_FILE)
 
@@ -124,7 +123,6 @@ class MeanAveragePrecisionTest(tf.test.TestCase):
         mean_average_precision.update_state(y_true, y_pred)
         result = mean_average_precision.result().numpy()
         self.assertAlmostEqual(result, 0.604, delta=delta)
-
 
 
 def load_samples(fname):

--- a/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
@@ -21,7 +21,7 @@ from keras_cv.metrics.coco import COCOMeanAveragePrecision
 
 SAMPLE_FILE = os.path.dirname(os.path.abspath(__file__)) + "/sample_boxes.npz"
 
-delta = 0.035
+delta = 0.04
 
 
 class MeanAveragePrecisionTest(tf.test.TestCase):

--- a/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/numerical_tests/mean_average_precision_test.py
@@ -21,7 +21,7 @@ from keras_cv.metrics.coco import COCOMeanAveragePrecision
 
 SAMPLE_FILE = os.path.dirname(os.path.abspath(__file__)) + "/sample_boxes.npz"
 
-delta = 0.05
+delta = 0.035
 
 
 class MeanAveragePrecisionTest(tf.test.TestCase):
@@ -110,20 +110,21 @@ class MeanAveragePrecisionTest(tf.test.TestCase):
         result = mean_average_precision.result().numpy()
         self.assertAlmostEqual(result, 0.610, delta=delta)
 
-    # TODO(lukewood): re-enable after performance testing
-    # def test_mean_average_precision_correctness_small(self):
-    #     y_true, y_pred, categories = load_samples(SAMPLE_FILE)
-    #
-    #     mean_average_precision = COCOMeanAveragePrecision(
-    #         class_ids=categories + [1000],
-    #         max_detections=100,
-    #         area_range=(0, 32**2),
-    #     )
-    #
-    #     mean_average_precision.update_state(y_true, y_pred)
-    #     result = mean_average_precision.result().numpy()
-    #     self.assertAlmostEqual(result, 0.604, delta=delta)
-    #
+
+    def test_mean_average_precision_correctness_small(self):
+        y_true, y_pred, categories = load_samples(SAMPLE_FILE)
+
+        mean_average_precision = COCOMeanAveragePrecision(
+            bounding_box_format="xyxy",
+            class_ids=categories + [1000],
+            max_detections=100,
+            area_range=(0, 32**2),
+        )
+
+        mean_average_precision.update_state(y_true, y_pred)
+        result = mean_average_precision.result().numpy()
+        self.assertAlmostEqual(result, 0.604, delta=delta)
+
 
 
 def load_samples(fname):

--- a/keras_cv/metrics/coco/recall.py
+++ b/keras_cv/metrics/coco/recall.py
@@ -98,6 +98,11 @@ class COCORecall(keras.metrics.Metric):
         num_thresholds = len(iou_thresholds)
         num_categories = len(class_ids)
 
+        if any([c < 0 for c in class_ids]):
+            raise ValueError(
+                "class_ids must be positive.  Got " f"class_ids={class_ids}"
+            )
+
         self.true_positives = self.add_weight(
             name="true_positives",
             shape=(num_thresholds, num_categories),

--- a/keras_cv/metrics/coco/recall.py
+++ b/keras_cv/metrics/coco/recall.py
@@ -82,7 +82,7 @@ class COCORecall(keras.metrics.Metric):
         iou_thresholds=None,
         area_range=None,
         max_detections=100,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
         # Initialize parameter values

--- a/keras_cv/metrics/coco/recall.py
+++ b/keras_cv/metrics/coco/recall.py
@@ -156,6 +156,8 @@ class COCORecall(keras.metrics.Metric):
             dtype=self.compute_dtype,
         )
 
+        y_pred = utils.sort_bounding_boxes(y_pred, axis=bounding_box.XYXY.CONFIDENCE)
+
         num_images = tf.shape(y_true)[0]
 
         iou_thresholds = tf.constant(self.iou_thresholds, dtype=tf.float32)
@@ -164,7 +166,6 @@ class COCORecall(keras.metrics.Metric):
         num_thresholds = tf.shape(iou_thresholds)[0]
         num_categories = tf.shape(class_ids)[0]
 
-        # Sort by bounding_box.CONFIDENCE to make maxDetections easy to compute.
         true_positives_update = tf.zeros_like(self.true_positives)
         ground_truth_boxes_update = tf.zeros_like(self.ground_truth_boxes)
 

--- a/keras_cv/metrics/coco/recall_test.py
+++ b/keras_cv/metrics/coco/recall_test.py
@@ -73,6 +73,7 @@ class COCORecallTest(tf.test.TestCase):
     def test_merge_state(self):
         y_true = tf.constant([[[0, 0, 100, 100, 1]]], dtype=tf.float32)
         y_pred = tf.constant([[[0, 50, 100, 150, 1, 1.0]]], dtype=tf.float32)
+        y_pred_match = tf.constant([[[0, 0, 100, 100, 1, 1.0]]], dtype=tf.float32)
 
         m1 = COCORecall(
             bounding_box_format="xyxy",
@@ -90,7 +91,8 @@ class COCORecallTest(tf.test.TestCase):
         )
 
         m1.update_state(y_true, y_pred)
-        m1.update_state(y_true, y_pred)
+        m1.update_state(y_true, y_pred_match)
+
         m2.update_state(y_true, y_pred)
 
         metric_result = COCORecall(

--- a/keras_cv/metrics/coco/recall_test.py
+++ b/keras_cv/metrics/coco/recall_test.py
@@ -90,7 +90,7 @@ class COCORecallTest(tf.test.TestCase):
         )
 
         m1.update_state(y_true, y_pred)
-        m1.update_state(y_true, y_true)
+        m1.update_state(y_true, y_pred)
         m2.update_state(y_true, y_pred)
 
         metric_result = COCORecall(


### PR DESCRIPTION
Noticed this bug during numerical testing, now I have sufficient test coverage of this and have fixed the issue.

In short:
```
ground_truths = utils.filter_boxes(...)
```

was overwriting every single other class if a single one was missing.  Now this is fixed