### PR TITLE
Style changes to NMS layer

### DIFF
--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -124,13 +124,13 @@ class NonMaxSuppression(tf.keras.layers.Layer):
         # output will be a ragged tensor because num_boxes will change across the batch
         boxes = self._encode_to_dense_output_tensor(nmsed_boxes)
         # converting all boxes to the original format
-        boxes = bounding_box.convert_format(
+        boxes = self._encode_to_ragged(boxes, nmsed_boxes.valid_detections)
+        return bounding_box.convert_format(
             boxes,
             source="yxyx",
             target=self.bounding_box_format,
             images=images,
         )
-        return self._encode_to_ragged(boxes, nmsed_boxes.valid_detections)
 
     def _encode_to_dense_output_tensor(self, nmsed_boxes):
         boxes = tf.TensorArray(tf.float32, size=0, dynamic_size=True)

--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -122,7 +122,7 @@ class NonMaxSuppression(tf.keras.layers.Layer):
             clip_boxes=False,
         )
         # output will be a ragged tensor because num_boxes will change across the batch
-        boxes = self._encode_to_dense_output_tensor(nmsed_boxes)
+        boxes = self._decode_nms_boxes_to_tensor(nmsed_boxes)
         # converting all boxes to the original format
         boxes = self._encode_to_ragged(boxes, nmsed_boxes.valid_detections)
         return bounding_box.convert_format(
@@ -132,7 +132,7 @@ class NonMaxSuppression(tf.keras.layers.Layer):
             images=images,
         )
 
-    def _encode_to_dense_output_tensor(self, nmsed_boxes):
+    def _decode_nms_boxes_to_tensor(self, nmsed_boxes):
         boxes = tf.TensorArray(tf.float32, size=0, dynamic_size=True)
 
         for i in tf.range(tf.shape(nmsed_boxes.nmsed_boxes)[0]):


### PR DESCRIPTION
- remove symbol import of convert_format(), it is important to keep `bounding_box` as it serves as the subject of the "sentence"
- improve readability by better publicizing the bounding_box.convert_format() call in the `call()` method
- refactor into an additional helper method

# Who can review

@quantumalaviya 