### PR TITLE
Migrate VGG19 to keras_cv.models

### DIFF
--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -18,11 +18,13 @@ from absl.testing import parameterized
 from tensorflow.keras import backend
 
 from keras_cv.models import densenet
+from keras_cv.models import vgg19
 
 MODEL_LIST = [
     (densenet.DenseNet121, 1024),
     (densenet.DenseNet169, 1664),
     (densenet.DenseNet201, 1920),
+    (vgg19.VGG19, 512),
 ]
 
 

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -1,0 +1,178 @@
+# Copyright 2022 The KerasCV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""VGG19 model for KerasCV.
+
+Reference:
+  - [Very Deep Convolutional Networks for Large-Scale Image Recognition](
+      https://arxiv.org/abs/1409.1556) (ICLR 2015)
+"""
+
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+
+
+def VGG19(
+    include_rescaling,
+    include_top,
+    num_classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    pooling=None,
+    classifier_activation="softmax",
+    name=None,
+    **kwargs,
+):
+    """Instantiates the VGG19 architecture.
+
+    Reference:
+    - [Very Deep Convolutional Networks for Large-Scale Image Recognition](
+        https://arxiv.org/abs/1409.1556) (ICLR 2015)
+
+    This function returns a Keras VGG19 model.
+
+    The default input size for this model is 224x224.
+
+    Args:
+      include_rescaling: whether or not to Rescale the inputs.If set to True,
+        inputs will be passed through a `Rescaling(1/255.0)` layer.
+      include_top: whether to include the 3 fully-connected
+        layers at the top of the network. If provided, num_classes must be provided.
+      num_classes: optional number of classes to classify images into, only to be
+        specified if `include_top` is True, and if no `weights` argument is
+        specified.
+      weights: one of `None` (random initialization), or a pretrained weight file path.
+      input_shape: optional shape tuple, defaults to (None, None, 3).
+      pooling: Optional pooling mode for feature extraction
+        when `include_top` is `False`.
+        - `None` means that the output of the model will be
+            the 4D tensor output of the
+            last convolutional block.
+        - `avg` means that global average pooling
+            will be applied to the output of the
+            last convolutional block, and thus
+            the output of the model will be a 2D tensor.
+        - `max` means that global max pooling will
+            be applied.
+      classifier_activation: A `str` or callable. The activation function to use
+        on the "top" layer. Ignored unless `include_top=True`. Set
+        `classifier_activation=None` to return the logits of the "top" layer.
+        When loading pretrained weights, `classifier_activation` can only
+        be `None` or `"softmax"`.
+      name: (Optional) name to pass to the model.  Defaults to "VGG19".
+
+    Returns:
+      A `keras.Model` instance.
+    """
+    if weights and not tf.io.gfile.exists(weights):
+        raise ValueError(
+            "The `weights` argument should be either `None` or the path to the "
+            "weights file to be loaded. Weights file not found at location: {weights}"
+        )
+
+    if include_top and not num_classes:
+        raise ValueError(
+            "If `include_top` is True, you should specify `num_classes`. "
+            f"Received: num_classes={num_classes}"
+        )
+
+    inputs = layers.Input(shape=input_shape)
+
+    x = inputs
+    if include_rescaling:
+        x = layers.Rescaling(1 / 255.0)(x)
+
+    # Block 1
+    x = layers.Conv2D(
+        64, (3, 3), activation="relu", padding="same", name="block1_conv1"
+    )(x)
+    x = layers.Conv2D(
+        64, (3, 3), activation="relu", padding="same", name="block1_conv2"
+    )(x)
+    x = layers.MaxPooling2D((2, 2), strides=(2, 2), name="block1_pool")(x)
+
+    # Block 2
+    x = layers.Conv2D(
+        128, (3, 3), activation="relu", padding="same", name="block2_conv1"
+    )(x)
+    x = layers.Conv2D(
+        128, (3, 3), activation="relu", padding="same", name="block2_conv2"
+    )(x)
+    x = layers.MaxPooling2D((2, 2), strides=(2, 2), name="block2_pool")(x)
+
+    # Block 3
+    x = layers.Conv2D(
+        256, (3, 3), activation="relu", padding="same", name="block3_conv1"
+    )(x)
+    x = layers.Conv2D(
+        256, (3, 3), activation="relu", padding="same", name="block3_conv2"
+    )(x)
+    x = layers.Conv2D(
+        256, (3, 3), activation="relu", padding="same", name="block3_conv3"
+    )(x)
+    x = layers.Conv2D(
+        256, (3, 3), activation="relu", padding="same", name="block3_conv4"
+    )(x)
+    x = layers.MaxPooling2D((2, 2), strides=(2, 2), name="block3_pool")(x)
+
+    # Block 4
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block4_conv1"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block4_conv2"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block4_conv3"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block4_conv4"
+    )(x)
+    x = layers.MaxPooling2D((2, 2), strides=(2, 2), name="block4_pool")(x)
+
+    # Block 5
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block5_conv1"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block5_conv2"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block5_conv3"
+    )(x)
+    x = layers.Conv2D(
+        512, (3, 3), activation="relu", padding="same", name="block5_conv4"
+    )(x)
+    x = layers.MaxPooling2D((2, 2), strides=(2, 2), name="block5_pool")(x)
+
+    if include_top:
+        x = layers.Flatten(name="flatten")(x)
+        x = layers.Dense(4096, activation="relu", name="fc1")(x)
+        x = layers.Dense(4096, activation="relu", name="fc2")(x)
+        x = layers.Dense(
+            num_classes, activation=classifier_activation, name="predictions"
+        )(x)
+    else:
+        if pooling == "avg":
+            x = layers.GlobalAveragePooling2D()(x)
+        elif pooling == "max":
+            x = layers.GlobalMaxPooling2D()(x)
+
+    model = keras.Model(inputs, x, name="vgg19", **kwargs)
+
+    if weights is not None:
+        model.load_weights(weights)
+    return model

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -33,7 +33,7 @@ def VGG19(
     input_shape=(None, None, 3),
     pooling=None,
     classifier_activation="softmax",
-    name=None,
+    name="VGG19",
     **kwargs,
 ):
     """Instantiates the VGG19 architecture.
@@ -169,7 +169,7 @@ def VGG19(
         elif pooling == "max":
             x = layers.GlobalMaxPooling2D()(x)
 
-    model = keras.Model(inputs, x, name="vgg19", **kwargs)
+    model = keras.Model(inputs, x, name=name, **kwargs)
 
     if weights is not None:
         model.load_weights(weights)

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -44,8 +44,6 @@ def VGG19(
 
     This function returns a Keras VGG19 model.
 
-    The default input size for this model is 224x224.
-
     Args:
       include_rescaling: whether or not to Rescale the inputs.If set to True,
         inputs will be passed through a `Rescaling(1/255.0)` layer.


### PR DESCRIPTION
# What does this PR do?

Creates a keras_cv.model version of VGG19, ported from keras.applications.
This follows the paradigm set forth by #476 in that it:

- Makes include_preprocessing required
- Does not provide default weights (yet)
- Drops support for channels_first input shape
- Supports kwargs to Keras.model


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

@LukeWood @tanzhenyu 
