### PR TITLE
Fix NMSLayer shape inference to work when no elements are present

### DIFF
--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -133,7 +133,13 @@ class NonMaxSuppression(tf.keras.layers.Layer):
         )
 
     def _decode_nms_boxes_to_tensor(self, nmsed_boxes):
-        boxes = tf.TensorArray(tf.float32, size=0, dynamic_size=True)
+        boxes = tf.TensorArray(
+            tf.float32,
+            size=0,
+            infer_shape=False,
+            element_shape=(6,),
+            dynamic_size=True,
+        )
 
         for i in tf.range(tf.shape(nmsed_boxes.nmsed_boxes)[0]):
             num_detections = nmsed_boxes.valid_detections[i]


### PR DESCRIPTION
@quantumalaviya 

without this, the layer will fail when no boxes are found in any images.  this is because the constructed ragged will be missing an axis, because it can't infer the shape when no elements are written.