### PR TITLE
Changed BaseImageAugmentationLayer to preserve additional unmodified …

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -258,8 +258,11 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
                 image=image,
             )
             result[BOUNDING_BOXES] = bounding_boxes
-        inputs.update(result)  # preserve unmodified, additional entries.
-        return inputs
+
+        # preserve any additional inputs unmodified by this layer.
+        for key in (inputs.keys() - result.keys()):
+            result[key] = inputs[key]
+        return result
 
     def _batch_augment(self, inputs):
         return self._map_fn(self._augment, inputs)

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -260,7 +260,7 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
             result[BOUNDING_BOXES] = bounding_boxes
 
         # preserve any additional inputs unmodified by this layer.
-        for key in (inputs.keys() - result.keys()):
+        for key in inputs.keys() - result.keys():
             result[key] = inputs[key]
         return result
 

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -258,7 +258,8 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
                 image=image,
             )
             result[BOUNDING_BOXES] = bounding_boxes
-        return result
+        inputs.update(result)  # preserve unmodified, additional entries.
+        return inputs
 
     def _batch_augment(self, inputs):
         return self._map_fn(self._augment, inputs)

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -110,3 +110,16 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         # Make sure the first image and second image get different augmentation
         self.assertNotAllClose(image_diff[0], image_diff[1])
         self.assertNotAllClose(label_diff[0], label_diff[1])
+
+    def test_augment_leaves_extra_dict_entries_unmodified(self):
+        add_layer = RandomAddLayer(fixed_value=0.5)
+        images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
+        filenames = tf.constant(["/path/to/first.jpg", "/path/to/second.jpg"])
+        inputs = {"images": images, "filenames": filenames}
+
+        outputs = add_layer(inputs)
+
+        self.assertListEqual(list(inputs.keys()), list(outputs.keys()))
+        self.assertAllEqual(inputs["filenames"], outputs["filenames"])
+        self.assertNotAllClose(inputs["images"], outputs["images"])
+        self.assertAllEqual(inputs["images"], images)  # Assert original unchanged

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -113,6 +113,19 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
 
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = RandomAddLayer(fixed_value=0.5)
+        images = np.random.random(size=(8, 8, 3)).astype("float32")
+        filenames = tf.constant("/path/to/first.jpg")
+        inputs = {"images": images, "filenames": filenames}
+
+        outputs = add_layer(inputs)
+
+        self.assertListEqual(list(inputs.keys()), list(outputs.keys()))
+        self.assertAllEqual(inputs["filenames"], outputs["filenames"])
+        self.assertNotAllClose(inputs["images"], outputs["images"])
+        self.assertAllEqual(inputs["images"], images)  # Assert original unchanged
+
+    def test_augment_leaves_batched_extra_dict_entries_unmodified(self):
+        add_layer = RandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         filenames = tf.constant(["/path/to/first.jpg", "/path/to/second.jpg"])
         inputs = {"images": images, "filenames": filenames}


### PR DESCRIPTION
# What does this PR do?
Changes `BaseImageAugmentationLayer` to allow extra, unmodified inputs to pass through, **in case of dictionary input**.

Fixes #565 

**Motivation**
Currently, if we provide custom dictionary input to `BaseImageAugmentationLayer`, like `{"images": ..., "filenames": ...}`, any extra key that is not `"images" `. `"labels"` (or few other supported) is going to be removed from the dictionary.

In my example, applying the layer will modify `"images"`, but will also remove `"filenames"`. 
This is limiting - the option to have any keys/data in `tf.data.Dataset` and then take only what we need is what makes it so awesome. 

This PR changes `BaseImageAugmentationLayer` to only modifie the entries it cares about, while leaving all other entires unchanged.

I believe this increases the flexibility of the layer as it's more agnostic towards the inputs on which it operates. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?
@LukeWood @qlzh727 participated in the Github Issue.