### PR TITLE
Add default name to DenseNet (to match docstring)

### DIFF
--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -156,7 +156,7 @@ def DenseNet(
     input_shape=(None, None, 3),
     pooling=None,
     classifier_activation="softmax",
-    name=None,
+    name="DenseNet",
     **kwargs,
 ):
     """Instantiates the DenseNet architecture.


### PR DESCRIPTION
# What does this PR do?

Fix inconsistency between docstring and parameter default for DenseNet name.
