### PR TITLE
Add initial weight exporting scripts

### DIFF
--- a/examples/training/classification/densenet/imagenet/basic_training.json
+++ b/examples/training/classification/densenet/imagenet/basic_training.json
@@ -1,1 +1,1 @@
-{"v0": {"validation_accuracy": "0.6343"}}
+{"v0": {"validation_accuracy": "0.6771"}}

--- a/examples/training/classification/densenet/imagenet/basic_training.json
+++ b/examples/training/classification/densenet/imagenet/basic_training.json
@@ -1,0 +1,1 @@
+{"v0": {"validation_accuracy": "0.6343"}}

--- a/shell/weights/process_weights.sh
+++ b/shell/weights/process_weights.sh
@@ -1,0 +1,17 @@
+WEIGHTS=$1
+OUTPUT_WEIGHTS=$2
+MODEL=$3
+GCS_PATH=$4
+
+python3 remove_top.py --weights_path=$1 --output_weights_path=$2 --model_name=$3 
+
+echo With top: $GCS_PATH$WEIGHTS
+echo With top checksum: $(shasum -a 256 $1)
+echo Without top: $GCS_PATH$OUTPUT_WEIGHTS
+echo Without top checksum: $(shasum -a 256 $2)
+
+gsutil cp $WEIGHTS $GCS_PATH
+gsutil cp $OUTPUT_WEIGHTS $GCS_PATH
+
+gsutil acl ch -u AllUsers:R $GCS_PATH/$WEIGHTS
+gsutil acl ch -u AllUsers:R $GCS_PATH/$OUTPUT_WEIGHTS

--- a/shell/weights/process_weights.sh
+++ b/shell/weights/process_weights.sh
@@ -1,14 +1,19 @@
+if [ "$#" -ne 4 ]; then
+  echo USAGE: ./process_weights.sh WEIGHTS_PATH OUTPUT_WEIGHTS_PATH MODEL_NAME GCS_PATH
+  exit 1
+fi
+
 WEIGHTS=$1
 OUTPUT_WEIGHTS=$2
 MODEL=$3
 GCS_PATH=$4
 
-python3 remove_top.py --weights_path=$1 --output_weights_path=$2 --model_name=$3 
+python3 remove_top.py --weights_path=$WEIGHTS --output_weights_path=$OUTPUT_WEIGHTS --model_name=$MODEL
 
 echo With top: $GCS_PATH$WEIGHTS
-echo With top checksum: $(shasum -a 256 $1)
+echo With top checksum: $(shasum -a 256 $WEIGHTS)
 echo Without top: $GCS_PATH$OUTPUT_WEIGHTS
-echo Without top checksum: $(shasum -a 256 $2)
+echo Without top checksum: $(shasum -a 256 $OUTPUT_WEIGHTS)
 
 gsutil cp $WEIGHTS $GCS_PATH
 gsutil cp $OUTPUT_WEIGHTS $GCS_PATH

--- a/shell/weights/remove_top.py
+++ b/shell/weights/remove_top.py
@@ -1,0 +1,20 @@
+import keras
+import keras_cv
+import os
+import sys
+
+from absl import flags
+flags.DEFINE_string("weights_path", None, "Path of weights to load")
+flags.DEFINE_string("output_weights_path", None, "Path of notop weights to store")
+flags.DEFINE_string("model_name", None, "Name of the KerasCV.model")
+
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
+
+if not FLAGS.weights_path.endswith(".h5"):
+    raise ValueError("Weights path must end in .h5")
+
+model = eval(f"keras_cv.models.{FLAGS.model_name}(include_rescaling=True, include_top=True, num_classes=1000, weights=FLAGS.weights_path)")
+
+without_top = keras.models.Model(model.input, model.layers[-3].output)
+without_top.save_weights(FLAGS.output_weights_path)

--- a/shell/weights/remove_top.py
+++ b/shell/weights/remove_top.py
@@ -1,9 +1,10 @@
-import keras
-import keras_cv
-import os
 import sys
 
+import keras
 from absl import flags
+
+import keras_cv
+
 flags.DEFINE_string("weights_path", None, "Path of weights to load")
 flags.DEFINE_string("output_weights_path", None, "Path of notop weights to store")
 flags.DEFINE_string("model_name", None, "Name of the KerasCV.model")
@@ -14,7 +15,13 @@ FLAGS(sys.argv)
 if not FLAGS.weights_path.endswith(".h5"):
     raise ValueError("Weights path must end in .h5")
 
-model = eval(f"keras_cv.models.{FLAGS.model_name}(include_rescaling=True, include_top=True, num_classes=1000, weights=FLAGS.weights_path)")
+model = eval(
+    f"keras_cv.models.{FLAGS.model_name}(include_rescaling=True, include_top=True, num_classes=1000, weights=FLAGS.weights_path)"
+)
 
 without_top = keras.models.Model(model.input, model.layers[-3].output)
 without_top.save_weights(FLAGS.output_weights_path)
+
+# Because the usage of keras_cv is in an eval() call, the linter is angry.
+# We include this to avoid an unused import warning
+keras_cv.models

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -1,13 +1,17 @@
+import json
+import os
 import struct
 import sys
-import os
-import json
 
-from tensorflow.python.summary.summary_iterator import summary_iterator
 from absl import flags
+from tensorflow.python.summary.summary_iterator import summary_iterator
 
 flags.DEFINE_string("logs_path", None, "Path of TensorBoard validation logs to load")
-flags.DEFINE_string("training_script_json", None, "Path to the JSON file for run history for the producing training script")
+flags.DEFINE_string(
+    "training_script_json",
+    None,
+    "Path to the JSON file for run history for the producing training script",
+)
 flags.DEFINE_string("weights_version", None, "The version of these weights (e.g. 'v0')")
 
 FLAGS = flags.FLAGS
@@ -17,7 +21,7 @@ FLAGS(sys.argv)
 files = [filename for _, _, filename in os.walk(FLAGS.logs_path)]
 assert len(files) == 1
 assert len(files[0]) == 1
-filename = FLAGS.logs_path+'/'+files[0][0]
+filename = FLAGS.logs_path + "/" + files[0][0]
 
 events = [e for e in summary_iterator(filename)]
 
@@ -26,7 +30,9 @@ for event in events[1:]:
     assert len(event.summary.value) == 1
     if not event.summary.value[0].tag == "evaluation_accuracy_vs_iterations":
         continue
-    validation_accuracy = struct.unpack('f',event.summary.value[0].tensor.tensor_content)[0]
+    validation_accuracy = struct.unpack(
+        "f", event.summary.value[0].tensor.tensor_content
+    )[0]
     max_validation_accuracy = max(max_validation_accuracy, validation_accuracy)
 
 max_validation_accuracy = f"{max_validation_accuracy:.4f}"
@@ -36,12 +42,12 @@ print(f"Max validation accuracy: {max_validation_accuracy}")
 new_results = {FLAGS.weights_version: {"validation_accuracy": max_validation_accuracy}}
 
 # Check if the file already exists
-results_file = open(FLAGS.training_script_json, 'r')
+results_file = open(FLAGS.training_script_json, "r")
 results_string = results_file.read()
 results = json.loads(results_string) if results_string != "" else {}
 results_file.close()
 
-results_file = open(FLAGS.training_script_json, 'w')
+results_file = open(FLAGS.training_script_json, "w")
 results[FLAGS.weights_version] = {"validation_accuracy": max_validation_accuracy}
 json.dump(results, results_file)
 results_file.close()

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -18,10 +18,11 @@ FLAGS = flags.FLAGS
 FLAGS(sys.argv)
 
 # Find the single validation logs in the supplied logs dir
-files = [filename for _, _, filename in os.walk(FLAGS.logs_path)]
-assert len(files) == 1
-assert len(files[0]) == 1
-filename = FLAGS.logs_path + "/" + files[0][0]
+files = os.listdir(FLAGS.logs_path)
+# Tensorboard logs are named based on timestamp, so the largest name alphabetically is the most recent.
+most_recent_file = max(files)
+
+filename = FLAGS.logs_path + "/" + most_recent_file
 
 events = [e for e in summary_iterator(filename)]
 

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -1,0 +1,47 @@
+import struct
+import sys
+import os
+import json
+
+from tensorflow.python.summary.summary_iterator import summary_iterator
+from absl import flags
+
+flags.DEFINE_string("logs_path", None, "Path of TensorBoard validation logs to load")
+flags.DEFINE_string("training_script_json", None, "Path to the JSON file for run history for the producing training script")
+flags.DEFINE_string("weights_version", None, "The version of these weights (e.g. 'v0')")
+
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
+
+# Find the single validation logs in the supplied logs dir
+files = [filename for _, _, filename in os.walk(FLAGS.logs_path)]
+assert len(files) == 1
+assert len(files[0]) == 1
+filename = FLAGS.logs_path+'/'+files[0][0]
+
+events = [e for e in summary_iterator(filename)]
+
+max_validation_accuracy = 0
+for event in events[1:]:
+    assert len(event.summary.value) == 1
+    if not event.summary.value[0].tag == "evaluation_accuracy_vs_iterations":
+        continue
+    validation_accuracy = struct.unpack('f',event.summary.value[0].tensor.tensor_content)[0]
+    max_validation_accuracy = max(max_validation_accuracy, validation_accuracy)
+
+max_validation_accuracy = f"{max_validation_accuracy:.4f}"
+
+print(f"Max validation accuracy: {max_validation_accuracy}")
+
+new_results = {FLAGS.weights_version: {"validation_accuracy": max_validation_accuracy}}
+
+# Check if the file already exists
+results_file = open(FLAGS.training_script_json, 'r')
+results_string = results_file.read()
+results = json.loads(results_string) if results_string != "" else {}
+results_file.close()
+
+results_file = open(FLAGS.training_script_json, 'w')
+results[FLAGS.weights_version] = {"validation_accuracy": max_validation_accuracy}
+json.dump(results, results_file)
+results_file.close()


### PR DESCRIPTION
At this point, we're not updating validation metadata or the like, just including a basic scripts to take classification weights trained on ImageNet and export them to GCS.

I expect this to evolve a lot over time, but it is a starting point.

@LukeWood 