### PR TITLE
Towards keypoint support: Converter and utility functions

### DIFF
--- a/keras_cv/keypoint/__init__.py
+++ b/keras_cv/keypoint/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_cv.keypoint.converters import convert_format
+from keras_cv.keypoint.formats import REL_XY
+from keras_cv.keypoint.formats import XY
+from keras_cv.keypoint.utils import discard_out_of_image

--- a/keras_cv/keypoint/__init__.py
+++ b/keras_cv/keypoint/__init__.py
@@ -15,4 +15,4 @@
 from keras_cv.keypoint.converters import convert_format
 from keras_cv.keypoint.formats import REL_XY
 from keras_cv.keypoint.formats import XY
-from keras_cv.keypoint.utils import filter_out_of_boundaries
+from keras_cv.keypoint.utils import filter_out_of_image

--- a/keras_cv/keypoint/__init__.py
+++ b/keras_cv/keypoint/__init__.py
@@ -15,4 +15,4 @@
 from keras_cv.keypoint.converters import convert_format
 from keras_cv.keypoint.formats import REL_XY
 from keras_cv.keypoint.formats import XY
-from keras_cv.keypoint.utils import discard_out_of_image
+from keras_cv.keypoint.utils import filter_out_of_boundaries

--- a/keras_cv/keypoint/converters.py
+++ b/keras_cv/keypoint/converters.py
@@ -15,12 +15,15 @@
 
 import tensorflow as tf
 
-from keras_cv.bounding_box.converters import RequiresImagesException
+
+# Internal exception
+class _RequiresImagesException(Exception):
+    pass
 
 
 def _rel_xy_to_xy(keypoints, images=None):
     if images is None:
-        raise RequiresImagesException()
+        raise _RequiresImagesException()
     shape = tf.cast(tf.shape(images), keypoints.dtype)
     h, w = shape[1], shape[2]
 
@@ -31,7 +34,7 @@ def _rel_xy_to_xy(keypoints, images=None):
 
 def _xy_to_rel_xy(keypoints, images=None):
     if images is None:
-        raise RequiresImagesException()
+        raise _RequiresImagesException()
     shape = tf.cast(tf.shape(images), keypoints.dtype)
     h, w = shape[1], shape[2]
 
@@ -136,7 +139,7 @@ def convert_format(keypoints, source, target, images=None, dtype=None):
     try:
         in_xy = TO_XY_CONVERTERS[source](keypoints, images=images)
         result = FROM_XY_CONVERTERS[target](in_xy, images=images)
-    except RequiresImagesException:
+    except _RequiresImagesException:
         raise ValueError(
             "convert_format() must receive `images` when transforming "
             f"between relative and absolute formats. "

--- a/keras_cv/keypoint/converters.py
+++ b/keras_cv/keypoint/converters.py
@@ -116,12 +116,14 @@ def convert_format(keypoints, source, target, images=None, dtype=None):
         raise ValueError(
             f"convert_format() received an unsupported format for the argument "
             f"`source`. `source` should be one of {TO_XY_CONVERTERS.keys()}. "
-            f"Got source={source}")
+            f"Got source={source}"
+        )
     if target not in FROM_XY_CONVERTERS:
         raise ValueError(
             f"convert_format() received an unsupported format for the argument "
             f"`target`. `target` should be one of {FROM_XY_CONVERTERS.keys()}. "
-            f"Got target={target}")
+            f"Got target={target}"
+        )
 
     if dtype:
         keypoints = tf.cast(keypoints, dtype)
@@ -139,7 +141,8 @@ def convert_format(keypoints, source, target, images=None, dtype=None):
             "convert_format() must receive `images` when transforming "
             f"between relative and absolute formats. "
             f"convert_format() received source=`{source}`, target=`{target}`, "
-            f"but images={images}")
+            f"but images={images}"
+        )
 
     return _format_outputs(result, squeeze_axis)
 
@@ -147,15 +150,19 @@ def convert_format(keypoints, source, target, images=None, dtype=None):
 def _format_inputs(keypoints, images):
     keypoints_rank = len(keypoints.shape)
     if keypoints_rank > 4:
-        raise ValueError("Expected keypoints rank to be in [2, 4], got "
-                         f"len(keypoints.shape)={keypoints_rank}.")
+        raise ValueError(
+            "Expected keypoints rank to be in [2, 4], got "
+            f"len(keypoints.shape)={keypoints_rank}."
+        )
     keypoints_includes_batch = keypoints_rank > 2
     keypoints_are_grouped = keypoints_rank == 4
     if images is not None:
         images_rank = len(images.shape)
         if images_rank > 4 or images_rank < 3:
-            raise ValueError("Expected images rank to be 3 or 4, got "
-                             f"len(images.shape)={images_rank}.")
+            raise ValueError(
+                "Expected images rank to be 3 or 4, got "
+                f"len(images.shape)={images_rank}."
+            )
         images_include_batch = images_rank == 4
         if keypoints_includes_batch != images_include_batch:
             raise ValueError(
@@ -163,7 +170,8 @@ def _format_inputs(keypoints, images):
                 f"or both unbatched. Received len(keypoints.shape)={keypoints_rank}, "
                 f"len(images.shape)={images_rank}. Expected either "
                 "len(keypoints.shape)=2 and len(images.shape)=3, or "
-                "len(keypoints.shape)>=3 and len(images.shape)=4.")
+                "len(keypoints.shape)>=3 and len(images.shape)=4."
+            )
         if not images_include_batch:
             images = tf.expand_dims(images, axis=0)
 

--- a/keras_cv/keypoint/converters.py
+++ b/keras_cv/keypoint/converters.py
@@ -1,0 +1,184 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Converter functions for working with keypoints formats."""
+
+import tensorflow as tf
+
+from keras_cv.bounding_box.converters import RequiresImagesException
+
+
+def _rel_xy_to_xy(keypoints, images=None):
+    if images is None:
+        raise RequiresImagesException()
+    shape = tf.cast(tf.shape(images), keypoints.dtype)
+    h, w = shape[1], shape[2]
+
+    x, y, rest = tf.split(keypoints, [1, 1, keypoints.shape[-1] - 2], axis=-1)
+
+    return tf.concat([x * w, y * h, rest], axis=-1)
+
+
+def _xy_to_rel_xy(keypoints, images=None):
+    if images is None:
+        raise RequiresImagesException()
+    shape = tf.cast(tf.shape(images), keypoints.dtype)
+    h, w = shape[1], shape[2]
+
+    x, y, rest = tf.split(keypoints, [1, 1, keypoints.shape[-1] - 2], axis=-1)
+
+    return tf.concat([x / w, y / h, rest], axis=-1)
+
+
+def _xy_noop(keypoints, images=None):
+    return keypoints
+
+
+TO_XY_CONVERTERS = {
+    "xy": _xy_noop,
+    "rel_xy": _rel_xy_to_xy,
+}
+
+FROM_XY_CONVERTERS = {
+    "xy": _xy_noop,
+    "rel_xy": _xy_to_rel_xy,
+}
+
+
+def convert_format(keypoints, source, target, images=None, dtype=None):
+    """Converts keypoints from one format to another.
+
+    Supported formats are:
+    - `"xy"`, absolute pixel positions.
+    - `"rel_xyxy"`.  relative pixel positions.
+
+    Formats are case insensitive.  It is recommended that you
+    capitalize width and height to maximize the visual difference
+    between `"xyWH"` and `"xyxy"`.
+
+    Relative formats, abbreviated `rel`, make use of the shapes of the
+    `images` passsed.  In these formats, the coordinates, widths, and
+    heights are all specified as percentages of the host image.
+    `images` may be a ragged Tensor.  Note that using a ragged Tensor
+    for images may cause a substantial performance loss, as each image
+    will need to be processed separately due to the mismatching image
+    shapes.
+
+    Usage:
+
+    ```python
+    images, keypoints = load_my_dataset()
+    keypoints_in_rel = keras_cv.keypoint.convert_format(
+        keypoint,
+        source='xy',
+        target='rel_xy',
+        images=images,
+    )
+    ```
+
+    Args:
+        keypoints: tf.Tensor or tf.RaggedTensor representing keypoints
+            in the format specified in the `source` parameter.
+            `keypoints` can optionally have extra dimensions stacked
+            on the final axis to store metadata.  keypoints should
+            have a rank between 2 and 4, with the shape
+            `[num_boxes,*]`, `[batch_size, num_boxes, *]` or
+            `[batch_size, num_groups, num_keypoints,*]`.
+        source: One of {" ".join([f'"{f}"' for f in
+            TO_XY_CONVERTERS.keys()])}.  Used to specify the original
+            format of the `boxes` parameter.
+        target: One of {" ".join([f'"{f}"' for f in
+            TO_XY_CONVERTERS.keys()])}.  Used to specify the
+            destination format of the `boxes` parameter.
+        images: (Optional) a batch of images aligned with `boxes` on
+            the first axis.  Should be rank 3 (`HWC` format) or 4
+            (`BHWC` format). Used in some converters to compute
+            relative pixel values of the bounding box dimensions.
+            Required when transforming from a rel format to a non-rel
+            format.
+        dtype: the data type to use when transforming the boxes.
+            Defaults to None, i.e. `keypoints` dtype.
+    """
+
+    source = source.lower()
+    target = target.lower()
+    if source not in TO_XY_CONVERTERS:
+        raise ValueError(
+            f"convert_format() received an unsupported format for the argument "
+            f"`source`. `source` should be one of {TO_XY_CONVERTERS.keys()}. "
+            f"Got source={source}")
+    if target not in FROM_XY_CONVERTERS:
+        raise ValueError(
+            f"convert_format() received an unsupported format for the argument "
+            f"`target`. `target` should be one of {FROM_XY_CONVERTERS.keys()}. "
+            f"Got target={target}")
+
+    if dtype:
+        keypoints = tf.cast(keypoints, dtype)
+
+    if source == target:
+        return keypoints
+
+    keypoints, images, squeeze_axis = _format_inputs(keypoints, images)
+
+    try:
+        in_xy = TO_XY_CONVERTERS[source](keypoints, images=images)
+        result = FROM_XY_CONVERTERS[target](in_xy, images=images)
+    except RequiresImagesException:
+        raise ValueError(
+            "convert_format() must receive `images` when transforming "
+            f"between relative and absolute formats. "
+            f"convert_format() received source=`{source}`, target=`{target}`, "
+            f"but images={images}")
+
+    return _format_outputs(result, squeeze_axis)
+
+
+def _format_inputs(keypoints, images):
+    keypoints_rank = len(keypoints.shape)
+    if keypoints_rank > 4:
+        raise ValueError("Expected keypoints rank to be in [2, 4], got "
+                         f"len(keypoints.shape)={keypoints_rank}.")
+    keypoints_includes_batch = keypoints_rank > 2
+    keypoints_are_grouped = keypoints_rank == 4
+    if images is not None:
+        images_rank = len(images.shape)
+        if images_rank > 4 or images_rank < 3:
+            raise ValueError("Expected images rank to be 3 or 4, got "
+                             f"len(images.shape)={images_rank}.")
+        images_include_batch = images_rank == 4
+        if keypoints_includes_batch != images_include_batch:
+            raise ValueError(
+                "convert_format() expects both `keypoints` and `images` to be batched "
+                f"or both unbatched. Received len(keypoints.shape)={keypoints_rank}, "
+                f"len(images.shape)={images_rank}. Expected either "
+                "len(keypoints.shape)=2 and len(images.shape)=3, or "
+                "len(keypoints.shape)>=3 and len(images.shape)=4.")
+        if not images_include_batch:
+            images = tf.expand_dims(images, axis=0)
+
+    squeeze_axis = []
+    if not keypoints_includes_batch:
+        keypoints = tf.expand_dims(keypoints, axis=0)
+        squeeze_axis.append(0)
+    if not keypoints_are_grouped:
+        keypoints = tf.expand_dims(keypoints, axis=1)
+        squeeze_axis.append(1)
+
+    return keypoints, images, squeeze_axis
+
+
+def _format_outputs(result, squeeze_axis):
+    if len(squeeze_axis) == 0:
+        return result
+    return tf.squeeze(result, axis=squeeze_axis)

--- a/keras_cv/keypoint/converters_test.py
+++ b/keras_cv/keypoint/converters_test.py
@@ -1,0 +1,149 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv import keypoint
+
+xy_keypoints = tf.constant(
+    [[[10, 20], [110, 120], [210, 220]], [[20, 30], [120, 130], [220, 230]]],
+    dtype=tf.float32,
+)
+rel_xy_keypoints = tf.constant(
+    [
+        [[0.01, 0.04], [0.11, 0.24], [0.21, 0.44]],
+        [[0.02, 0.06], [0.12, 0.26], [0.22, 0.46]],
+    ],
+    dtype=tf.float32,
+)
+
+images = tf.ones([2, 500, 1000, 3])
+
+keypoints = {
+    "xy": xy_keypoints,
+    "rel_xy": rel_xy_keypoints,
+}
+
+test_cases = [
+    (f"{source}_{target}", source, target)
+    for (source, target) in itertools.permutations(keypoints.keys(), 2)
+] + [("xy_xy", "xy", "xy")]
+
+
+class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(*test_cases)
+    def test_converters(self, source, target):
+        source_keypoints = keypoints[source]
+        target_keypoints = keypoints[target]
+        self.assertAllClose(
+            keypoint.convert_format(
+                source_keypoints, source=source, target=target, images=images
+            ),
+            target_keypoints,
+        )
+
+    @parameterized.named_parameters(*test_cases)
+    def test_converters_unbatched(self, source, target):
+        source_keypoints = keypoints[source][0]
+        target_keypoints = keypoints[target][0]
+
+        self.assertAllClose(
+            keypoint.convert_format(
+                source_keypoints, source=source, target=target, images=images[0]
+            ),
+            target_keypoints,
+        )
+
+    @parameterized.named_parameters(*test_cases)
+    def test_converters_ragged_groups(self, source, target):
+        source_keypoints = keypoints[source]
+        target_keypoints = keypoints[target]
+
+        def create_ragged_group(ins):
+            res = []
+            for b, groups in zip(ins, [[1, 2], [0, 3]]):
+                res.append(tf.RaggedTensor.from_row_lengths(b, groups))
+            return tf.stack(res, axis=0)
+
+        source_keypoints = create_ragged_group(source_keypoints)
+        target_keypoints = create_ragged_group(target_keypoints)
+
+        self.assertAllClose(
+            keypoint.convert_format(
+                source_keypoints, source=source, target=target, images=images
+            ),
+            target_keypoints,
+        )
+
+    @parameterized.named_parameters(*test_cases)
+    def test_converters_with_metadata(self, source, target):
+        source_keypoints = keypoints[source]
+        target_keypoints = keypoints[target]
+
+        def add_metadata(ins):
+            return tf.concat([ins, tf.ones([2, 3, 5])], axis=-1)
+
+        source_keypoints = add_metadata(source_keypoints)
+        target_keypoints = add_metadata(target_keypoints)
+
+        self.assertAllClose(
+            keypoint.convert_format(
+                source_keypoints, source=source, target=target, images=images
+            ),
+            target_keypoints,
+        )
+
+    def test_raise_errors_when_missing_shape(self):
+        with self.assertRaises(ValueError) as e:
+            keypoint.convert_format(keypoints["xy"], source="xy", target="rel_xy")
+
+        self.assertEqual(
+            str(e.exception),
+            "convert_format() must receive `images` when transforming "
+            "between relative and absolute formats. convert_format() "
+            "received source=`xy`, target=`rel_xy`, but images=None",
+        )
+
+    @parameterized.named_parameters(
+        (
+            "keypoint_rank",
+            tf.ones([2, 3, 4, 2, 1]),
+            None,
+            "Expected keypoints rank to be in [2, 4], got len(keypoints.shape)=5.",
+        ),
+        (
+            "images_rank",
+            tf.ones([4, 2]),
+            tf.ones([35, 35]),
+            "Expected images rank to be 3 or 4, got len(images.shape)=2.",
+        ),
+        (
+            "batch_mismatch",
+            tf.ones([2, 4, 2]),
+            tf.ones([35, 35, 3]),
+            "convert_format() expects both `keypoints` and `images` to be batched or "
+            "both unbatched. Received len(keypoints.shape)=3, len(images.shape)=3. "
+            "Expected either len(keypoints.shape)=2 and len(images.shape)=3, or "
+            "len(keypoints.shape)>=3 and len(images.shape)=4.",
+        ),
+    )
+    def test_input_format_exception(self, keypoints, images, expected):
+        with self.assertRaises(ValueError) as e:
+            keypoint.convert_format(
+                keypoints, source="xy", target="rel_xy", images=images
+            )
+        self.assertEqual(str(e.exception), expected)

--- a/keras_cv/keypoint/formats.py
+++ b/keras_cv/keypoint/formats.py
@@ -1,0 +1,63 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+formats.py contains axis information for each supported format.
+"""
+
+
+class XY:
+    """XY contains axis indices for the XY format.
+
+    All values in the XY format should be absolute pixel values.
+
+    The XY format consists of the following required indices:
+
+    - X: the width position
+    - Y: the height position
+
+    and the following optional indices, used in some KerasCV components:
+
+    - CLASS: class of the keypoints
+    - CONFIDENCE: confidence of the keypoints
+    """
+
+    X = 0
+    Y = 1
+    CLASS = 2
+    CONFIDENCE = 3
+
+
+class REL_XY:
+    """REL_XY contains axis indices for the REL_XY format.
+
+
+    REL_XY is like XY, but each value is relative to the width and height of the
+    origin image.  Values are percentages of the origin images' width and height
+    respectively.
+
+    The REL_XY format consists of the following required indices:
+
+    - X: the width position
+    - Y: the height position
+
+    and the following optional indices, used in some KerasCV components:
+
+    - CLASS: class of the keypoints
+    - CONFIDENCE: confidence of the keypoints
+    """
+
+    X = 0
+    Y = 1
+    CLASS = 2
+    CONFIDENCE = 3

--- a/keras_cv/keypoint/utils.py
+++ b/keras_cv/keypoint/utils.py
@@ -15,7 +15,7 @@
 import tensorflow as tf
 
 
-def discard_out_of_image(keypoints, image):
+def filter_out_of_boundaries(keypoints, image):
     """Discards keypoints if falling outside of the image.
 
     Args:
@@ -30,12 +30,10 @@ def discard_out_of_image(keypoints, image):
 
     image_shape = tf.cast(tf.shape(image), keypoints.dtype)
     mask = tf.math.logical_and(
-        tf.math.logical_and(
-            keypoints[..., 0] >= 0, keypoints[..., 0] < image_shape[-2]
-        ),
-        tf.math.logical_and(
-            keypoints[..., 1] >= 0, keypoints[..., 1] < image_shape[-3]
-        ),
+        tf.math.logical_and(keypoints[..., 0] >= 0,
+                            keypoints[..., 0] < image_shape[-2]),
+        tf.math.logical_and(keypoints[..., 1] >= 0,
+                            keypoints[..., 1] < image_shape[-3]),
     )
     masked = tf.ragged.boolean_mask(keypoints, mask)
     if isinstance(masked, tf.RaggedTensor):

--- a/keras_cv/keypoint/utils.py
+++ b/keras_cv/keypoint/utils.py
@@ -1,0 +1,43 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for keypoint transformation."""
+import tensorflow as tf
+
+
+def discard_out_of_image(keypoints, image):
+    """Discards keypoints if falling outside of the image.
+
+    Args:
+      keypoints: a, possibly ragged, 2D (ungrouped), 3D (grouped)
+        keypoint data in the 'xy' format.
+      image: a 3D tensor in the HWC format.
+
+    Returns:
+      tf.RaggedTensor: a 2D or 3D ragged tensor with at least one
+        ragged rank containing only keypoint in the image.
+    """
+
+    image_shape = tf.cast(tf.shape(image), keypoints.dtype)
+    mask = tf.math.logical_and(
+        tf.math.logical_and(
+            keypoints[..., 0] >= 0, keypoints[..., 0] < image_shape[-2]
+        ),
+        tf.math.logical_and(
+            keypoints[..., 1] >= 0, keypoints[..., 1] < image_shape[-3]
+        ),
+    )
+    masked = tf.ragged.boolean_mask(keypoints, mask)
+    if isinstance(masked, tf.RaggedTensor):
+        return masked
+    return tf.RaggedTensor.from_tensor(masked)

--- a/keras_cv/keypoint/utils.py
+++ b/keras_cv/keypoint/utils.py
@@ -18,7 +18,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-def filter_out_of_boundaries(keypoints, image):
+def filter_out_of_image(keypoints, image):
     """Discards keypoints if falling outside of the image.
 
     Args:

--- a/keras_cv/keypoint/utils.py
+++ b/keras_cv/keypoint/utils.py
@@ -14,6 +14,9 @@
 """Utility functions for keypoint transformation."""
 import tensorflow as tf
 
+H_AXIS = -3
+W_AXIS = -2
+
 
 def filter_out_of_boundaries(keypoints, image):
     """Discards keypoints if falling outside of the image.
@@ -30,10 +33,12 @@ def filter_out_of_boundaries(keypoints, image):
 
     image_shape = tf.cast(tf.shape(image), keypoints.dtype)
     mask = tf.math.logical_and(
-        tf.math.logical_and(keypoints[..., 0] >= 0,
-                            keypoints[..., 0] < image_shape[-2]),
-        tf.math.logical_and(keypoints[..., 1] >= 0,
-                            keypoints[..., 1] < image_shape[-3]),
+        tf.math.logical_and(
+            keypoints[..., 0] >= 0, keypoints[..., 0] < image_shape[W_AXIS]
+        ),
+        tf.math.logical_and(
+            keypoints[..., 1] >= 0, keypoints[..., 1] < image_shape[H_AXIS]
+        ),
     )
     masked = tf.ragged.boolean_mask(keypoints, mask)
     if isinstance(masked, tf.RaggedTensor):

--- a/keras_cv/keypoint/utils_test.py
+++ b/keras_cv/keypoint/utils_test.py
@@ -1,0 +1,45 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.keypoint.utils import discard_out_of_image
+
+
+class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        (
+            "all inside",
+            tf.constant([[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]]),
+            tf.zeros([100, 100, 3]),
+            tf.ragged.constant([[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]]),
+        ),
+        (
+            "some inside",
+            tf.constant([[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]]),
+            tf.zeros([50, 50, 3]),
+            tf.ragged.constant([[10.0, 20.0], [30.0, 40.0]]),
+        ),
+        (
+            "ragged input",
+            tf.RaggedTensor.from_row_lengths(
+                [[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]], [2, 1]
+            ),
+            tf.zeros([50, 50, 3]),
+            tf.RaggedTensor.from_row_lengths([[10.0, 20.0], [30.0, 40.0]], [2, 0]),
+        ),
+    )
+    def test_result(self, keypoints, image, expected):
+        self.assertAllClose(discard_out_of_image(keypoints, image), expected)

--- a/keras_cv/keypoint/utils_test.py
+++ b/keras_cv/keypoint/utils_test.py
@@ -15,7 +15,7 @@
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv.keypoint.utils import filter_out_of_boundaries
+from keras_cv.keypoint.utils import filter_out_of_image
 
 
 class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
@@ -48,4 +48,4 @@ class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
         ),
     )
     def test_result(self, keypoints, image, expected):
-        self.assertAllClose(filter_out_of_boundaries(keypoints, image), expected)
+        self.assertAllClose(filter_out_of_image(keypoints, image), expected)

--- a/keras_cv/keypoint/utils_test.py
+++ b/keras_cv/keypoint/utils_test.py
@@ -19,7 +19,6 @@ from keras_cv.keypoint.utils import filter_out_of_boundaries
 
 
 class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
-
     @parameterized.named_parameters(
         (
             "all inside",
@@ -36,12 +35,17 @@ class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
         (
             "ragged input",
             tf.RaggedTensor.from_row_lengths(
-                [[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]], [2, 1]),
+                [[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]], [2, 1]
+            ),
             tf.zeros([50, 50, 3]),
-            tf.RaggedTensor.from_row_lengths([[10.0, 20.0], [30.0, 40.0]],
-                                             [2, 0]),
+            tf.RaggedTensor.from_row_lengths([[10.0, 20.0], [30.0, 40.0]], [2, 0]),
+        ),
+        (
+            "height - width confusion",
+            tf.constant([[[10.0, 20.0]], [[40.0, 30.0]], [[30.0, 40.0]]]),
+            tf.zeros((50, 40, 3)),
+            tf.ragged.constant([[[10.0, 20.0]], [], [[30.0, 40.0]]], ragged_rank=1),
         ),
     )
     def test_result(self, keypoints, image, expected):
-        self.assertAllClose(filter_out_of_boundaries(keypoints, image),
-                            expected)
+        self.assertAllClose(filter_out_of_boundaries(keypoints, image), expected)

--- a/keras_cv/keypoint/utils_test.py
+++ b/keras_cv/keypoint/utils_test.py
@@ -15,10 +15,11 @@
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv.keypoint.utils import discard_out_of_image
+from keras_cv.keypoint.utils import filter_out_of_boundaries
 
 
 class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
+
     @parameterized.named_parameters(
         (
             "all inside",
@@ -35,11 +36,12 @@ class UtilsTestCase(tf.test.TestCase, parameterized.TestCase):
         (
             "ragged input",
             tf.RaggedTensor.from_row_lengths(
-                [[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]], [2, 1]
-            ),
+                [[10.0, 20.0], [30.0, 40.0], [50.0, 50.0]], [2, 1]),
             tf.zeros([50, 50, 3]),
-            tf.RaggedTensor.from_row_lengths([[10.0, 20.0], [30.0, 40.0]], [2, 0]),
+            tf.RaggedTensor.from_row_lengths([[10.0, 20.0], [30.0, 40.0]],
+                                             [2, 0]),
         ),
     )
     def test_result(self, keypoints, image, expected):
-        self.assertAllClose(discard_out_of_image(keypoints, image), expected)
+        self.assertAllClose(filter_out_of_boundaries(keypoints, image),
+                            expected)


### PR DESCRIPTION
# What does this PR do?

Adds keypoint format, converter and utility functions.

```python
import tensorflow as tf
from keras_cv import keypoint

keypoints = tf.constant([
    [ 10,20],
    [110,220],
    [510,520],
], dtype=tf.float32)

image = tf.zeros((500,500,3))

in_image = keypoint.discard_out_of_image(keypoints,image=image)

relative = keypoint.convert_format(in_image,
                                   source='xy',
                                   target='rel_xy',
                                   images=image)

print(relative)
```
will output

```
<tf.RaggedTensor [[0.02, 0.04],
 [0.22, 0.44]]>
```



Related to #518


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

Incremental PR as requested by @LukeWood 
