### PR TITLE
Improves `serialization_test.py` to cover all argument with default values

### DIFF
--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -21,7 +21,6 @@ from tensorflow.keras.layers import RandomContrast
 from tensorflow.keras.layers import RandomCrop
 from tensorflow.keras.layers import RandomFlip
 from tensorflow.keras.layers import RandomHeight
-from tensorflow.keras.layers import RandomRotation
 from tensorflow.keras.layers import RandomTranslation
 from tensorflow.keras.layers import RandomWidth
 from tensorflow.keras.layers import RandomZoom
@@ -57,6 +56,7 @@ from keras_cv.layers.preprocessing.random_gaussian_blur import RandomGaussianBlu
 from keras_cv.layers.preprocessing.random_hue import RandomHue
 from keras_cv.layers.preprocessing.random_jpeg_quality import RandomJpegQuality
 from keras_cv.layers.preprocessing.random_resized_crop import RandomResizedCrop
+from keras_cv.layers.preprocessing.random_rotation import RandomRotation
 from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -107,6 +107,7 @@ class RandomAugmentationPipeline(BaseImageAugmentationLayer):
         config.update(
             {
                 "augmentations_per_image": self.augmentations_per_image,
+                "auto_vectorize": self.auto_vectorize,
                 "rate": self.rate,
                 "layers": self.layers,
                 "seed": self.seed,

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -66,5 +66,5 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
 
     def get_config(self):
         config = super().get_config()
-        config.update({"factor": self.factor})
+        config.update({"factor": self.factor, "seed": self.seed})
         return config

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -222,6 +222,7 @@ class RandomRotation(BaseImageAugmentationLayer):
             "fill_mode": self.fill_mode,
             "fill_value": self.fill_value,
             "interpolation": self.interpolation,
+            "bounding_box_format": self.bounding_box_format,
             "seed": self.seed,
         }
         base_config = super().get_config()

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -78,6 +78,7 @@ class Solarization(BaseImageAugmentationLayer):
         **kwargs
     ):
         super().__init__(seed=seed, **kwargs)
+        self.seed = seed
         self.addition_factor = preprocessing.parse_factor(
             addition_factor, max_value=255, seed=seed, param_name="addition_factor"
         )
@@ -110,6 +111,7 @@ class Solarization(BaseImageAugmentationLayer):
             "threshold_factor": self.threshold_factor,
             "addition_factor": self.addition_factor,
             "value_range": self.value_range,
+            "seed": self.seed,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))


### PR DESCRIPTION
# What does this PR do?

While working on `RandomRotation` I remarked that the serialization of some layers is inaccurate, as they are not saving some default argument. By example, in the case of `RandomRotation`, it is `bounding_box_format`, but for `RandomJpegQuality` it is `seed`.

There is a check for the presence of `seed`, but only if it is passed in the `init_args` of serialization test. If a test configuration for a new layer with a `seed` parameter is added , but no `seed` parameter is added in the `serialization_test.py` `init_args`, then the test is skipped.

This PR solves this issue, by looking at the init parameters of the layers, and ensuring all of them are returned by the `get_config()` method of the added layer. Therefore this would be a regression test if a new parameter is added to an existent layer,  but no additional key is added to `get_config()` return value. In that case the parameter check would be covered, without the need to add the new parameter to `serialization_test.py`. In fact with this version, `init_args` in `serialization_test.py` should only contain non-default argument of each layers and nothing else. In contrast with the current version where it should contain _non default values_ for each of the arguments to cover all serializations scenarios.


List of missing parameters in serialization fixed by this PR:
 * `RandomRotation` : `bounding_box_format`
 * `RandomJpegQuality` : `seed`
 * `Solarization` : `seed`
 * `RandomAugmentationPipeline` : `auto_vectorized`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

@LukeWood and @tanzhenyu 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
