### PR TITLE
`classifier_activation` docstring corrections

### DIFF
--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -87,8 +87,7 @@ def CSPDarkNet(
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.
-            When loading pretrained weights, `classifier_activation` can only
-            be `None` or `"softmax"`.
+
         name: (Optional) name to pass to the model.  Defaults to "DarkNet".
     Returns:
         A `keras.Model` instance.

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -112,8 +112,7 @@ def DarkNet(
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.
-            When loading pretrained weights, `classifier_activation` can only
-            be `None` or `"softmax"`.
+
         name: (Optional) name to pass to the model.  Defaults to "DarkNet".
     Returns:
         A `keras.Model` instance.

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -192,8 +192,7 @@ def DenseNet(
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.
-            When loading pretrained weights, `classifier_activation` can only
-            be `None` or `"softmax"`.
+
         name: (Optional) name to pass to the model.  Defaults to "DenseNet".
 
     Returns:

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -75,6 +75,9 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
                 be a 2D tensor.
             - `max` means that global max pooling will be applied.
         name: (Optional) name to pass to the model.  Defaults to "{name}".
+        classifier_activation: A `str` or callable. The activation function to use
+            on the "top" layer. Ignored unless `include_top=True`. Set
+            `classifier_activation=None` to return the logits of the "top" layer.
     Returns:
       A `keras.Model` instance.
 """
@@ -172,37 +175,35 @@ def ResNet(
     """Instantiates the ResNet architecture.
 
     Args:
-      stackwise_filters: number of filters for each stack in the model.
-      stackwise_blocks: number of blocks for each stack in the model.
-      stackwise_strides: stride for each stack in the model.
-      include_rescaling: whether or not to Rescale the inputs. If set to True,
-        inputs will be passed through a `Rescaling(1/255.0)` layer.
-      name: string, model name.
-      include_top: whether to include the fully-connected
-        layer at the top of the network.
-      weights: one of `None` (random initialization),
-        or the path to the weights file to be loaded.
-      input_shape: optional shape tuple, defaults to (None, None, 3).
-      pooling: optional pooling mode for feature extraction
-        when `include_top` is `False`.
-        - `None` means that the output of the model will be
-            the 4D tensor output of the
-            last convolutional layer.
-        - `avg` means that global average pooling
-            will be applied to the output of the
-            last convolutional layer, and thus
-            the output of the model will be a 2D tensor.
-        - `max` means that global max pooling will
-            be applied.
-      num_classes: optional number of classes to classify images
-        into, only to be specified if `include_top` is True, and
-        if no `weights` argument is specified.
-      classifier_activation: A `str` or callable. The activation function to use
-        on the "top" layer. Ignored unless `include_top=True`. Set
-        `classifier_activation=None` to return the logits of the "top" layer.
-        When loading pretrained weights, `classifier_activation` can only
-        be `None` or `"softmax"`.
-      **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
+        stackwise_filters: number of filters for each stack in the model.
+        stackwise_blocks: number of blocks for each stack in the model.
+        stackwise_strides: stride for each stack in the model.
+        include_rescaling: whether or not to Rescale the inputs. If set to True,
+            inputs will be passed through a `Rescaling(1/255.0)` layer.
+            name: string, model name.
+        include_top: whether to include the fully-connected
+            layer at the top of the network.
+        weights: one of `None` (random initialization),
+            or the path to the weights file to be loaded.
+        input_shape: optional shape tuple, defaults to (None, None, 3).
+        pooling: optional pooling mode for feature extraction
+            when `include_top` is `False`.
+            - `None` means that the output of the model will be
+                the 4D tensor output of the
+                last convolutional layer.
+            - `avg` means that global average pooling
+                will be applied to the output of the
+                last convolutional layer, and thus
+                the output of the model will be a 2D tensor.
+            - `max` means that global max pooling will
+                be applied.
+        num_classes: optional number of classes to classify images
+            into, only to be specified if `include_top` is True, and
+            if no `weights` argument is specified.
+        classifier_activation: A `str` or callable. The activation function to use
+            on the "top" layer. Ignored unless `include_top=True`. Set
+            `classifier_activation=None` to return the logits of the "top" layer.
+        **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
 
     Returns:
       A `keras.Model` instance.

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -74,6 +74,9 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
                 be a 2D tensor.
             - `max` means that global max pooling will be applied.
         name: (Optional) name to pass to the model.  Defaults to "{name}".
+        classifier_activation: A `str` or callable. The activation function to use
+            on the "top" layer. Ignored unless `include_top=True`. Set
+            `classifier_activation=None` to return the logits of the "top" layer.
     Returns:
       A `keras.Model` instance.
 """
@@ -178,37 +181,35 @@ def ResNetV2(
     """Instantiates the ResNetV2 architecture.
 
     Args:
-      stackwise_filters: number of filters for each stack in the model.
-      stackwise_blocks: number of blocks for each stack in the model.
-      stackwise_strides: stride for each stack in the model.
-      include_rescaling: whether or not to Rescale the inputs. If set to True,
-        inputs will be passed through a `Rescaling(1/255.0)` layer.
-      name: string, model name.
-      include_top: whether to include the fully-connected
-        layer at the top of the network.
-      weights: one of `None` (random initialization),
-        or the path to the weights file to be loaded.
-      input_shape: optional shape tuple, defaults to (None, None, 3).
-      pooling: optional pooling mode for feature extraction
-        when `include_top` is `False`.
-        - `None` means that the output of the model will be
-            the 4D tensor output of the
-            last convolutional layer.
-        - `avg` means that global average pooling
-            will be applied to the output of the
-            last convolutional layer, and thus
-            the output of the model will be a 2D tensor.
-        - `max` means that global max pooling will
-            be applied.
-      num_classes: optional number of classes to classify images
-        into, only to be specified if `include_top` is True, and
-        if no `weights` argument is specified.
-      classifier_activation: A `str` or callable. The activation function to use
-        on the "top" layer. Ignored unless `include_top=True`. Set
-        `classifier_activation=None` to return the logits of the "top" layer.
-        When loading pretrained weights, `classifier_activation` can only
-        be `None` or `"softmax"`.
-      **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
+        stackwise_filters: number of filters for each stack in the model.
+        stackwise_blocks: number of blocks for each stack in the model.
+        stackwise_strides: stride for each stack in the model.
+        include_rescaling: whether or not to Rescale the inputs. If set to True,
+            inputs will be passed through a `Rescaling(1/255.0)` layer.
+            name: string, model name.
+        include_top: whether to include the fully-connected
+            layer at the top of the network.
+        weights: one of `None` (random initialization),
+            or the path to the weights file to be loaded.
+        input_shape: optional shape tuple, defaults to (None, None, 3).
+        pooling: optional pooling mode for feature extraction
+            when `include_top` is `False`.
+            - `None` means that the output of the model will be
+                the 4D tensor output of the
+                last convolutional layer.
+            - `avg` means that global average pooling
+                will be applied to the output of the
+                last convolutional layer, and thus
+                the output of the model will be a 2D tensor.
+            - `max` means that global max pooling will
+                be applied.
+        num_classes: optional number of classes to classify images
+            into, only to be specified if `include_top` is True, and
+            if no `weights` argument is specified.
+        classifier_activation: A `str` or callable. The activation function to use
+            on the "top" layer. Ignored unless `include_top=True`. Set
+            `classifier_activation=None` to return the logits of the "top" layer.
+        **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
 
     Returns:
       A `keras.Model` instance.


### PR DESCRIPTION
@LukeWood @ianjjohnson 

Minor corrections to docstrings:
1. Removed the following since pretrained weights are not relevant right now: `When loading pretrained weights, ``classifier_activation`` can only be ``None`` or ``"softmax"``.` 
2. Fixed indentation of the docstring is `resnet` files.
3. Included `classifier_activation` in the main ResNet docstring.