### PR TITLE
Use fstring format in models/weights.py

### DIFF
--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -30,7 +30,7 @@ def parse_weights(weights, include_top, model_type):
         "The `weights` argument should be either `None`, a the path to the "
         "weights file to be loaded, or the name of pre-trained weights from "
         "https://github.com/keras-team/keras-cv/blob/master/keras_cv/models/weights.py. "
-        "Invalid `weights` argument: {weights}"
+        f"Invalid `weights` argument: {weights}"
     )
 
 


### PR DESCRIPTION
This was previously mis-reporting the error using the string literal "{weights}" instead of the input param.

@LukeWood 