### PR TITLE
Add an augment_label method to the RandomGaussianBlur augmentation layer

### DIFF
--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -83,6 +83,9 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
 
         return tf.squeeze(blurred, axis=0)
 
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
     @staticmethod
     def get_kernel(factor, filter_size):
         x = tf.cast(

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -61,6 +61,9 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
         jpeg_quality = transformation
         return tf.image.adjust_jpeg_quality(image, jpeg_quality)
 
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
     def get_config(self):
         config = super().get_config()
         config.update({"factor": self.factor})

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -58,7 +58,13 @@ TEST_CONFIGURATIONS = [
             "seed": 1,
         },
     ),
-    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
+    (
+        "RandomGaussianBlur",
+        preprocessing.RandomGaussianBlur,
+        {"kernel_size": 3, "factor": (0.0, 3.0)},
+    )("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)})(
+        "RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}
+    ),
     (
         "RandomSharpness",
         preprocessing.RandomSharpness,

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -62,9 +62,9 @@ TEST_CONFIGURATIONS = [
         "RandomGaussianBlur",
         preprocessing.RandomGaussianBlur,
         {"kernel_size": 3, "factor": (0.0, 3.0)},
-    )("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)})(
-        "RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}
     ),
+    ("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)}),
+    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
     (
         "RandomSharpness",
         preprocessing.RandomSharpness,


### PR DESCRIPTION
# What does this PR do?

Makes RandomGaussianBlur and RandomJpeg override the augment_label method. Without overriding this method, I found that these layers were throwing a NotImplementedError when applied to a tensor that included labels.

Fixes #538 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

@LukeWood 
