### PR TITLE
Adding Feature Pyramid Network

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -26,7 +26,7 @@ from tensorflow.keras.layers import RandomZoom
 from tensorflow.keras.layers import Rescaling
 from tensorflow.keras.layers import Resizing
 
-from keras_cv.layers.fpn.FeaturePyramid import FeaturePyramid
+from keras_cv.layers.fpn.feature_pyramid import FeaturePyramid
 from keras_cv.layers.preprocessing.aug_mix import AugMix
 from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -26,6 +26,7 @@ from tensorflow.keras.layers import RandomZoom
 from tensorflow.keras.layers import Rescaling
 from tensorflow.keras.layers import Resizing
 
+from keras_cv.layers.fpn.FeaturePyramid import FeaturePyramid
 from keras_cv.layers.preprocessing.aug_mix import AugMix
 from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle

--- a/keras_cv/layers/fpn/FeaturePyramid.py
+++ b/keras_cv/layers/fpn/FeaturePyramid.py
@@ -25,7 +25,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
 
     There is an output associated with each input in the basic FPN. The output Pi
     at level `i` (corresponding to Ci) is given by performing a merge operation on
-    the outputs after:
+    the outputs of:
     1) a top down operation on Pj (where j = i - 1)
     2) a lateral operation on Ci
 
@@ -50,7 +50,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             match the corresponding level from pyramid_levels list. The top-most layer
             is not merged and the corresponding operation is therefore not included.
             Passing None will populate the list with the default FPN operation
-            (a 1X1 Conv2D layer). Defaults to None.
+            (an add operation). Defaults to None.
 
     References:
         [FPN paper](https://arxiv.org/pdf/1612.03144)

--- a/keras_cv/layers/fpn/FeaturePyramid.py
+++ b/keras_cv/layers/fpn/FeaturePyramid.py
@@ -1,0 +1,134 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+
+class FeaturePyramid(tf.keras.layers.Layer):
+    """Implements a Feature Pyramid Network.
+
+    Feature Pyramid Networks (FPNs) are basic components that are added to an
+    existing CNN to extract features at different scales. For the basic FPN, the
+    inputs are features `Ci` from different levels of a CNN, where the feature is
+    scaled from the image size by `1/2^i` for any level `i`.
+
+    There is an output associated with each input in the basic FPN. The output Pi
+    at level `i` (corresponding to Ci) is given by performing a merge operation on
+    the outputs after:
+    1) a top down operation on Pj (where j = i - 1)
+    2) a lateral operation on Ci
+
+    Args:
+        pyramid_levels: a python list that specifies all the values of level `i`
+            for which the feature Ci will be specified. The size of this list is
+            num_pyramid_levels.
+        num_channels: an integer representing the number of channels for the FPN
+            operations. Defaults to 256.
+        lateral_ops: a python list of size num_pyramid_levels that specifies all the
+            lateral operations performed by the FPN. Each operation from the list must
+            match the corresponding level from pyramid_levels list. Passing None will
+            populate the list with the default FPN operation (a 1X1 Conv2D layer).
+            Defaults to None.
+        top_down_ops: a python list of size num_pyramid_levels that specifies all the
+            top down operations performed by the FPN. Each operation from the list must
+            match the corresponding level from pyramid_levels list. Passing None will
+            populate the list with the default FPN operation (an UpSampling2D layer).
+            Defaults to None.
+        merge_ops: a python list of size (num_pyramid_levels - 1) that specifies all
+            the merge operations performed by the FPN. Each operation from the list must
+            match the corresponding level from pyramid_levels list. The top-most layer
+            is not merged and the corresponding operation is therefore not included.
+            Passing None will populate the list with the default FPN operation
+            (a 1X1 Conv2D layer). Defaults to None.
+
+    References:
+        [FPN paper](https://arxiv.org/pdf/1612.03144)
+
+    Sample Usage:
+    ```python
+    inp = tf.keras.layers.Input((384, 384, 3))
+    efnb0 = tf.keras.applications.EfficientNetB0(input_tensor=inp, include_top = False)
+
+    layer_names = ['block2b_add', 'block3b_add', 'block5c_add', 'top_activation']
+    backbone_outputs = [efnb0.get_layer(name).output for name in layer_names]
+
+    features = FeaturePyramid([2,3,4,5])(backbone_outputs)
+    P2, P3, P4, P5 = features.values()
+    ```
+    """
+
+    def __init__(
+        self,
+        pyramid_levels,
+        num_channels=256,
+        lateral_ops=None,
+        top_down_ops=None,
+        merge_ops=None,
+        **kwargs,
+    ):
+        super(FeaturePyramid, self).__init__(name="FPN", **kwargs)
+        self.pyramid_levels = sorted(pyramid_levels)
+        self.num_pyramid_levels = len(self.pyramid_levels)
+        self.num_channels = num_channels
+
+        if not lateral_ops:
+            # populate self.lateral_ops with default FPN Conv2D 1X1 layers
+            self.lateral_ops = []
+            for i in pyramid_levels:
+                self.lateral_ops.append(
+                    tf.keras.layers.Conv2D(
+                        self.num_channels,
+                        kernel_size=1,
+                        strides=1,
+                        padding="same",
+                        name=f"lateral_P{i}",
+                    )
+                )
+        else:
+            self.lateral_ops = lateral_ops
+
+        # the same upsampling layer is used for all levels
+        self.top_down_ops = (
+            [tf.keras.layers.UpSampling2D(size=2)] * self.num_pyramid_levels
+            if not top_down_ops
+            else top_down_ops
+        )
+        # same merge_ops for all layers as well
+        self.merge_ops = (
+            [tf.keras.layers.Add()] * (self.num_pyramid_levels - 1)
+            if not merge_ops
+            else merge_ops
+        )
+
+    def _create_pyramid(self, features):
+        # process first scale outside loop because no merge op required
+        output_features = {}
+        P_i = self.lateral_ops[-1](features[-1])
+        P_top_down_i = self.top_down_ops[-1](P_i)
+
+        # store the output in a dictionary
+        output_features[f"P{self.pyramid_levels[-1]}"] = P_i
+
+        # loop across all scales and perform FPN ops
+        for i in range(self.num_pyramid_levels - 2, -1, -1):
+            P_i = self.lateral_ops[i](features[i])
+            P_i = self.merge_ops[i - 1]([P_i, P_top_down_i])
+            P_top_down_i = self.top_down_ops[i](P_i)
+
+            output_features[f"P{self.pyramid_levels[i]}"] = P_i
+
+        return output_features
+
+    def call(self, features):
+        return self._create_pyramid(features)

--- a/keras_cv/layers/fpn/__init__.py
+++ b/keras_cv/layers/fpn/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_cv.layers.fpn.FeaturePyramid import FeaturePyramid

--- a/keras_cv/layers/fpn/__init__.py
+++ b/keras_cv/layers/fpn/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_cv.layers.fpn.FeaturePyramid import FeaturePyramid
+from keras_cv.layers.fpn.feature_pyramid import FeaturePyramid

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -14,7 +14,7 @@
 
 import tensorflow as tf
 
-
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
 class FeaturePyramid(tf.keras.layers.Layer):
     """Implements a Feature Pyramid Network.
 
@@ -81,7 +81,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
         merge_ops=None,
         **kwargs,
     ):
-        super(FeaturePyramid, self).__init__(name="FPN", **kwargs)
+        super(FeaturePyramid, self).__init__(**kwargs)
         self.pyramid_levels = sorted(pyramid_levels)
         self.num_pyramid_levels = len(self.pyramid_levels)
         self.num_channels = num_channels

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -28,7 +28,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
     the outputs of:
     1) a top down operation on Pj (where j = i - 1)
     2) a lateral operation on Ci
-    
+
     The layer must be called with the feature Ci in increasing order of `i`. As an
     example, for `pyramid_levels`=[2,3,4,5], the layer should be called with the
     list [C2,C3,C4,C5] as input
@@ -108,7 +108,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             if not top_down_ops
             else top_down_ops
         )
-        # the same merge layer is used for all levels 
+        # the same merge layer is used for all levels
         self.merge_ops = (
             [tf.keras.layers.Add()] * (self.num_pyramid_levels - 1)
             if not merge_ops
@@ -129,7 +129,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             P_i = self.lateral_ops[i](features[i])
             P_i = self.merge_ops[i - 1]([P_i, P_top_down_i])
             P_top_down_i = self.top_down_ops[i](P_i)
-            
+
             # store the outputs in a dictionary
             output_features[f"P{self.pyramid_levels[i]}"] = P_i
 
@@ -147,5 +147,4 @@ class FeaturePyramid(tf.keras.layers.Layer):
             "merge_ops": self.merge_ops,
         }
         base_config = super().get_config()
-        return dict(list(base_config.items()) + list(config.items()))    
-    
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -28,7 +28,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
     the outputs of:
     1) a top down operation on Pj (where j = i - 1)
     2) a lateral operation on Ci
-    
+
     The layer must be called with the feature Ci in increasing order of `i`. As an
     example, for `pyramid_levels`=[2,3,4,5], the layer should be called with the
     list [C2,C3,C4,C5] as input
@@ -108,7 +108,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             if not top_down_ops
             else top_down_ops
         )
-        # the same merge layer is used for all levels 
+        # the same merge layer is used for all levels
         self.merge_ops = (
             [tf.keras.layers.Add()] * (self.num_pyramid_levels - 1)
             if not merge_ops
@@ -129,7 +129,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             P_i = self.lateral_ops[i](features[i])
             P_i = self.merge_ops[i - 1]([P_i, P_top_down_i])
             P_top_down_i = self.top_down_ops[i](P_i)
-            
+
             # store the outputs in a dictionary
             output_features[f"P{self.pyramid_levels[i]}"] = P_i
 

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -108,7 +108,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             if not top_down_ops
             else top_down_ops
         )
-        # same merge_ops for all layers 
+        # the same merge layer is used for all levels 
         self.merge_ops = (
             [tf.keras.layers.Add()] * (self.num_pyramid_levels - 1)
             if not merge_ops

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -14,6 +14,7 @@
 
 import tensorflow as tf
 
+
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
 class FeaturePyramid(tf.keras.layers.Layer):
     """Implements a Feature Pyramid Network.

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -87,6 +87,11 @@ class FeaturePyramid(tf.keras.layers.Layer):
         self.num_pyramid_levels = len(self.pyramid_levels)
         self.num_channels = num_channels
 
+        # required for successful serialization
+        self.lateral_ops_passed = lateral_ops
+        self.top_down_ops_passed = lateral_ops
+        self.merge_ops_passed = lateral_ops
+
         if not lateral_ops:
             # populate self.lateral_ops with default FPN Conv2D 1X1 layers
             self.lateral_ops = []
@@ -143,9 +148,9 @@ class FeaturePyramid(tf.keras.layers.Layer):
         config = {
             "pyramid_levels": self.pyramid_levels,
             "num_channels": self.num_channels,
-            "lateral_ops": self.lateral_ops,
-            "top_down_ops": self.top_down_ops,
-            "merge_ops": self.merge_ops,
+            "lateral_ops": self.lateral_ops_passed,
+            "top_down_ops": self.top_down_ops_passed,
+            "merge_ops": self.merge_ops_passed,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/fpn/feature_pyramid.py
+++ b/keras_cv/layers/fpn/feature_pyramid.py
@@ -28,7 +28,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
     the outputs of:
     1) a top down operation on Pj (where j = i - 1)
     2) a lateral operation on Ci
-
+    
     The layer must be called with the feature Ci in increasing order of `i`. As an
     example, for `pyramid_levels`=[2,3,4,5], the layer should be called with the
     list [C2,C3,C4,C5] as input
@@ -108,7 +108,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             if not top_down_ops
             else top_down_ops
         )
-        # the same merge layer is used for all levels
+        # the same merge layer is used for all levels 
         self.merge_ops = (
             [tf.keras.layers.Add()] * (self.num_pyramid_levels - 1)
             if not merge_ops
@@ -129,7 +129,7 @@ class FeaturePyramid(tf.keras.layers.Layer):
             P_i = self.lateral_ops[i](features[i])
             P_i = self.merge_ops[i - 1]([P_i, P_top_down_i])
             P_top_down_i = self.top_down_ops[i](P_i)
-
+            
             # store the outputs in a dictionary
             output_features[f"P{self.pyramid_levels[i]}"] = P_i
 
@@ -147,4 +147,5 @@ class FeaturePyramid(tf.keras.layers.Layer):
             "merge_ops": self.merge_ops,
         }
         base_config = super().get_config()
-        return dict(list(base_config.items()) + list(config.items()))
+        return dict(list(base_config.items()) + list(config.items()))    
+    

--- a/keras_cv/layers/fpn/feature_pyramid_test.py
+++ b/keras_cv/layers/fpn/feature_pyramid_test.py
@@ -1,0 +1,95 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers import FeaturePyramid
+
+
+class FeaturePyramidTest(tf.test.TestCase):
+    def test_return_type(self):
+        layer = FeaturePyramid(pyramid_levels=[2, 3, 4, 5])
+        C2 = tf.keras.layers.Input([64, 64, 3])
+        C3 = tf.keras.layers.Input([32, 32, 3])
+        C4 = tf.keras.layers.Input([16, 16, 3])
+        C5 = tf.keras.layers.Input([8, 8, 3])
+
+        xs = layer([C2, C3, C4, C5])
+        self.assertTrue(isinstance(xs, dict))
+
+    def test_return_shape(self):
+        layer = FeaturePyramid(pyramid_levels=[2, 3, 4, 5])
+        C2 = tf.ones((2, 64, 64, 3))
+        C3 = tf.ones((2, 32, 32, 3))
+        C4 = tf.ones((2, 16, 16, 3))
+        C5 = tf.ones((2, 8, 8, 3))
+
+        xs = layer([C2, C3, C4, C5])
+
+        self.assertEqual(xs["P2"].shape, (2, 64, 64, 256))
+        self.assertEqual(xs["P3"].shape, (2, 32, 32, 256))
+        self.assertEqual(xs["P4"].shape, (2, 16, 16, 256))
+        self.assertEqual(xs["P5"].shape, (2, 8, 8, 256))
+
+    def test_non_square_images(self):
+        layer = FeaturePyramid(pyramid_levels=[2, 3, 4, 5])
+        C2 = tf.ones((2, 64, 128, 3))
+        C3 = tf.ones((2, 32, 64, 3))
+        C4 = tf.ones((2, 16, 32, 3))
+        C5 = tf.ones((2, 8, 16, 3))
+
+        xs = layer([C2, C3, C4, C5])
+
+        self.assertEqual(xs["P2"].shape, (2, 64, 128, 256))
+        self.assertEqual(xs["P3"].shape, (2, 32, 64, 256))
+        self.assertEqual(xs["P4"].shape, (2, 16, 32, 256))
+        self.assertEqual(xs["P5"].shape, (2, 8, 16, 256))
+
+    def test_different_channels(self):
+        layer = FeaturePyramid(pyramid_levels=[2, 3, 4, 5])
+
+        C2 = tf.ones((2, 64, 64, 256))
+        C3 = tf.ones((2, 32, 32, 512))
+        C4 = tf.ones((2, 16, 16, 1024))
+        C5 = tf.ones((2, 8, 8, 2048))
+
+        xs = layer([C2, C3, C4, C5])
+
+        self.assertEqual(xs["P2"].shape, (2, 64, 64, 256))
+        self.assertEqual(xs["P3"].shape, (2, 32, 32, 256))
+        self.assertEqual(xs["P4"].shape, (2, 16, 16, 256))
+        self.assertEqual(xs["P5"].shape, (2, 8, 8, 256))
+
+    def test_in_a_model(self):
+        layer = FeaturePyramid(pyramid_levels=[2, 3, 4, 5])
+
+        C2 = tf.keras.layers.Input([64, 64, 3])
+        C3 = tf.keras.layers.Input([32, 32, 3])
+        C4 = tf.keras.layers.Input([16, 16, 3])
+        C5 = tf.keras.layers.Input([8, 8, 3])
+        xs = layer([C2, C3, C4, C5])
+
+        model = tf.keras.models.Model(inputs=[C2, C3, C4, C5], outputs=xs)
+
+        C2 = tf.ones((2, 64, 64, 3))
+        C3 = tf.ones((2, 32, 32, 3))
+        C4 = tf.ones((2, 16, 16, 3))
+        C5 = tf.ones((2, 8, 8, 3))
+
+        xs = model([C2, C3, C4, C5])
+
+        self.assertEqual(xs["P2"].shape, (2, 64, 64, 256))
+        self.assertEqual(xs["P3"].shape, (2, 32, 32, 256))
+        self.assertEqual(xs["P4"].shape, (2, 16, 16, 256))
+        self.assertEqual(xs["P5"].shape, (2, 8, 8, 256))

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -15,7 +15,6 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv import core
-from keras_cv.layers import fpn
 from keras_cv.layers import preprocessing
 from keras_cv.layers import regularization
 
@@ -147,17 +146,6 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
                 "chain_depth": -1,
                 "alpha": 1.0,
                 "seed": 1,
-            },
-        ),
-        (
-            "FeaturePyramid",
-            fpn.FeaturePyramid,
-            {
-                "pyramid_levels": [2, 3, 4, 5],
-                "num_channels": 256,
-                "lateral_ops": None,
-                "top_down_ops": None,
-                "merge_ops": None,
             },
         ),
     )

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -17,6 +17,7 @@ from absl.testing import parameterized
 from keras_cv import core
 from keras_cv.layers import preprocessing
 from keras_cv.layers import regularization
+from keras_cv.layers import fpn
 
 
 def custom_compare(obj1, obj2):
@@ -146,6 +147,17 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
                 "chain_depth": -1,
                 "alpha": 1.0,
                 "seed": 1,
+            },
+        ),
+        (
+            "FeaturePyramid",
+            fpn.FeaturePyramid,
+            {
+                "pyramid_levels": [2, 3, 4, 5],
+                "num_channels": 256,
+                "lateral_ops": None,
+                "top_down_ops": None,
+                "merge_ops": None,
             },
         ),
     )

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -15,9 +15,9 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv import core
+from keras_cv.layers import fpn
 from keras_cv.layers import preprocessing
 from keras_cv.layers import regularization
-from keras_cv.layers import fpn
 
 
 def custom_compare(obj1, obj2):

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -15,6 +15,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv import core
+from keras_cv.layers import fpn
 from keras_cv.layers import preprocessing
 from keras_cv.layers import regularization
 
@@ -146,6 +147,17 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
                 "chain_depth": -1,
                 "alpha": 1.0,
                 "seed": 1,
+            },
+        ),
+        (
+            "FeaturePyramid",
+            fpn.FeaturePyramid,
+            {
+                "pyramid_levels": [2, 3, 4, 5],
+                "num_channels": 256,
+                "lateral_ops": None,
+                "top_down_ops": None,
+                "merge_ops": None,
             },
         ),
     )


### PR DESCRIPTION
The first version of the FPN layer. This layer aims only to create the FPN structure. Whether this should be exposed to users is still not definite. This layer can be used to implement other commonly used layers that require an FPN structure like RetinaNet FPNs, PAFPNs, BiFPNs, etc. 