### PR TITLE
Towards keypoint support: Adds no-op operations some on existing augmentation

### DIFF
--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -70,6 +70,12 @@ class AutoContrast(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update({"value_range": self.value_range})

--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -64,9 +64,6 @@ class AutoContrast(BaseImageAugmentationLayer):
         result = tf.where(tf.math.is_nan(result), original_image, result)
         return result
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -112,9 +112,6 @@ class Equalization(BaseImageAugmentationLayer):
         image = preprocessing.transform_value_range(image, (0, 255), self.value_range)
         return image
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -118,6 +118,12 @@ class Equalization(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update({"bins": self.bins, "value_range": self.value_range})

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -76,6 +76,12 @@ class Grayscale(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {
             "output_channels": self.output_channels,

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -70,9 +70,6 @@ class Grayscale(BaseImageAugmentationLayer):
         else:
             raise ValueError("Unsupported value for `output_channels`.")
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -241,6 +241,12 @@ class GridMask(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {
             "ratio_factor": self.ratio_factor,

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -235,9 +235,6 @@ class GridMask(BaseImageAugmentationLayer):
 
         return tf.where(mask, fill_value, image)
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/layers_configurations_test.py
+++ b/keras_cv/layers/preprocessing/layers_configurations_test.py
@@ -1,0 +1,93 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.layers import preprocessing
+
+# List of augmentation layers that do not modify
+# geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
+# is a No-Op.
+TEST_CONFIGURATIONS = [
+    ("AutoContrast", preprocessing.AutoContrast, {"value_range": (0, 255)}),
+    ("Equalization", preprocessing.Equalization, {"value_range": (0, 255)}),
+    ("Grayscale", preprocessing.Grayscale, {}),
+    ("GridMask", preprocessing.GridMask, {}),
+    (
+        "Posterization",
+        preprocessing.Posterization,
+        {"bits": 3, "value_range": (0, 255)},
+    ),
+    (
+        "RandomColorDegeneration",
+        preprocessing.RandomColorDegeneration,
+        {"factor": 0.5},
+    ),
+    (
+        "RandomCutout",
+        preprocessing.RandomCutout,
+        {"height_factor": 0.2, "width_factor": 0.2},
+    ),
+    (
+        "RandomHue",
+        preprocessing.RandomHue,
+        {"factor": 0.5, "value_range": (0, 255)},
+    ),
+    (
+        "RandomChannelShift",
+        preprocessing.RandomChannelShift,
+        {"value_range": (0, 255), "factor": 0.5},
+    ),
+    (
+        "RandomColorJitter",
+        preprocessing.RandomColorJitter,
+        {
+            "value_range": (0, 255),
+            "brightness_factor": (-0.2, 0.5),
+            "contrast_factor": (0.5, 0.9),
+            "saturation_factor": (0.5, 0.9),
+            "hue_factor": (0.5, 0.9),
+            "seed": 1,
+        },
+    ),
+    (
+        "RandomGaussianBlur",
+        preprocessing.RandomGaussianBlur,
+        {"kernel_size": 3, "factor": (0.0, 3.0)},
+    ),
+    ("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)}),
+    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
+    (
+        "RandomSharpness",
+        preprocessing.RandomSharpness,
+        {"factor": 0.5, "value_range": (0, 255)},
+    ),
+    ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
+]
+
+
+# List of augmentation layers that does modify
+# geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
+# are expected to modify bounding boxes or keypoints, and in that
+# would certainly requires extra construction arguments such as
+# `bounding_box_format`.
+GEOMETRIC_TEST_CONFIGURATIONS = [
+    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
+    (
+        "RandomResizedCrop",
+        preprocessing.RandomResizedCrop,
+        {
+            "target_size": (224, 224),
+            "crop_area_factor": (0.8, 1.0),
+            "aspect_ratio_factor": (3 / 4, 4 / 3),
+        },
+    ),
+]

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -106,6 +106,12 @@ class Posterization(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {"bits": 8 - self._shift, "value_range": self._value_range}
         base_config = super().get_config()

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -90,9 +90,6 @@ class Posterization(BaseImageAugmentationLayer):
             target_range=self._value_range,
         )
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def _batch_augment(self, inputs):
         # Skip the use of vectorized_map or map_fn as the implementation is already
         # vectorized

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -97,6 +97,12 @@ class RandomChannelShift(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -91,9 +91,6 @@ class RandomChannelShift(BaseImageAugmentationLayer):
         image = preprocessing.transform_value_range(result, (0, 1), self.value_range)
         return image
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -62,9 +62,6 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
         result = preprocessing.blend(image, degenerate, transformation)
         return result
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -68,6 +68,12 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update({"factor": self.factor, "seed": self.seed})

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -138,6 +138,12 @@ class RandomColorJitter(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -132,9 +132,6 @@ class RandomColorJitter(BaseImageAugmentationLayer):
         )
         return image
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -118,6 +118,12 @@ class RandomCutout(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def _compute_rectangle_position(self, inputs):
         input_shape = tf.shape(inputs)
         image_height, image_width = (

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -89,6 +89,12 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     @staticmethod
     def get_kernel(factor, filter_size):
         x = tf.cast(

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -83,9 +83,6 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
 
         return tf.squeeze(blurred, axis=0)
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -71,9 +71,6 @@ class RandomHue(BaseImageAugmentationLayer):
         image = preprocessing.transform_value_range(image, (0, 1), self.value_range)
         return image
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -77,6 +77,12 @@ class RandomHue(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {
             "factor": self.factor,

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -61,9 +61,6 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
         jpeg_quality = transformation
         return tf.image.adjust_jpeg_quality(image, jpeg_quality)
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -67,6 +67,12 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update({"factor": self.factor, "seed": self.seed})

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -77,6 +77,12 @@ class RandomSaturation(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {
             "factor": self.factor,

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -71,9 +71,6 @@ class RandomSaturation(BaseImageAugmentationLayer):
         adjust_factor = transformation / (1 - transformation)
         return tf.image.adjust_saturation(image, saturation_factor=adjust_factor)
 
-    def augment_bounding_boxes(self, bounding_boxes, transformation=None, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -117,6 +117,12 @@ class RandomSharpness(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -111,9 +111,6 @@ class RandomSharpness(BaseImageAugmentationLayer):
         )
         return result
 
-    def augment_bounding_boxes(self, bounding_boxes, transformation, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -109,6 +109,12 @@ class Solarization(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_keypoints(self, keypoints, **kwargs):
+        return keypoints
+
     def get_config(self):
         config = {
             "threshold_factor": self.threshold_factor,

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -103,9 +103,6 @@ class Solarization(BaseImageAugmentationLayer):
         )
         return result
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
-        return bounding_boxes
-
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -15,12 +15,19 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv.layers import preprocessing
+
+# Imports from with_labels the list of augmentation that should perform a No-Op.
 from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+
+# List here the layers that are expected to modify bounding boxes with
+# their specific parameters.
+GEOMETRIC_TEST_CONFIGURATIONS = []
 
 
 class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         *TEST_CONFIGURATIONS,
+        *GEOMETRIC_TEST_CONFIGURATIONS,
         ("CutMix", preprocessing.CutMix, {}),
     )
     def test_can_run_with_bounding_boxes(self, layer_cls, init_args):
@@ -37,7 +44,10 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
         self.assertTrue("bounding_boxes" in outputs)
 
     # this has to be a separate test case to exclude CutMix and MixUp
-    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    @parameterized.named_parameters(
+        *TEST_CONFIGURATIONS,
+        *GEOMETRIC_TEST_CONFIGURATIONS,
+    )
     def test_can_run_with_bouding_boxes_single_image(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
         img = tf.random.uniform(

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -1,0 +1,37 @@
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.layers import preprocessing
+from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+
+
+class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        *TEST_CONFIGURATIONS,
+        ("CutMix", preprocessing.CutMix, {}),
+    )
+    def test_can_run_with_bounding_boxes(self, layer_cls, init_args):
+        layer = layer_cls(**init_args)
+
+        img = tf.random.uniform(
+            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
+        )
+        labels = tf.ones((3, 2), dtype=tf.float32)
+        bounding_boxes = tf.ones((3, 2, 4), dtype=tf.float32)
+
+        inputs = {"images": img, "labels": labels, "bounding_boxes": bounding_boxes}
+        outputs = layer(inputs)
+        self.assertTrue("bounding_boxes" in outputs)
+
+    # this has to be a separate test case to exclude CutMix and MixUp
+    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    def test_can_run_with_bouding_boxes_single_image(self, layer_cls, init_args):
+        layer = layer_cls(**init_args)
+        img = tf.random.uniform(
+            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
+        )
+        labels = tf.ones((3), dtype=tf.float32)
+        bounding_boxes = tf.ones((3, 4), dtype=tf.float32)
+        inputs = {"images": img, "labels": labels, "bounding_boxes": bounding_boxes}
+        outputs = layer(inputs)
+        self.assertTrue("bounding_boxes" in outputs)

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -42,9 +42,7 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
     def test_can_run_with_bounding_boxes(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
 
-        img = tf.random.uniform(
-            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
-        )
+        img = tf.ones(shape=(3, 4, 4, 3), dtype=tf.float32)
         bounding_boxes = tf.ones((3, 2, 4), dtype=tf.float32)
 
         inputs = {"images": img, "bounding_boxes": bounding_boxes}
@@ -58,9 +56,7 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_can_run_with_bouding_boxes_single_image(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
-        img = tf.random.uniform(
-            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
-        )
+        img = tf.ones(shape=(4, 4, 3), dtype=tf.float32)
         bounding_boxes = tf.ones((3, 4), dtype=tf.float32)
         inputs = {"images": img, "bounding_boxes": bounding_boxes}
         outputs = layer(inputs)
@@ -69,7 +65,7 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
     # CutMix needs labels data
     def test_cut_mix_keeps_bounding_box_data(self):
         layer = preprocessing.CutMix()
-        img = tf.ones(shape=(3, 512, 512, 3), dtype=tf.float32)
+        img = tf.ones(shape=(3, 4, 4, 3), dtype=tf.float32)
         labels = tf.ones((3), dtype=tf.float32)
         bounding_boxes = tf.reshape(
             tf.range(3 * 2 * 4, dtype=tf.float32), shape=(3, 2, 4)

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -21,7 +21,17 @@ from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
 
 # List here the layers that are expected to modify bounding boxes with
 # their specific parameters.
-GEOMETRIC_TEST_CONFIGURATIONS = []
+GEOMETRIC_TEST_CONFIGURATIONS = [
+    (
+        "RandomShear",
+        preprocessing.RandomShear,
+        {
+            "x_factor": 0.3,
+            "x_factor": 0.3,
+            "bounding_box_format": "xyxy",
+        },
+    ),
+]
 
 
 class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -38,7 +38,6 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         *TEST_CONFIGURATIONS,
         *GEOMETRIC_TEST_CONFIGURATIONS,
-        ("CutMix", preprocessing.CutMix, {}),
     )
     def test_can_run_with_bounding_boxes(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
@@ -66,3 +65,15 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
         inputs = {"images": img, "bounding_boxes": bounding_boxes}
         outputs = layer(inputs)
         self.assertTrue("bounding_boxes" in outputs)
+
+    # CutMix needs labels data
+    def test_cut_mix_keeps_bounding_box_data(self):
+        layer = preprocessing.CutMix()
+        img = tf.ones(shape=(3, 512, 512, 3), dtype=tf.float32)
+        labels = tf.ones((3), dtype=tf.float32)
+        bounding_boxes = tf.reshape(
+            tf.range(3 * 2 * 4, dtype=tf.float32), shape=(3, 2, 4)
+        )
+        inputs = {"images": img, "bounding_boxes": bounding_boxes, "labels": labels}
+        outputs = layer(inputs)
+        self.assertAllEqual(inputs["bounding_boxes"], outputs["bounding_boxes"])

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -46,10 +46,9 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((3, 2), dtype=tf.float32)
         bounding_boxes = tf.ones((3, 2, 4), dtype=tf.float32)
 
-        inputs = {"images": img, "labels": labels, "bounding_boxes": bounding_boxes}
+        inputs = {"images": img, "bounding_boxes": bounding_boxes}
         outputs = layer(inputs)
         self.assertTrue("bounding_boxes" in outputs)
 
@@ -63,8 +62,7 @@ class WithBoundingBoxesTest(tf.test.TestCase, parameterized.TestCase):
         img = tf.random.uniform(
             shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((3), dtype=tf.float32)
         bounding_boxes = tf.ones((3, 4), dtype=tf.float32)
-        inputs = {"images": img, "labels": labels, "bounding_boxes": bounding_boxes}
+        inputs = {"images": img, "bounding_boxes": bounding_boxes}
         outputs = layer(inputs)
         self.assertTrue("bounding_boxes" in outputs)

--- a/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing/with_bounding_boxes_test.py
@@ -17,7 +17,7 @@ from absl.testing import parameterized
 from keras_cv.layers import preprocessing
 
 # Imports from with_labels the list of augmentation that should perform a No-Op.
-from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+from keras_cv.layers.preprocessing.layers_configurations_test import TEST_CONFIGURATIONS
 
 # List here the layers that are expected to modify bounding boxes with
 # their specific parameters.

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -1,0 +1,41 @@
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.layers import preprocessing
+from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+
+
+class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(
+        *TEST_CONFIGURATIONS,
+        ("CutMix", preprocessing.CutMix, {}),
+    )
+    def test_can_run_with_keypoints(self, layer_cls, init_args):
+        if "clip_points_to_image_size" in init_args:
+            init_args["clip_points_to_image_size"] = False
+        layer = layer_cls(**init_args)
+
+        img = tf.random.uniform(
+            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
+        )
+        labels = tf.ones((3, 2), dtype=tf.float32)
+        keypoints = tf.ones((3, 2, 6, 2), dtype=tf.float32)
+
+        inputs = {"images": img, "labels": labels, "keypoints": keypoints}
+        outputs = layer(inputs)
+        self.assertTrue("keypoints" in outputs)
+
+    # this has to be a separate test case to exclude CutMix and MixUp
+    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    def test_can_run_with_keypoints_single_image(self, layer_cls, init_args):
+        if "clip_points_to_image_size" in init_args:
+            init_args["clip_points_to_image_size"] = True
+        layer = layer_cls(**init_args)
+        img = tf.random.uniform(
+            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
+        )
+        labels = tf.ones((3), dtype=tf.float32)
+        keypoints = tf.ones((3, 8, 2), dtype=tf.float32)
+        inputs = {"images": img, "labels": labels, "keypoints": keypoints}
+        outputs = layer(inputs)
+        self.assertTrue("keypoints" in outputs)

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -15,12 +15,19 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv.layers import preprocessing
+
+# Imports from with_labels the list of augmentation that should perform a No-Op.
 from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+
+# List here the layers that are expected to modify keypoints with
+# their specific parameters.
+GEOMETRIC_TEST_CONFIGURATIONS = []
 
 
 class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         *TEST_CONFIGURATIONS,
+        *GEOMETRIC_TEST_CONFIGURATIONS,
         ("CutMix", preprocessing.CutMix, {}),
     )
     def test_can_run_with_keypoints(self, layer_cls, init_args):
@@ -39,7 +46,10 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
         self.assertTrue("keypoints" in outputs)
 
     # this has to be a separate test case to exclude CutMix and MixUp
-    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    @parameterized.named_parameters(
+        *TEST_CONFIGURATIONS,
+        *GEOMETRIC_TEST_CONFIGURATIONS,
+    )
     def test_can_run_with_keypoints_single_image(self, layer_cls, init_args):
         if "clip_points_to_image_size" in init_args:
             init_args["clip_points_to_image_size"] = True

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -17,7 +17,7 @@ from absl.testing import parameterized
 from keras_cv.layers import preprocessing
 
 # Imports from with_labels the list of augmentation that should perform a No-Op.
-from keras_cv.layers.preprocessing.with_labels_test import TEST_CONFIGURATIONS
+from keras_cv.layers.preprocessing.layers_configurations_test import TEST_CONFIGURATIONS
 
 # List here the layers that are expected to modify keypoints with
 # their specific parameters.

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -28,7 +28,6 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         *TEST_CONFIGURATIONS,
         *GEOMETRIC_TEST_CONFIGURATIONS,
-        ("CutMix", preprocessing.CutMix, {}),
     )
     def test_can_run_with_keypoints(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
@@ -56,3 +55,15 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
         inputs = {"images": img, "keypoints": keypoints}
         outputs = layer(inputs)
         self.assertTrue("keypoints" in outputs)
+
+    # CutMix needs labels data
+    def test_cut_mix_keeps_keypoints_data(self):
+        layer = preprocessing.CutMix()
+        img = tf.ones(shape=(3, 512, 512, 3), dtype=tf.float32)
+        labels = tf.ones((3), dtype=tf.float32)
+        keypoints = tf.reshape(
+            tf.range(3 * 2 * 6 * 2, dtype=tf.float32), shape=(3, 2, 6, 2)
+        )
+        inputs = {"images": img, "keypoints": keypoints, "labels": labels}
+        outputs = layer(inputs)
+        self.assertAllEqual(inputs["keypoints"], outputs["keypoints"])

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -31,17 +31,14 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
         ("CutMix", preprocessing.CutMix, {}),
     )
     def test_can_run_with_keypoints(self, layer_cls, init_args):
-        if "clip_points_to_image_size" in init_args:
-            init_args["clip_points_to_image_size"] = False
         layer = layer_cls(**init_args)
 
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((3, 2), dtype=tf.float32)
         keypoints = tf.ones((3, 2, 6, 2), dtype=tf.float32)
 
-        inputs = {"images": img, "labels": labels, "keypoints": keypoints}
+        inputs = {"images": img, "keypoints": keypoints}
         outputs = layer(inputs)
         self.assertTrue("keypoints" in outputs)
 
@@ -51,14 +48,11 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
         *GEOMETRIC_TEST_CONFIGURATIONS,
     )
     def test_can_run_with_keypoints_single_image(self, layer_cls, init_args):
-        if "clip_points_to_image_size" in init_args:
-            init_args["clip_points_to_image_size"] = True
         layer = layer_cls(**init_args)
         img = tf.random.uniform(
             shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((3), dtype=tf.float32)
         keypoints = tf.ones((3, 8, 2), dtype=tf.float32)
-        inputs = {"images": img, "labels": labels, "keypoints": keypoints}
+        inputs = {"images": img, "keypoints": keypoints}
         outputs = layer(inputs)
         self.assertTrue("keypoints" in outputs)

--- a/keras_cv/layers/preprocessing/with_keypoints_test.py
+++ b/keras_cv/layers/preprocessing/with_keypoints_test.py
@@ -32,9 +32,7 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
     def test_can_run_with_keypoints(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
 
-        img = tf.random.uniform(
-            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
-        )
+        img = tf.ones(shape=(3, 4, 4, 3), dtype=tf.float32)
         keypoints = tf.ones((3, 2, 6, 2), dtype=tf.float32)
 
         inputs = {"images": img, "keypoints": keypoints}
@@ -48,9 +46,7 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_can_run_with_keypoints_single_image(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
-        img = tf.random.uniform(
-            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
-        )
+        img = tf.ones(shape=(4, 4, 3), dtype=tf.float32)
         keypoints = tf.ones((3, 8, 2), dtype=tf.float32)
         inputs = {"images": img, "keypoints": keypoints}
         outputs = layer(inputs)
@@ -59,7 +55,7 @@ class WithKeypointsTest(tf.test.TestCase, parameterized.TestCase):
     # CutMix needs labels data
     def test_cut_mix_keeps_keypoints_data(self):
         layer = preprocessing.CutMix()
-        img = tf.ones(shape=(3, 512, 512, 3), dtype=tf.float32)
+        img = tf.ones(shape=(3, 4, 4, 3), dtype=tf.float32)
         labels = tf.ones((3), dtype=tf.float32)
         keypoints = tf.reshape(
             tf.range(3 * 2 * 6 * 2, dtype=tf.float32), shape=(3, 2, 6, 2)

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -79,7 +79,7 @@ TEST_CONFIGURATIONS = [
 
 # List of augmentation layers that does modify
 # geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
-# is a No-Op.
+# are expected to modify bounding boxes or keypoints.
 GEOMETRIC_TEST_CONFIGURATIONS = [
     (
         "RandomResizedCrop",

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -15,82 +15,10 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv.layers import preprocessing
-
-# List of augmentation layers that do not modify
-# geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
-# is a No-Op.
-TEST_CONFIGURATIONS = [
-    ("AutoContrast", preprocessing.AutoContrast, {"value_range": (0, 255)}),
-    ("Equalization", preprocessing.Equalization, {"value_range": (0, 255)}),
-    ("Grayscale", preprocessing.Grayscale, {}),
-    ("GridMask", preprocessing.GridMask, {}),
-    (
-        "Posterization",
-        preprocessing.Posterization,
-        {"bits": 3, "value_range": (0, 255)},
-    ),
-    (
-        "RandomColorDegeneration",
-        preprocessing.RandomColorDegeneration,
-        {"factor": 0.5},
-    ),
-    (
-        "RandomCutout",
-        preprocessing.RandomCutout,
-        {"height_factor": 0.2, "width_factor": 0.2},
-    ),
-    (
-        "RandomHue",
-        preprocessing.RandomHue,
-        {"factor": 0.5, "value_range": (0, 255)},
-    ),
-    (
-        "RandomChannelShift",
-        preprocessing.RandomChannelShift,
-        {"value_range": (0, 255), "factor": 0.5},
-    ),
-    (
-        "RandomColorJitter",
-        preprocessing.RandomColorJitter,
-        {
-            "value_range": (0, 255),
-            "brightness_factor": (-0.2, 0.5),
-            "contrast_factor": (0.5, 0.9),
-            "saturation_factor": (0.5, 0.9),
-            "hue_factor": (0.5, 0.9),
-            "seed": 1,
-        },
-    ),
-    (
-        "RandomGaussianBlur",
-        preprocessing.RandomGaussianBlur,
-        {"kernel_size": 3, "factor": (0.0, 3.0)},
-    ),
-    ("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)}),
-    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
-    (
-        "RandomSharpness",
-        preprocessing.RandomSharpness,
-        {"factor": 0.5, "value_range": (0, 255)},
-    ),
-    ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
-]
-
-# List of augmentation layers that does modify
-# geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
-# are expected to modify bounding boxes or keypoints.
-GEOMETRIC_TEST_CONFIGURATIONS = [
-    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
-    (
-        "RandomResizedCrop",
-        preprocessing.RandomResizedCrop,
-        {
-            "target_size": (224, 224),
-            "crop_area_factor": (0.8, 1.0),
-            "aspect_ratio_factor": (3 / 4, 4 / 3),
-        },
-    ),
-]
+from keras_cv.layers.preprocessing.layers_configurations_test import (
+    GEOMETRIC_TEST_CONFIGURATIONS,
+)
+from keras_cv.layers.preprocessing.layers_configurations_test import TEST_CONFIGURATIONS
 
 
 class WithLabelsTest(tf.test.TestCase, parameterized.TestCase):

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -73,7 +73,6 @@ TEST_CONFIGURATIONS = [
         preprocessing.RandomSharpness,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
-    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
     ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
 ]
 
@@ -81,6 +80,7 @@ TEST_CONFIGURATIONS = [
 # geometry. i.e. `augment_bounding_boxes()` and `augment_keypoints()`
 # are expected to modify bounding boxes or keypoints.
 GEOMETRIC_TEST_CONFIGURATIONS = [
+    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
     (
         "RandomResizedCrop",
         preprocessing.RandomResizedCrop,


### PR DESCRIPTION
# What does this PR do?

Adds keypoints bounding_boxes no-op operations.

It does so by adding `with_keypoints.py` and `with_bounding_boxes.py` tests that ensure all augmentation supports these augmentations

Related to #518

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

Incremental PR as requested by @LukeWood 

