### PR TITLE
Add input-tensor param to all KerasCV.models

### DIFF
--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -24,6 +24,7 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
+from keras_cv.models import utils
 from keras_cv.models.__internal__.darknet_utils import CrossStagePartial
 from keras_cv.models.__internal__.darknet_utils import DarknetConvBlock
 from keras_cv.models.__internal__.darknet_utils import DarknetConvBlockDepthwise
@@ -112,13 +113,7 @@ def CSPDarkNet(
     base_channels = int(width_multiplier * 64)
     base_depth = max(round(depth_multiplier * 3), 1)
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -40,6 +40,7 @@ def CSPDarkNet(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name=None,
@@ -75,6 +76,8 @@ def CSPDarkNet(
             specified.
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         input_shape: optional shape tuple, defaults to (None, None, 3).
         pooling: optional pooling mode for feature extraction when `include_top`
             is `False`.
@@ -109,7 +112,13 @@ def CSPDarkNet(
     base_channels = int(width_multiplier * 64)
     base_depth = max(round(depth_multiplier * 3), 1)
 
-    inputs = layers.Input(shape=input_shape)
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
+from keras_cv.models import utils
 from keras_cv.models.__internal__.darknet_utils import DarknetConvBlock
 from keras_cv.models.__internal__.darknet_utils import ResidualBlocks
 from keras_cv.models.__internal__.darknet_utils import SpatialPyramidPoolingBottleneck
@@ -134,13 +135,7 @@ def DarkNet(
             f"num_classes={num_classes}"
         )
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -50,6 +50,8 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction when `include_top`
             is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -71,6 +73,7 @@ def DarkNet(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name=None,
@@ -101,6 +104,8 @@ def DarkNet(
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction when `include_top`
             is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -129,7 +134,13 @@ def DarkNet(
             f"num_classes={num_classes}"
         )
 
-    inputs = layers.Input(shape=input_shape)
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
 
     x = inputs
     if include_rescaling:
@@ -209,6 +220,7 @@ def DarkNet21(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     name="DarkNet21",
     **kwargs,
@@ -220,6 +232,7 @@ def DarkNet21(
         num_classes=num_classes,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         name=name,
         **kwargs,
@@ -232,6 +245,7 @@ def DarkNet53(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     name="DarkNet53",
     **kwargs,
@@ -243,6 +257,7 @@ def DarkNet53(
         num_classes=num_classes,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         name=name,
         **kwargs,

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -47,6 +47,8 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -154,6 +156,7 @@ def DenseNet(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="DenseNet",
@@ -181,6 +184,8 @@ def DenseNet(
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -210,7 +215,13 @@ def DenseNet(
             f"Received: num_classes={num_classes}"
         )
 
-    inputs = layers.Input(shape=input_shape)
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
 
     x = inputs
     if include_rescaling:
@@ -257,6 +268,7 @@ def DenseNet121(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     name="DenseNet121",
     **kwargs,
@@ -268,6 +280,7 @@ def DenseNet121(
         num_classes=num_classes,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         name=name,
         **kwargs,
@@ -280,6 +293,7 @@ def DenseNet169(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     name="DenseNet169",
     **kwargs,
@@ -291,6 +305,7 @@ def DenseNet169(
         num_classes=num_classes,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         name=name,
         **kwargs,
@@ -303,6 +318,7 @@ def DenseNet201(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     name="DenseNet201",
     **kwargs,
@@ -314,6 +330,7 @@ def DenseNet201(
         num_classes=num_classes,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         name=name,
         **kwargs,

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -24,6 +24,8 @@ from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
 
+from keras_cv.models import utils
+
 BN_AXIS = 3
 
 BASE_DOCSTRING = """Instantiates the {name} architecture.
@@ -215,13 +217,7 @@ def DenseNet(
             f"Received: num_classes={num_classes}"
         )
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/mlp_mixer.py
+++ b/keras_cv/models/mlp_mixer.py
@@ -87,6 +87,7 @@ def MLPMixer(
     include_rescaling,
     include_top,
     num_classes=None,
+    input_tensor=None,
     weights=None,
     pooling=None,
     classifier_activation="softmax",
@@ -123,6 +124,8 @@ def MLPMixer(
         if no `weights` argument is specified.
       weights: one of `None` (random initialization), or a pretrained
         weight file path.
+      input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+        to use as image input for the model.
       pooling: optional pooling mode for feature extraction
         when `include_top` is `False`.
         - `None` means that the output of the model will be
@@ -182,7 +185,13 @@ def MLPMixer(
     if input_shape[0] % patch_size[0] != 0:
         raise ValueError("Input resolution should be divisible by the patch size.")
 
-    inputs = layers.Input(shape=input_shape)
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
 
     x = inputs
     if include_rescaling:
@@ -226,6 +235,7 @@ def MLPMixerB16(
     include_rescaling,
     include_top,
     num_classes=None,
+    input_tensor=None,
     weights=None,
     pooling=None,
     name="mlp_mixer_b16",
@@ -241,6 +251,7 @@ def MLPMixerB16(
         include_rescaling=include_rescaling,
         include_top=include_top,
         num_classes=num_classes,
+        input_tensor=input_tensor,
         weights=weights,
         pooling=pooling,
         name=name,
@@ -254,6 +265,7 @@ def MLPMixerB32(
     include_rescaling,
     include_top,
     num_classes=None,
+    input_tensor=None,
     weights=None,
     pooling=None,
     name="mlp_mixer_b32",
@@ -269,6 +281,7 @@ def MLPMixerB32(
         include_rescaling=include_rescaling,
         include_top=include_top,
         num_classes=num_classes,
+        input_tensor=input_tensor,
         weights=weights,
         pooling=pooling,
         name=name,
@@ -282,6 +295,7 @@ def MLPMixerL16(
     include_rescaling,
     include_top,
     num_classes=None,
+    input_tensor=None,
     weights=None,
     pooling=None,
     name="mlp_mixer_l16",
@@ -297,6 +311,7 @@ def MLPMixerL16(
         include_rescaling=include_rescaling,
         include_top=include_top,
         num_classes=num_classes,
+        input_tensor=input_tensor,
         weights=weights,
         pooling=pooling,
         name=name,

--- a/keras_cv/models/mlp_mixer.py
+++ b/keras_cv/models/mlp_mixer.py
@@ -23,6 +23,8 @@ from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
 
+from keras_cv.models import utils
+
 
 def MLPBlock(mlp_dim, name=None):
     """An MLP block consisting of two linear layers with GELU activation in
@@ -185,13 +187,7 @@ def MLPMixer(
     if input_shape[0] % patch_size[0] != 0:
         raise ValueError("Input resolution should be divisible by the patch size.")
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -180,9 +180,9 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.parameters(*MODEL_LIST)
     def test_model_can_be_used_as_backbone(self, app, last_dim, args):
-        inputs = keras.layers.Input(shape=(None, None, 3))
+        inputs = keras.layers.Input(shape=(224, 224, 3))
         backbone = app(
-            include_rescaling=False, include_top=False, input_tensor=inputs, **args
+            include_rescaling=False, include_top=False, input_tensor=inputs, pooling='avg', **args
         )
 
         x = inputs

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -16,6 +16,7 @@
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow.keras import backend
+from tensorflow import keras
 
 from keras_cv.models import csp_darknet
 from keras_cv.models import darknet
@@ -177,6 +178,18 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
 
         backend.clear_session()
 
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        inputs = keras.layers.Input(shape=(None, None, 3))
+        backbone = app(include_rescaling=False, include_top=False, input_tensor=inputs, **args)
+
+        x = inputs
+        x = backbone(x)
+
+        backbone_output = backbone.get_layer(index=-1).output
+
+        model = keras.Model(inputs=inputs, outputs=[backbone_output])
+        model.compile()
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -182,7 +182,11 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
     def test_model_can_be_used_as_backbone(self, app, last_dim, args):
         inputs = keras.layers.Input(shape=(224, 224, 3))
         backbone = app(
-            include_rescaling=False, include_top=False, input_tensor=inputs, pooling='avg', **args
+            include_rescaling=False,
+            include_top=False,
+            input_tensor=inputs,
+            pooling="avg",
+            **args
         )
 
         x = inputs

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -15,8 +15,8 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow.keras import backend
 from tensorflow import keras
+from tensorflow.keras import backend
 
 from keras_cv.models import csp_darknet
 from keras_cv.models import darknet
@@ -181,7 +181,9 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(*MODEL_LIST)
     def test_model_can_be_used_as_backbone(self, app, last_dim, args):
         inputs = keras.layers.Input(shape=(None, None, 3))
-        backbone = app(include_rescaling=False, include_top=False, input_tensor=inputs, **args)
+        backbone = app(
+            include_rescaling=False, include_top=False, input_tensor=inputs, **args
+        )
 
         x = inputs
         x = backbone(x)
@@ -190,6 +192,7 @@ class ApplicationsTest(tf.test.TestCase, parameterized.TestCase):
 
         model = keras.Model(inputs=inputs, outputs=[backbone_output])
         model.compile()
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -18,9 +18,10 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
+
+from keras_cv.models import utils
 
 MODEL_CONFIGS = {
     "ResNet50": {
@@ -232,13 +233,7 @@ def ResNet(
             f"Received pooling={pooling} and include_top={include_top}. "
         )
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
     x = inputs
 
     if include_rescaling:

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -18,6 +18,7 @@ Reference:
 """
 
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
 
@@ -66,6 +67,8 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -167,6 +170,7 @@ def ResNet(
     name="ResNet",
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     num_classes=None,
     classifier_activation="softmax",
@@ -186,6 +190,8 @@ def ResNet(
         weights: one of `None` (random initialization),
             or the path to the weights file to be loaded.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be
@@ -226,8 +232,14 @@ def ResNet(
             f"Received pooling={pooling} and include_top={include_top}. "
         )
 
-    img_input = layers.Input(shape=input_shape)
-    x = img_input
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
+    x = inputs
 
     if include_rescaling:
         x = layers.Rescaling(1 / 255.0)(x)
@@ -262,7 +274,7 @@ def ResNet(
             x = layers.GlobalMaxPooling2D(name="max_pool")(x)
 
     # Create model.
-    model = tf.keras.Model(img_input, x, name=name, **kwargs)
+    model = tf.keras.Model(inputs, x, name=name, **kwargs)
 
     if weights is not None:
         model.load_weights(weights)
@@ -276,6 +288,7 @@ def ResNet50(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet50",
@@ -292,6 +305,7 @@ def ResNet50(
         name=name,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,
@@ -305,6 +319,7 @@ def ResNet101(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet101",
@@ -320,6 +335,7 @@ def ResNet101(
         include_top=include_top,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,
@@ -333,6 +349,7 @@ def ResNet152(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet152",
@@ -348,6 +365,7 @@ def ResNet152(
         name=name,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -18,6 +18,7 @@ Reference:
 """
 
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
 
@@ -65,6 +66,8 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be the 4D tensor output
@@ -173,6 +176,7 @@ def ResNetV2(
     name="ResNetV2",
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     num_classes=None,
     classifier_activation="softmax",
@@ -192,6 +196,8 @@ def ResNetV2(
         weights: one of `None` (random initialization),
             or the path to the weights file to be loaded.
         input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         pooling: optional pooling mode for feature extraction
             when `include_top` is `False`.
             - `None` means that the output of the model will be
@@ -232,8 +238,14 @@ def ResNetV2(
             f"Received pooling={pooling} and include_top={include_top}. "
         )
 
-    img_input = layers.Input(shape=input_shape)
-    x = img_input
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
+    x = inputs
 
     if include_rescaling:
         x = layers.Rescaling(1 / 255.0)(x)
@@ -268,7 +280,7 @@ def ResNetV2(
             x = layers.GlobalMaxPooling2D(name="max_pool")(x)
 
     # Create model.
-    model = tf.keras.Model(img_input, x, name=name, **kwargs)
+    model = tf.keras.Model(inputs, x, name=name, **kwargs)
 
     if weights is not None:
         model.load_weights(weights)
@@ -282,6 +294,7 @@ def ResNet50V2(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet50v2",
@@ -298,6 +311,7 @@ def ResNet50V2(
         name=name,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,
@@ -311,6 +325,7 @@ def ResNet101V2(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet101v2",
@@ -326,6 +341,7 @@ def ResNet101V2(
         include_top=include_top,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,
@@ -339,6 +355,7 @@ def ResNet152V2(
     num_classes=None,
     weights=None,
     input_shape=(None, None, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="resnet152v2",
@@ -354,6 +371,7 @@ def ResNet152V2(
         name=name,
         weights=weights,
         input_shape=input_shape,
+        input_tensor=input_tensor,
         pooling=pooling,
         num_classes=num_classes,
         classifier_activation=classifier_activation,

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -18,9 +18,10 @@ Reference:
 """
 
 import tensorflow as tf
-from tensorflow import keras
 from tensorflow.keras import backend
 from tensorflow.keras import layers
+
+from keras_cv.models import utils
 
 MODEL_CONFIGS = {
     "ResNet50V2": {
@@ -238,13 +239,7 @@ def ResNetV2(
             f"Received pooling={pooling} and include_top={include_top}. "
         )
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
     x = inputs
 
     if include_rescaling:

--- a/keras_cv/models/utils.py
+++ b/keras_cv/models/utils.py
@@ -1,0 +1,28 @@
+# Copyright 2022 The KerasCV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utility functions for models"""
+
+from tensorflow import keras
+from tensorflow.keras import layers
+
+
+def parse_model_inputs(input_shape, input_tensor):
+    if input_tensor is None:
+        return layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            return layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            return input_tensor

--- a/keras_cv/models/utils_test.py
+++ b/keras_cv/models/utils_test.py
@@ -1,0 +1,30 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for KerasCV model utils."""
+
+import tensorflow as tf
+from keras import layers
+
+from keras_cv.models import utils
+
+
+class ModelUtilTestCase(tf.test.TestCase):
+    def test_parse_model_inputs(self):
+        input_shape = (224, 244, 3)
+
+        inputs = utils.parse_model_inputs(input_shape, None)
+        self.assertEqual(inputs.shape.as_list(), list((None,) + input_shape))
+
+        input_tensor = layers.Input(shape=input_shape)
+        self.assertIs(utils.parse_model_inputs(input_shape, input_tensor), input_tensor)

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -23,6 +23,8 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
+from keras_cv.models import utils
+
 
 def VGG19(
     include_rescaling,
@@ -88,13 +90,7 @@ def VGG19(
             f"Received: num_classes={num_classes}"
         )
 
-    if input_tensor is None:
-        inputs = layers.Input(shape=input_shape)
-    else:
-        if not keras.backend.is_keras_tensor(input_tensor):
-            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
-        else:
-            inputs = input_tensor
+    inputs = utils.parse_model_inputs(input_shape, input_tensor)
 
     x = inputs
     if include_rescaling:

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -30,6 +30,7 @@ def VGG19(
     num_classes=None,
     weights=None,
     input_shape=(224, 224, 3),
+    input_tensor=None,
     pooling=None,
     classifier_activation="softmax",
     name="VGG19",
@@ -52,6 +53,8 @@ def VGG19(
         specified.
       weights: one of `None` (random initialization), or a pretrained weight file path.
       input_shape: optional shape tuple, defaults to (224, 224, 3).
+      input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+        to use as image input for the model.
       pooling: Optional pooling mode for feature extraction
         when `include_top` is `False`.
         - `None` means that the output of the model will be
@@ -85,7 +88,13 @@ def VGG19(
             f"Received: num_classes={num_classes}"
         )
 
-    inputs = layers.Input(shape=input_shape)
+    if input_tensor is None:
+        inputs = layers.Input(shape=input_shape)
+    else:
+        if not keras.backend.is_keras_tensor(input_tensor):
+            inputs = layers.Input(tensor=input_tensor, shape=input_shape)
+        else:
+            inputs = input_tensor
 
     x = inputs
     if include_rescaling:


### PR DESCRIPTION
Fixes #638

This is necessary for high performance of KerasCV models used as backbones in RetinaNet and other applications

@LukeWood 