### PR TITLE
Towards keypoint support: `BaseImageAugmentationLayer` modification

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -25,7 +25,7 @@ class RandomAddLayer(BaseImageAugmentationLayer):
         self.value_range = value_range
         self.fixed_value = fixed_value
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         if self.fixed_value:
             return self.fixed_value
         return self._random_generator.random_uniform(
@@ -37,6 +37,12 @@ class RandomAddLayer(BaseImageAugmentationLayer):
 
     def augment_label(self, label, transformation, **kwargs):
         return label + transformation
+
+    def augment_bounding_boxes(self, bounding_boxes, transformation, **kwargs):
+        return bounding_boxes + transformation
+
+    def augment_keypoints(self, keypoints, transformation, **kwargs):
+        return keypoints + transformation
 
 
 class VectorizeDisabledLayer(BaseImageAugmentationLayer):
@@ -136,3 +142,35 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         self.assertAllEqual(inputs["filenames"], outputs["filenames"])
         self.assertNotAllClose(inputs["images"], outputs["images"])
         self.assertAllEqual(inputs["images"], images)  # Assert original unchanged
+
+    def test_augment_image_and_localization_data(self):
+        add_layer = RandomAddLayer(fixed_value=2.0)
+        images = np.random.random(size=(8, 8, 3)).astype("float32")
+        bounding_boxes = np.random.random(size=(3, 4)).astype("float32")
+        keypoints = np.random.random(size=(3, 5, 2)).astype("float32")
+
+        output = add_layer(
+            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+        )
+
+        expected_output = {
+            "images": images + 2.0,
+            "bounding_boxes": bounding_boxes + 2.0,
+            "keypoints": keypoints + 2.0,
+        }
+        self.assertAllClose(output, expected_output)
+
+    def test_augment_batch_image_and_localization_data(self):
+        add_layer = RandomAddLayer()
+        images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
+        bounding_boxes = np.random.random(size=(2, 3, 4)).astype("float32")
+        keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
+
+        output = add_layer(
+            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+        )
+
+        bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
+        keypoints_diff = output["keypoints"] - keypoints
+        self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
+        self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -138,7 +138,9 @@ class GridMask(BaseImageAugmentationLayer):
                 f'"gaussian_noise", or "random".  Got `fill_mode`={fill_mode}'
             )
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(
+        self, image=None, label=None, bounding_boxes=None, **kwargs
+    ):
         ratio = self.ratio_factor()
 
         # compute grid mask

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -63,7 +63,9 @@ class RandomChannelShift(BaseImageAugmentationLayer):
         self.channels = channels
         self.factor = preprocessing.parse_factor(factor, seed=self.seed)
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(
+        self, image=None, label=None, bounding_boxes=None, **kwargs
+    ):
         shifts = []
         for _ in range(self.channels):
             shifts.append(self._get_shift())

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -54,7 +54,7 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
         )
         self.seed = seed
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         return self.factor()
 
     def augment_image(self, image, transformation=None, **kwargs):

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -94,7 +94,7 @@ class RandomCutout(BaseImageAugmentationLayer):
         else:
             return type(factor)(0), factor
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, image=None, **kwargs):
         center_x, center_y = self._compute_rectangle_position(image)
         rectangle_height, rectangle_width = self._compute_rectangle_size(image)
         return center_x, center_y, rectangle_height, rectangle_width

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -58,7 +58,7 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
                     ", got {} ".format(type(self.kernel_size))
                 )
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         factor = self.factor()
         blur_v = RandomGaussianBlur.get_kernel(factor, self.y)
         blur_h = RandomGaussianBlur.get_kernel(factor, self.x)

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -55,8 +55,7 @@ class RandomHue(BaseImageAugmentationLayer):
         self.value_range = value_range
         self.seed = seed
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
-        del image, label, bounding_boxes
+    def get_random_transformation(self, **kwargs):
         invert = preprocessing.random_inversion(self._random_generator)
         # We must scale self.factor() to the range [-0.5, 0.5].  This is because the
         # tf.image operation performs rotation on the hue saturation value orientation.

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -109,7 +109,7 @@ class RandomRotation(BaseImageAugmentationLayer):
         self.seed = seed
         self.bounding_box_format = bounding_box_format
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         min_angle = self.lower * 2.0 * np.pi
         max_angle = self.upper * 2.0 * np.pi
         angle = self._random_generator.random_uniform(

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -50,8 +50,7 @@ class RandomSaturation(BaseImageAugmentationLayer):
         )
         self.seed = seed
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
-        del image, label, bounding_boxes
+    def get_random_transformation(self, **kwargs):
         return self.factor()
 
     def augment_image(self, image, transformation=None, **kwargs):

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -59,7 +59,7 @@ class RandomSharpness(BaseImageAugmentationLayer):
         self.factor = preprocessing.parse_factor(factor)
         self.seed = seed
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         return self.factor()
 
     def augment_image(self, image, transformation=None, **kwargs):

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -87,7 +87,7 @@ class RandomShear(BaseImageAugmentationLayer):
         self.fill_value = fill_value
         self.seed = seed
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         x = self._get_shear_amount(self.x_factor)
         y = self._get_shear_amount(self.y_factor)
         return (x, y)

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -86,7 +86,7 @@ class Solarization(BaseImageAugmentationLayer):
         )
         self.value_range = value_range
 
-    def get_random_transformation(self, image=None, label=None, bounding_boxes=None):
+    def get_random_transformation(self, **kwargs):
         return (self.addition_factor(), self.threshold_factor())
 
     def augment_image(self, image, transformation=None, **kwargs):


### PR DESCRIPTION
# What does this PR do?

* Adds a `BaseImageAugmentationLayer.augment_keypoints()` method 
* Adds `keypoint` argument to `BaseImageAugmentationLayer.get_random_transformation()`
* Adds support in layer derived from `keras_cv.layers.preprocessing.BaseImageAugmentationLayer` for the new `keypoint` argument by adding `**kwargs`. It aims to allow additional argument support to `get_random_transformation()` (i.e. `segmentation_mask`) without a need to modify every derived classes ( that would for sure not need to access the additional arguments to produce their transformation in 99% of cases).

Related to  #518


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests? -> No need to do additional tests at this point.

## Who can review?

Incremental PR for #518 as requested by @LukeWood 