### PR TITLE
Fixed error message when requirement does not meet for minimum TF version

### DIFF
--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv import version_check
+
+
+version_check.check_tf_version()
+
+
 from keras_cv import layers
 from keras_cv import metrics
 from keras_cv import models
 from keras_cv import utils
-from keras_cv import version_check
 from keras_cv.core import ConstantFactorSampler
 from keras_cv.core import FactorSampler
 from keras_cv.core import NormalFactorSampler
 from keras_cv.core import UniformFactorSampler
 
-version_check.check_tf_version()
 
 __version__ = "0.2.8"

--- a/keras_cv/version_check.py
+++ b/keras_cv/version_check.py
@@ -15,8 +15,6 @@
 """KerasCV Version check."""
 
 
-import warnings
-
 import tensorflow as tf
 from packaging.version import parse
 
@@ -24,13 +22,10 @@ MIN_VERSION = "2.9.0"
 
 
 def check_tf_version():
-    if parse(tf.__version__) < parse(MIN_VERSION):
-        warnings.warn(
-            f"The Tensorflow package version needs to be at least {MIN_VERSION} \n"
-            "for KerasCV to run. Currently, your TensorFlow version is \n"
-            f"{tf.__version__}. Please upgrade with \n"
-            "`$ pip install --upgrade tensorflow`. \n"
-            "You can use `pip freeze` to check afterwards that everything is "
-            "ok.",
-            ImportWarning,
+    if parse(tf.__version__) <= parse(MIN_VERSION):
+        raise RuntimeError(
+            f"The Tensorflow package version needs to be at least {MIN_VERSION} "
+            "for KerasCV to run. Currently, your TensorFlow version is "
+            f"{tf.__version__}. Please upgrade with `$ pip install --upgrade tensorflow`. "
+            "You can use `pip freeze` to check afterwards that everything is ok."
         )

--- a/keras_cv/version_check_test.py
+++ b/keras_cv/version_check_test.py
@@ -20,18 +20,15 @@ from keras_cv import version_check
 def test_check_tf_version_error():
     version_check.tf.__version__ = "2.8.0"
 
-    with pytest.warns(ImportWarning) as record:
+    with pytest.raises(
+        RuntimeError, match="Tensorflow package version needs to be at least 2.9.0"
+    ):
         version_check.check_tf_version()
-    assert len(record) == 1
-    assert (
-        "Tensorflow package version needs to be at least 2.9.0"
-        in record[0].message.args[0]
-    )
 
 
 def test_check_tf_version_passes_rc2():
     # should pass
-    version_check.tf.__version__ = "2.9.0rc2"
+    version_check.tf.__version__ = "2.9.1rc2"
     version_check.check_tf_version()
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,9 @@ filterwarnings =
 [flake8]
 max-line-length = 88
 max-doc-length = 200
-per-file-ignores = **/__init__.py:F401
-
+per-file-ignores =
+    ./keras_cv/__init__.py:E402, F401
+    **/__init__.py:F401
 ignore =
     # Conflicts with black
     E203
@@ -40,3 +41,4 @@ force_single_line = True
 known_first_party = keras_cv,tests
 default_section = THIRDPARTY
 line_length = 88
+skip = keras_cv/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     author_email="keras-cv@google.com",
     license="Apache License 2.0",
     install_requires=["packaging", "absl-py"],
+    python_requires=">=3.7",
     extras_require={
         "tests": ["flake8", "isort", "black", "pytest"],
         "examples": ["tensorflow_datasets", "matplotlib"],


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #460, #442.
This checks the TF version before importing any internal modules of Keras-CV. The previous warning is now replaced with a `RunttimeError` error since TF <=2.9.0 does not have modules required for the latest Keras-CV functioning, hence warning were deemed unusable.

This also replaces the test for `version_check` from a warning to error checking and adds skipping rules for `keras_cv/__init__.py` to skip `flake8` and `isort` warning. 

Check a demo [here](https://colab.research.google.com/drive/1LxZrmufCohfAsgBTDuiBL5cPVre2a4-x?usp=sharing)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
