### PR TITLE
Initial basic training template (densenet / cifar10)

### DIFF
--- a/examples/training/classification/densenet.json
+++ b/examples/training/classification/densenet.json
@@ -1,0 +1,1 @@
+{"experiment_id": "testing", "gcs_weights_path": "gs://ian-kerascv/densenet/testing/weights.hdf5"}

--- a/examples/training/classification/densenet.json
+++ b/examples/training/classification/densenet.json
@@ -1,1 +1,1 @@
-{"experiment_id": "testing", "gcs_weights_path": "gs://ian-kerascv/densenet/testing/weights.hdf5", "gcs_tensorboard_path": "gs://ian-kerascv/densenet/testing/logs/"}
+{"experiment_id": "testing", "author": "ianjjohnson", "gcs_weights_path": "gs://ian-kerascv/densenet/testing/weights.hdf5", "gcs_tensorboard_path": "gs://ian-kerascv/densenet/logs/testing/", "evaluation_metrics": {"loss": 2.302229881286621, "accuracy": 0.10000000149011612}}

--- a/examples/training/classification/densenet.json
+++ b/examples/training/classification/densenet.json
@@ -1,1 +1,1 @@
-{"experiment_id": "testing", "gcs_weights_path": "gs://ian-kerascv/densenet/testing/weights.hdf5"}
+{"experiment_id": "testing", "gcs_weights_path": "gs://ian-kerascv/densenet/testing/weights.hdf5", "gcs_tensorboard_path": "gs://ian-kerascv/densenet/testing/logs/"}

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -23,6 +23,7 @@ train, test = load_cfar10_dataset()
 NUM_CLASSES = 10
 EPOCHS = 1
 WEIGHTS_PATH = "weights.hdf5"
+MODEL_GS_PATH = "densenet"
 
 checkpoint = ModelCheckpoint(
     WEIGHTS_PATH,
@@ -57,4 +58,4 @@ with tf.distribute.MirroredStrategy().scope():
         validation_data=test,
     )
 
-model.save_weights("gs://ian-kerascv/" + WEIGHTS_PATH)
+model.save("gs://ian-kerascv/" + MODEL_GS_PATH)

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -91,7 +91,7 @@ def main(argv):
         mode="max",
     )
     tensorboard = TensorBoard(log_dir=gcs_tensorboard_path)
-    early_stopping = EarlyStopping(patience=5)
+    early_stopping = EarlyStopping(patience=10)
     callbacks = [gcs_backup, local_checkpoint, tensorboard, early_stopping]
 
     if _WANDB_PROJECT.value:

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -1,0 +1,60 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from keras.callbacks import ModelCheckpoint
+from utils import load_cfar10_dataset
+
+from keras_cv.models import DenseNet121
+
+train, test = load_cfar10_dataset()
+
+NUM_CLASSES = 10
+EPOCHS = 1
+WEIGHTS_PATH = "weights.hdf5"
+
+checkpoint = ModelCheckpoint(
+    WEIGHTS_PATH,
+    monitor="val_accuracy",
+    verbose=1,
+    save_best_only=True,
+    save_weights_only=True,
+    mode="max",
+)
+
+with tf.distribute.MirroredStrategy().scope():
+    model = DenseNet121(
+        include_rescaling=True,
+        include_top=True,
+        num_classes=NUM_CLASSES,
+        input_shape=(32, 32, 3),
+    )
+    model.compile(
+        optimizer="adam",
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+
+    if tf.io.gfile.exists(WEIGHTS_PATH):
+        model.load_weights(WEIGHTS_PATH)
+
+    model.fit(
+        train,
+        batch_size=32,
+        epochs=EPOCHS,
+        callbacks=[checkpoint],
+        validation_data=test,
+    )
+
+model.save_weights("gs://ian-kerascv/" + WEIGHTS_PATH)

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -66,13 +66,11 @@ def main(argv):
     assert _EXPERIMENT_ID.value
     assert _AUTHOR.value
 
-    gcs_path_base = "gs://{bucket}/densenet/{experiment}/".format(
-        bucket=_GCS_BUCKET.value, experiment=_EXPERIMENT_ID.value
-    )
+    gcs_path_base = f"gs://{_GCS_BUCKET.value}/densenet/{_EXPERIMENT_ID.value}/"
     gcs_backup_path = gcs_path_base + "backup/"
     gcs_weights_path = gcs_path_base + WEIGHTS_PATH
-    gcs_tensorboard_path = "gs://{bucket}/densenet/logs/{experiment}/".format(
-        bucket=_GCS_BUCKET.value, experiment=_EXPERIMENT_ID.value
+    gcs_tensorboard_path = (
+        f"gs://{_GCS_BUCKET.value}/densenet/logs/{_EXPERIMENT_ID.value}/"
     )
 
     train, test = load_cifar10_dataset(BATCH_SIZE)
@@ -121,11 +119,7 @@ def main(argv):
     # In order to save only weights to GCS, we manually store weights locally
     # (in our local_checkpoint callback) and then copy them to GCS using gsutil.
     # In case storing weights in GCS fails, the weights are also stored locally.
-    os.system(
-        "gsutil cp {local_path} {remote_path}".format(
-            local_path=WEIGHTS_PATH, remote_path=gcs_weights_path
-        )
-    )
+    os.system(f"gsutil cp {WEIGHTS_PATH} {gcs_weights_path}")
 
     metadata = {
         "experiment_id": _EXPERIMENT_ID.value,

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -99,7 +99,7 @@ def main(argv):
         wandb.init(_WANDB_PROJECT.value, entity="keras-team-testing")
         callbacks.append(WandbCallback())
 
-    with tf.device("/cpu:0"):
+    with tf.distribute.MirroredStrategy().scope():
         model = DenseNet121(
             include_rescaling=True,
             include_top=True,

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -24,6 +24,7 @@ from absl import app
 from absl import flags
 from keras.callbacks import BackupAndRestore
 from keras.callbacks import ModelCheckpoint
+from keras.callbacks import EarlyStopping
 from keras.callbacks import TensorBoard
 from keras.optimizers import Adam
 from utils import get_learning_rate_schedule
@@ -92,7 +93,8 @@ def main(argv):
         mode="max",
     )
     tensorboard = TensorBoard(log_dir=gcs_tensorboard_path)
-    callbacks = [gcs_backup, local_checkpoint, tensorboard]
+    early_stopping = EarlyStopping(patience=5)
+    callbacks = [gcs_backup, local_checkpoint, tensorboard, early_stopping]
 
     if _WANDB_PROJECT.value:
         wandb.init(_WANDB_PROJECT.value, entity="keras-team-testing")

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from keras.callbacks import ModelCheckpoint
+from utils import build_checkpoint_callback
 from utils import load_cfar10_dataset
 
 from keras_cv.models import DenseNet121
@@ -23,16 +23,8 @@ train, test = load_cfar10_dataset()
 NUM_CLASSES = 10
 EPOCHS = 1
 WEIGHTS_PATH = "weights.hdf5"
-MODEL_GS_PATH = "densenet"
+MODEL_GS_PATH = "densenet/"
 
-checkpoint = ModelCheckpoint(
-    WEIGHTS_PATH,
-    monitor="val_accuracy",
-    verbose=1,
-    save_best_only=True,
-    save_weights_only=True,
-    mode="max",
-)
 
 with tf.distribute.MirroredStrategy().scope():
     model = DenseNet121(
@@ -54,8 +46,8 @@ with tf.distribute.MirroredStrategy().scope():
         train,
         batch_size=32,
         epochs=EPOCHS,
-        callbacks=[checkpoint],
+        callbacks=[build_checkpoint_callback()],
         validation_data=test,
     )
 
-model.save("gs://ian-kerascv/" + MODEL_GS_PATH)
+model.save("gs://ian-kerascv/" + MODEL_GS_PATH + WEIGHTS_PATH)

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -27,7 +27,7 @@ from keras.callbacks import ModelCheckpoint
 from keras.callbacks import TensorBoard
 from keras.optimizers import Adam
 from utils import get_learning_rate_schedule
-from utils import load_cifar10_dataset
+from utils import load_cats_and_dogs_dataset
 from wandb.keras import WandbCallback
 
 import keras_cv
@@ -44,7 +44,7 @@ _WANDB_PROJECT = flags.DEFINE_string(
     "wandb_project", None, "Optional, a WandB project for exporting training data"
 )
 
-NUM_CLASSES = 10
+NUM_CLASSES = 2
 EPOCHS = 250
 BATCH_SIZE = 32
 WEIGHTS_PATH = "weights.hdf5"
@@ -78,7 +78,7 @@ def main(argv):
         f"gs://{_GCS_BUCKET.value}/densenet/logs/{_EXPERIMENT_ID.value}/"
     )
 
-    train, test = load_cifar10_dataset(BATCH_SIZE)
+    train, test = load_cats_and_dogs_dataset(BATCH_SIZE)
     train = train.map(augment, num_parallel_calls=tf.data.AUTOTUNE)
     train = train.prefetch(tf.data.AUTOTUNE)
 

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -103,7 +103,7 @@ def main(argv):
             include_rescaling=True,
             include_top=True,
             num_classes=NUM_CLASSES,
-            input_shape=(32, 32, 3),
+            input_shape=(150, 150, 3),
         )
 
         model.compile(

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -19,7 +19,6 @@ import json
 import os
 
 import tensorflow as tf
-import keras_cv
 from absl import app
 from absl import flags
 from keras.callbacks import BackupAndRestore
@@ -29,6 +28,7 @@ from keras.optimizers import Adam
 from utils import get_learning_rate_schedule
 from utils import load_cfar10_dataset
 
+import keras_cv
 from keras_cv.models import DenseNet121
 
 _GCS_BUCKET = flags.DEFINE_string("gcs_bucket", None, "Name of GCS Bucket")
@@ -47,6 +47,7 @@ AUGMENT_LAYERS = [
     keras_cv.layers.MixUp(),
     keras_cv.layers.RandomFlip(),
 ]
+
 
 @tf.function
 def augment(img, label):

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -19,6 +19,7 @@ import json
 import os
 
 import tensorflow as tf
+import wandb
 from absl import app
 from absl import flags
 from keras.callbacks import BackupAndRestore
@@ -27,12 +28,10 @@ from keras.callbacks import TensorBoard
 from keras.optimizers import Adam
 from utils import get_learning_rate_schedule
 from utils import load_cifar10_dataset
+from wandb.keras import WandbCallback
 
 import keras_cv
 from keras_cv.models import DenseNet121
-
-import wandb
-from wandb.keras import WandbCallback
 
 _GCS_BUCKET = flags.DEFINE_string("gcs_bucket", None, "Name of GCS Bucket")
 _EXPERIMENT_ID = flags.DEFINE_string(

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -97,7 +97,7 @@ def main(argv):
     callbacks = [gcs_backup, local_checkpoint, tensorboard, early_stopping]
 
     if _WANDB_PROJECT.value:
-        wandb.init(_WANDB_PROJECT.value, entity="keras-team-testing")
+        wandb.init(project=_WANDB_PROJECT.value, entity="keras-team-testing")
         callbacks.append(WandbCallback())
 
     with tf.distribute.MirroredStrategy().scope():

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -109,7 +109,7 @@ def main(argv):
         model.compile(
             optimizer=Adam(
                 learning_rate=get_learning_rate_schedule(
-                    EPOCHS, steps_per_epoch=train.cardinality().numpy()
+                    decay_steps=train.cardinality().numpy() * EPOCHS,
                 )
             ),
             loss="categorical_crossentropy",

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -23,8 +23,8 @@ import wandb
 from absl import app
 from absl import flags
 from keras.callbacks import BackupAndRestore
-from keras.callbacks import ModelCheckpoint
 from keras.callbacks import EarlyStopping
+from keras.callbacks import ModelCheckpoint
 from keras.callbacks import TensorBoard
 from keras.optimizers import Adam
 from utils import get_learning_rate_schedule

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -46,7 +46,7 @@ with tf.distribute.MirroredStrategy().scope():
         train,
         batch_size=32,
         epochs=EPOCHS,
-        callbacks=[build_checkpoint_callback()],
+        callbacks=[build_checkpoint_callback(WEIGHTS_PATH)],
         validation_data=test,
     )
 

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -52,10 +52,8 @@ WEIGHTS_PATH = "weights.hdf5"
 
 AUGMENT_LAYERS = [
     keras_cv.layers.RandomFlip(),
-    keras_cv.layers.RandAugment(value_range=(0, 255), magnitude=0.7),
+    keras_cv.layers.RandAugment(value_range=(0, 255), magnitude=0.3),
     keras_cv.layers.RandomCutout(height_factor=0.1, width_factor=0.1),
-    keras_cv.layers.CutMix(),
-    keras_cv.layers.MixUp(),
 ]
 
 

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -60,7 +60,6 @@ def main(argv):
         mode="max",
     )
 
-    model = None
     with tf.distribute.MirroredStrategy().scope():
         model = DenseNet121(
             include_rescaling=True,

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -27,7 +27,7 @@ from keras.callbacks import EarlyStopping
 from keras.callbacks import ModelCheckpoint
 from keras.callbacks import TensorBoard
 from keras.optimizers import Adam
-from utils import get_learning_rate_schedule
+from tensorflow.keras.optimizers.schedules import PolynomialDecay
 from utils import load_cats_and_dogs_dataset
 from wandb.keras import WandbCallback
 
@@ -108,8 +108,10 @@ def main(argv):
 
         model.compile(
             optimizer=Adam(
-                learning_rate=get_learning_rate_schedule(
+                learning_rate=PolynomialDecay(
+                    initial_learning_rate=0.005,
                     decay_steps=train.cardinality().numpy() * EPOCHS,
+                    end_learning_rate=0.0001,
                 )
             ),
             loss="categorical_crossentropy",

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -11,9 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""A training script for a DenseNet.
 
+This example is under active development and should not be forked for other models yet.
+"""
 import tensorflow as tf
-from utils import build_checkpoint_callback
+import os
+
+from utils import build_backup_and_restore_callback, build_checkpoint_callback
 from utils import load_cfar10_dataset
 
 from keras_cv.models import DenseNet121
@@ -21,10 +26,13 @@ from keras_cv.models import DenseNet121
 train, test = load_cfar10_dataset()
 
 NUM_CLASSES = 10
-EPOCHS = 1
-WEIGHTS_PATH = "weights.hdf5"
-MODEL_GS_PATH = "densenet/"
+EPOCHS = 10
+PATH_BASE = "gs://ian-kerascv/densenet/experimentid/"
+BACKUP_PATH = PATH_BASE + "backup/"
+REMOTE_WEIGHTS_PATH = PATH_BASE + "weights.hdf5"
+LOCAL_TMP_WEIGHTS_PATH = "tmp.hdf5"
 
+backup = build_backup_and_restore_callback(BACKUP_PATH)
 
 with tf.distribute.MirroredStrategy().scope():
     model = DenseNet121(
@@ -33,21 +41,23 @@ with tf.distribute.MirroredStrategy().scope():
         num_classes=NUM_CLASSES,
         input_shape=(32, 32, 3),
     )
+
     model.compile(
         optimizer="adam",
         loss="categorical_crossentropy",
         metrics=["accuracy"],
     )
 
-    if tf.io.gfile.exists(WEIGHTS_PATH):
-        model.load_weights(WEIGHTS_PATH)
-
     model.fit(
         train,
         batch_size=32,
         epochs=EPOCHS,
-        callbacks=[build_checkpoint_callback(WEIGHTS_PATH)],
+        callbacks=[backup],
         validation_data=test,
     )
 
-model.save("gs://ian-kerascv/" + MODEL_GS_PATH + WEIGHTS_PATH)
+model.save_weights(LOCAL_TMP_WEIGHTS_PATH)
+os.system("gsutil -m cp " + LOCAL_TMP_WEIGHTS_PATH + " " + REMOTE_WEIGHTS_PATH)
+os.system("rm " + LOCAL_TMP_WEIGHTS_PATH)
+
+# TODO(ianjjohnson) After success, store a file with the final output (JSON)

--- a/examples/training/classification/densenet.py
+++ b/examples/training/classification/densenet.py
@@ -15,6 +15,7 @@
 
 This example is under active development and should not be forked for other models yet.
 """
+import json
 import os
 
 import tensorflow as tf
@@ -32,7 +33,7 @@ _EXPERIMENT_ID = flags.DEFINE_string(
 )
 
 NUM_CLASSES = 10
-EPOCHS = 1
+EPOCHS = 10
 BATCH_SIZE = 32
 WEIGHTS_PATH = "weights.hdf5"
 
@@ -91,7 +92,12 @@ def main(argv):
         )
     )
 
-    # TODO(ianjjohnson) After success, store a local file with metadata and a pointer to the GCS weights file.
+    metadata = {
+        "experiment_id": _EXPERIMENT_ID.value,
+        "gcs_weights_path": gcs_weights_path,
+    }
+    with open("densenet.json", "w") as outfile:
+        json.dump(metadata, outfile)
 
 
 if __name__ == "__main__":

--- a/examples/training/classification/testing.py
+++ b/examples/training/classification/testing.py
@@ -1,0 +1,7 @@
+plt.figure(figsize=(10, 10))
+for images, labels in train.take(1):
+    for i in range(9):
+        ax = plt.subplot(3, 3, i + 1)
+        plt.imshow(images[i].numpy().astype("uint8"))
+        plt.title(np.argmax(labels[i].numpy()))
+        plt.axis("off")

--- a/examples/training/classification/training_tutorial.py
+++ b/examples/training/classification/training_tutorial.py
@@ -1,0 +1,182 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Title: Training a DenseNet for Image Classification with KerasCV
+Author: [ianjjohnson](https://github.com/ianjjohnson)
+Date created: 2022/07/21
+Last modified: 2022/07/21
+Description: Use KerasCV to train a DenseNet using modern best practives for image classification
+"""
+
+"""
+## Overview
+KerasCV makes training state-of-the-art classification models easy by providing implementations of modern models, preprocessing techniques, and layers. In this tutorial, we walk through training a DenseNet model against the cats and dogs dataset using Keras and KerasCV. Throughout this tutorial, we use some utility methods for data loading, etc. that can be found in KerasCV on [GitHub](github.com/keras-team/keras-cv).
+"""
+
+"""
+## Imports & setup
+This tutorial requires you to have KerasCV installed:
+```shell
+pip install keras-cv
+```
+We begin by importing all required packages:
+"""
+import json
+import os
+
+import tensorflow as tf
+import wandb
+from absl import app
+from absl import flags
+from keras.callbacks import BackupAndRestore
+from keras.callbacks import EarlyStopping
+from keras.callbacks import ModelCheckpoint
+from keras.callbacks import TensorBoard
+from keras.optimizers import Adam
+from tensorflow.keras.optimizers.schedules import PolynomialDecay
+from utils import augment
+from utils import load_cats_and_dogs_dataset
+from utils import save_training_results
+from wandb.keras import WandbCallback
+
+import keras_cv
+from keras_cv.models import DenseNet121
+
+"""
+## Data loading
+This guide uses the
+[Cats vs Dogs dataset](https://www.tensorflow.org/datasets/catalog/cats_vs_dogs)
+for demonstration purposes.
+To get started, we first load the dataset using the `load_cats_and_dogs_dataset` from our KerasCV training utils. Note that this method performs image resizing, one-hot encoding of targets, and batching for us.
+"""
+
+NUM_CLASSES = 2
+BATCH_SIZE = 32
+WIDTH = 150
+HEIGHT = 150
+EPOCHS = 250
+train, test = load_cats_and_dogs_dataset(
+    batch_size=BATCH_SIZE, width=WIDTH, height=HEIGHT
+)
+
+
+"""
+Next, we augment our dataset. We define a set of augmentation layers and then apply them to our input dataset using the `apply_augmentation` method from our KerasCV training utils. Note that both before and after augmentation we can visualize our dataset using the `visualize_dataset` method from the KerasCV training utils.
+"""
+
+# (Optionally): visualize_dataset(train, "Pre-augmentation")
+
+AUGMENT_LAYERS = [
+    keras_cv.layers.RandomFlip(),
+    keras_cv.layers.RandAugment(value_range=(0, 255), magnitude=0.3),
+    keras_cv.layers.RandomCutout(height_factor=0.1, width_factor=0.1),
+]
+train = train.map(
+    augment(AUGMENT_LAYERS), num_parallel_calls=tf.data.AUTOTUNE
+).prefetch(tf.data.AUTOTUNE)
+
+# (Optionally): visualize_dataset(train, "Post-augmentation")
+
+"""
+Now we can begin training our model. We begin by loading a DenseNet model from KerasCV
+"""
+
+
+def get_model():
+    return DenseNet121(
+        include_rescaling=True,
+        include_top=True,
+        num_classes=NUM_CLASSES,
+        input_shape=(WIDTH, HEIGHT, 3),
+    )
+
+
+"""
+Next, we pick an optimizer. Here we use Adam with a linearly decaying learning rate
+"""
+
+
+def get_optimizer():
+    return Adam(
+        learning_rate=PolynomialDecay(
+            initial_learning_rate=0.005,
+            decay_steps=train.cardinality().numpy() * EPOCHS,
+            end_learning_rate=0.0001,
+        )
+    )
+
+
+"""
+Next, we pick a loss function. Here we use a built-in Keras loss function, so we simply specify it as a string.
+"""
+
+
+def get_loss_fn():
+    return "binary_crossentropy"
+
+
+"""
+Next, we specify the metrics that we want to track. For this example, we track accuracy. Once again, accuracy is a built-in metric in Keras so we can specify it as a string.
+"""
+
+
+def get_metrics():
+    return ["accuracy"]
+
+
+"""
+As a last piece of configuration, we configure callbacks for the method. We use EarlyStopping, BackupAndRestore, and a Weights and Biases (WandB) integration callback. Note that the WandB callback requires some initialization, so we do that in the `get_callbacks` method.
+"""
+
+
+def get_callbacks():
+    wandb.init(project="densenet-training-tutorial", entity="keras-team-testing")
+    return [
+        EarlyStopping(patience=10),
+        BackupAndRestore("training_backup/"),
+        WandbCallback(),
+    ]
+
+
+"""
+We can now compile the model and fit it to the training dataset.
+"""
+
+with tf.distribute.MirroredStrategy().scope():
+    model = get_model()
+
+    model.compile(
+        optimizer=get_optimizer(),
+        loss=get_loss_fn(),
+        metrics=get_metrics(),
+    )
+
+    model.fit(
+        train,
+        batch_size=BATCH_SIZE,
+        epochs=EPOCHS,
+        callbacks=get_callbacks(),
+        validation_data=test,
+    )
+
+"""
+Next, we record validation metrics from the model and store metadata about the run as JSON using the `save_training_results` method from the KerasCV training utils.
+"""
+validation_metrics = model.evaluate(test, return_dict=True)
+
+AUTHOR = "ianjjohnson"
+RESULTS_PATH = "densenet_training_tutorial.json"
+save_training_results(
+    results_path=RESULTS_PATH, validation_metrics=validation_metrics, author=AUTHOR
+)

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,7 +15,7 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from keras.callbacks import ModelCheckpoint
+from keras.callbacks import ModelCheckpoint, BackupAndRestore
 
 
 def load_cfar10_dataset():
@@ -38,3 +38,6 @@ def build_checkpoint_callback(weights_path):
         save_weights_only=True,
         mode="max",
     )
+
+def build_backup_and_restore_callback(backup_path):
+    return BackupAndRestore(backup_path)

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,6 +15,7 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from keras.layers import Resizing
 from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
 
 
@@ -23,8 +24,16 @@ def load_cats_and_dogs_dataset(batch_size=32):
         "cats_vs_dogs", split=["train[:90%]", "train[90%:]"], as_supervised=True
     )
 
-    train = train_ds.map(lambda x, y: (x, tf.one_hot(y, 2))).batch(batch_size)
-    test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 2))).batch(batch_size)
+    resizing = Resizing(150, 150)
+
+    train = train_ds.map(
+        lambda x, y: (resizing(x), tf.one_hot(y, 2)),
+        num_parallel_calls=tf.data.AUTOTUNE,
+    ).batch(batch_size)
+    test = test_ds.map(
+        lambda x, y: (resizing(x), tf.one_hot(y, 2)),
+        num_parallel_calls=tf.data.AUTOTUNE,
+    ).batch(batch_size)
 
     return train, test
 

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -16,7 +16,7 @@
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from keras.layers import Resizing
-from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
+from tensorflow.keras.optimizers.schedules import PolynomialDecay
 
 
 def load_cats_and_dogs_dataset(batch_size=32):
@@ -49,10 +49,7 @@ def load_cifar10_dataset(batch_size=32):
     return train, test
 
 
-def get_learning_rate_schedule(epochs, steps_per_epoch):
-    epoch_boundaries = [epochs / 20, epochs / 10, epochs / 5, epochs / 2]
-    values = [0.01, 0.005, 0.001, 0.0005, 0.00025]
-
-    boundaries = [steps_per_epoch * x for x in epoch_boundaries]
-
-    return PiecewiseConstantDecay(boundaries, values)
+def get_learning_rate_schedule(decay_steps):
+    return PolynomialDecay(
+        initial_learning_rate=0.01, decay_steps=decay_steps, end_learning_rate=0.0001
+    )

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -17,12 +17,12 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 
-def load_cfar10_dataset():
+def load_cfar10_dataset(batch_size=32):
     train_ds, test_ds = tfds.load(
         "cifar10", split=["train", "test"], as_supervised=True
     )
 
-    train = train_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
-    test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
+    train = train_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(batch_size)
+    test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(batch_size)
 
     return train, test

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,6 +15,7 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from keras.callbacks import ModelCheckpoint
 
 
 def load_cfar10_dataset():
@@ -26,3 +27,14 @@ def load_cfar10_dataset():
     test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
 
     return train, test
+
+
+def build_checkpoint_callback(weights_path):
+    return ModelCheckpoint(
+        weights_path,
+        monitor="val_accuracy",
+        verbose=1,
+        save_best_only=True,
+        save_weights_only=True,
+        mode="max",
+    )

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,7 +15,6 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from keras.optimizers import Adam
 from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
 
 

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -18,7 +18,7 @@ import tensorflow_datasets as tfds
 from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
 
 
-def load_cfar10_dataset(batch_size=32):
+def load_cifar10_dataset(batch_size=32):
     train_ds, test_ds = tfds.load(
         "cifar10", split=["train", "test"], as_supervised=True
     )

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -1,0 +1,27 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for training demos."""
+
+import tensorflow_datasets as tfds
+
+
+def load_cfar10_dataset():
+    train_ds, test_ds = tfds.load(
+        "cifar10", split=["train", "test"], as_supervised=True
+    )
+
+    train = train_ds.shuffle(100).batch(32)
+    test = test_ds.batch(32)
+
+    return train, test

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for training demos."""
 
+import tensorflow as tf
 import tensorflow_datasets as tfds
 
 
@@ -21,7 +22,7 @@ def load_cfar10_dataset():
         "cifar10", split=["train", "test"], as_supervised=True
     )
 
-    train = train_ds.shuffle(100).batch(32)
-    test = test_ds.batch(32)
+    train = train_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
+    test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
 
     return train, test

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -18,6 +18,17 @@ import tensorflow_datasets as tfds
 from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
 
 
+def load_cats_and_dogs_dataset(batch_size=32):
+    train_ds, test_ds = tfds.load(
+        "cats_vs_dogs", split=["train[:90%]", "train[90%:]"], as_supervised=True
+    )
+
+    train = train_ds.map(lambda x, y: (x, tf.one_hot(y, 2))).batch(batch_size)
+    test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 2))).batch(batch_size)
+
+    return train, test
+
+
 def load_cifar10_dataset(batch_size=32):
     train_ds, test_ds = tfds.load(
         "cifar10", split=["train", "test"], as_supervised=True

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,7 +15,6 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from keras.callbacks import ModelCheckpoint, BackupAndRestore
 
 
 def load_cfar10_dataset():
@@ -27,17 +26,3 @@ def load_cfar10_dataset():
     test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(32)
 
     return train, test
-
-
-def build_checkpoint_callback(weights_path):
-    return ModelCheckpoint(
-        weights_path,
-        monitor="val_accuracy",
-        verbose=1,
-        save_best_only=True,
-        save_weights_only=True,
-        mode="max",
-    )
-
-def build_backup_and_restore_callback(backup_path):
-    return BackupAndRestore(backup_path)

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -15,6 +15,8 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from keras.optimizers import Adam
+from tensorflow.keras.optimizers.schedules import PiecewiseConstantDecay
 
 
 def load_cfar10_dataset(batch_size=32):
@@ -26,3 +28,12 @@ def load_cfar10_dataset(batch_size=32):
     test = test_ds.map(lambda x, y: (x, tf.one_hot(y, 10))).batch(batch_size)
 
     return train, test
+
+
+def get_learning_rate_schedule(epochs, steps_per_epoch):
+    epoch_boundaries = [epochs / 20, epochs / 10, epochs / 5, epochs / 2]
+    values = [0.01, 0.005, 0.001, 0.0005, 0.00025]
+
+    boundaries = [steps_per_epoch * x for x in epoch_boundaries]
+
+    return PiecewiseConstantDecay(boundaries, values)

--- a/examples/training/classification/utils.py
+++ b/examples/training/classification/utils.py
@@ -23,9 +23,7 @@ def load_cats_and_dogs_dataset(batch_size=32):
     train_ds, test_ds = tfds.load(
         "cats_vs_dogs", split=["train[:90%]", "train[90%:]"], as_supervised=True
     )
-
     resizing = Resizing(150, 150)
-
     train = train_ds.map(
         lambda x, y: (resizing(x), tf.one_hot(y, 2)),
         num_parallel_calls=tf.data.AUTOTUNE,
@@ -34,7 +32,6 @@ def load_cats_and_dogs_dataset(batch_size=32):
         lambda x, y: (resizing(x), tf.one_hot(y, 2)),
         num_parallel_calls=tf.data.AUTOTUNE,
     ).batch(batch_size)
-
     return train, test
 
 
@@ -51,5 +48,5 @@ def load_cifar10_dataset(batch_size=32):
 
 def get_learning_rate_schedule(decay_steps):
     return PolynomialDecay(
-        initial_learning_rate=0.01, decay_steps=decay_steps, end_learning_rate=0.0001
+        initial_learning_rate=0.005, decay_steps=decay_steps, end_learning_rate=0.0001
     )


### PR DESCRIPTION
# What does this PR do?

This creates an initial template for training KerasCV model architectures.
It currently supports
- Failure recovery
- Storing weights to GCS
- Basic tensorboard output to GCS
- A simple custom learning rate schedule
- Very basic metadata output

It's not ready for real use at this point, but let's talk through the structure and high-level approach, and then we can add features from here.

Some open questions:
- How generic do we want to make training scripts (I'd like to avoid too much code duplication but also recognize that it's important to avoid unnecessary indirection, especially since these should mostly stand alone)
- Should we have a single copy of the model setup / training / weight storage code, and make each training script implement just data augmentation and a training loop? Or should we embrace some code duplication so that training scripts can be more easily customized

@LukeWood @tanzhenyu 
