### PR TITLE
Fixed reference sections in some docstrings

### DIFF
--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -52,9 +52,9 @@ class AugMix(BaseImageAugmentationLayer):
         seed: Integer. Used to create a random seed.
 
     References:
-        [AugMix paper](https://arxiv.org/pdf/1912.02781)
-        [Official Code](https://github.com/google-research/augmix)
-        [Unoffial TF Code](https://github.com/szacho/augmix-tf)
+        - [AugMix paper](https://arxiv.org/pdf/1912.02781)
+        - [Official Code](https://github.com/google-research/augmix)
+        - [Unoffial TF Code](https://github.com/szacho/augmix-tf)
 
     Sample Usage:
     ```python

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -30,7 +30,7 @@ class CutMix(BaseImageAugmentationLayer):
             when training an imagenet1k classification model.
         seed: Integer. Used to create a random seed.
     References:
-       [CutMix paper]( https://arxiv.org/abs/1905.04899).
+       - [CutMix paper]( https://arxiv.org/abs/1905.04899).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -31,7 +31,7 @@ class FourierMix(BaseImageAugmentationLayer):
             recommended in the paper.
         seed: Integer. Used to create a random seed.
     References:
-        [FMix paper](https://arxiv.org/abs/2002.12047).
+        - [FMix paper](https://arxiv.org/abs/2002.12047).
 
     Sample usage:
     ```python

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -86,7 +86,7 @@ class GridMask(BaseImageAugmentationLayer):
     ```
 
     References:
-        - https://arxiv.org/abs/2001.04086
+        - [GridMask paper](https://arxiv.org/abs/2001.04086)
     """
 
     def __init__(

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -30,8 +30,8 @@ class MixUp(BaseImageAugmentationLayer):
         seed: Integer. Used to create a random seed.
 
     References:
-        [MixUp paper](https://arxiv.org/abs/1710.09412).
-        [MixUp for Object Detection paper](https://arxiv.org/pdf/1902.04103).
+        - [MixUp paper](https://arxiv.org/abs/1710.09412).
+        - [MixUp for Object Detection paper](https://arxiv.org/pdf/1902.04103).
 
     Sample usage:
     ```python


### PR DESCRIPTION
# What does this PR do?
Some docstrings didn't have a mardown list in their reference sections. A good example is the [AugMix paper](https://keras.io/api/keras_cv/layers/preprocessing/aug_mix/). This PR attempts to fix them.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

If I've missed any section, please let me know!
<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
