### PR TITLE
Utilities for handling Run-length-encoded Segmentation Maps

### DIFF
--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -25,6 +25,14 @@ def rle_to_mask2d(mask_rle, shape):
 
     Returns:
       mask: 2-dimensional segmentation map.
+    
+    Reference:
+      - [StackOverflow Answer by jdehesa](https://stackoverflow.com/questions/58693261/decoding-rle-run-length-encoding-mask-with-tensorflow-datasets/58842473#58842473)
+    
+    Sample Usage:
+    ```python
+    sample_mask = rle_to_mask2d(sample_rle, shape=(768, 768))
+    ```
     """
     shape = tf.convert_to_tensor(shape, tf.int64)
     size = tf.math.reduce_prod(shape)
@@ -65,6 +73,11 @@ def mask2d_to_rle(mask):
 
     Returns:
       mask_rle: a string that represents the run-length encoded segmentation map.
+    
+    Sample Usage:
+    ```python
+    sample_rle_mask = mask2d_to_rle(sample_mask)
+    ```
     """
     # Transpose the mask
     mask = tf.transpose(mask).numpy()

--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -16,7 +16,7 @@ import numpy as np
 import tensorflow as tf
 
 
-def rle_to_mask2d(mask_rle: str, shape) -> tf.Tensor:
+def rle_to_mask2d(mask_rle, shape):
     """Converts a Run-length encoded segmentation map to a 2-dimensional segmentation map.
 
     Args:
@@ -51,7 +51,7 @@ def rle_to_mask2d(mask_rle: str, shape) -> tf.Tensor:
     return mask
 
 
-def mask2d_to_rle(mask: tf.Tensor) -> str:
+def mask2d_to_rle(mask):
     """Converts a 2-dimensional segmentation map to a Run-length encoded segmentation map.
 
     Args:

--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -8,7 +8,7 @@ def rle_to_mask2d(mask_rle: str, shape) -> tf.Tensor:
     Args:
       mask_rle: a string that represents a run-length encoded segmentation map.
       shape: shape of the resultant 2-dimensional segmentation map.
-    
+
     Returns:
       mask: 2-dimensional segmentation map.
     """
@@ -26,14 +26,14 @@ def rle_to_mask2d(mask_rle: str, shape) -> tf.Tensor:
     # Make scattering indices
     r = tf.range(total_ones)
     cumulative_sum_of_lengths = tf.math.cumsum(lengths)
-    s = tf.searchsorted(cumulative_sum_of_lengths, r, 'right')
+    s = tf.searchsorted(cumulative_sum_of_lengths, r, "right")
     idx = r + tf.gather(
         starts - tf.pad(cumulative_sum_of_lengths[:-1], [(1, 0)]), s
-    ) # Search where r goes in cumulative_sum_of_lengths
+    )  # Search where r goes in cumulative_sum_of_lengths
     # Scatter ones into flattened mask
     mask_flat = tf.scatter_nd(tf.expand_dims(idx, 1), ones, [size])
     # Transpose and Reshape into mask
-    mask =  tf.transpose(tf.reshape(mask_flat, shape))
+    mask = tf.transpose(tf.reshape(mask_flat, shape))
     return mask
 
 
@@ -42,7 +42,7 @@ def mask2d_to_rle(mask: tf.Tensor) -> str:
 
     Args:
       mask: a tensor that represents a 2-dimensional segmentation map.
-    
+
     Returns:
       mask_rle: a string that represents the run-length encoded segmentation map.
     """
@@ -51,5 +51,5 @@ def mask2d_to_rle(mask: tf.Tensor) -> str:
     pixels = np.concatenate([[0], pixels, [0]])
     runs = np.where(pixels[1:] != pixels[:-1])[0] + 1
     runs[1::2] -= runs[::2]
-    mask_rle = ' '.join(str(x) for x in runs)
+    mask_rle = " ".join(str(x) for x in runs)
     return mask_rle

--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -1,0 +1,55 @@
+import numpy as np
+import tensorflow as tf
+
+
+def rle_to_mask2d(mask_rle: str, shape) -> tf.Tensor:
+    """Converts a Run-length encoded segmentation map to a 2-dimensional segmentation map.
+
+    Args:
+      mask_rle: a string that represents a run-length encoded segmentation map.
+      shape: shape of the resultant 2-dimensional segmentation map.
+    
+    Returns:
+      mask: 2-dimensional segmentation map.
+    """
+    shape = tf.convert_to_tensor(shape, tf.int64)
+    size = tf.math.reduce_prod(shape)
+    # Split string
+    s = tf.strings.split(mask_rle)
+    s = tf.strings.to_number(s, tf.int64)
+    # Get starts and lengths
+    starts = s[::2] - 1
+    lengths = s[1::2]
+    # Make ones to be scattered
+    total_ones = tf.reduce_sum(lengths)
+    ones = tf.ones([total_ones], tf.uint8)
+    # Make scattering indices
+    r = tf.range(total_ones)
+    cumulative_sum_of_lengths = tf.math.cumsum(lengths)
+    s = tf.searchsorted(cumulative_sum_of_lengths, r, 'right')
+    idx = r + tf.gather(
+        starts - tf.pad(cumulative_sum_of_lengths[:-1], [(1, 0)]), s
+    ) # Search where r goes in cumulative_sum_of_lengths
+    # Scatter ones into flattened mask
+    mask_flat = tf.scatter_nd(tf.expand_dims(idx, 1), ones, [size])
+    # Transpose and Reshape into mask
+    mask =  tf.transpose(tf.reshape(mask_flat, shape))
+    return mask
+
+
+def mask2d_to_rle(mask: tf.Tensor) -> str:
+    """Converts a 2-dimensional segmentation map to a Run-length encoded segmentation map.
+
+    Args:
+      mask: a tensor that represents a 2-dimensional segmentation map.
+    
+    Returns:
+      mask_rle: a string that represents the run-length encoded segmentation map.
+    """
+    mask = tf.transpose(mask).numpy()
+    pixels = mask.flatten()
+    pixels = np.concatenate([[0], pixels, [0]])
+    runs = np.where(pixels[1:] != pixels[:-1])[0] + 1
+    runs[1::2] -= runs[::2]
+    mask_rle = ' '.join(str(x) for x in runs)
+    return mask_rle

--- a/keras_cv/utils/rle_utils.py
+++ b/keras_cv/utils/rle_utils.py
@@ -26,6 +26,9 @@ def rle_to_mask2d(mask_rle, shape):
     Returns:
       mask: 2-dimensional segmentation map.
     
+    Raises:
+      ValueError if the resultant flattened mask cannot be reshaped to `shape`.
+    
     Reference:
       - [StackOverflow Answer by jdehesa](https://stackoverflow.com/questions/58693261/decoding-rle-run-length-encoding-mask-with-tensorflow-datasets/58842473#58842473)
     
@@ -61,7 +64,11 @@ def rle_to_mask2d(mask_rle, shape):
     mask_flat = tf.scatter_nd(tf.expand_dims(idx, 1), ones, [size])
     
     # Transpose and Reshape into mask
-    mask = tf.transpose(tf.reshape(mask_flat, shape))
+    try:
+        reshaped_mask = tf.reshape(mask_flat, shape)
+    except ValueError as value_error:
+        print(value_error)
+    mask = tf.transpose(reshaped_mask)
     return mask
 
 


### PR DESCRIPTION
# Utilities Added

- A function `rle_to_mask2d` is added that converts a Run-length encoded segmentation map to a 2-dimensional segmentation map. This function was adapted from [this StackOverflow answer](https://stackoverflow.com/a/58842473/8209968).
- A function `mask2d_to_rle` is added that converts a 2-dimensional segmentation map to a Run-length encoded segmentation map.

**Demo Notebook:** https://colab.research.google.com/drive/17ilyBukuAwwG1h7paB-JCGPmKP2zBqoV?usp=sharing

PR related to https://github.com/keras-team/keras-cv/issues/533 and https://github.com/keras-team/keras-cv/issues/327

CC: @LukeWood @tanzhenyu @sayakpaul @innat [@ayulockin](https://github.com/ayulockin)