### PR TITLE
Switch to tensorboard.dev for training metadata handling

### DIFF
--- a/examples/training/classification/densenet/imagenet/basic_training.json
+++ b/examples/training/classification/densenet/imagenet/basic_training.json
@@ -1,1 +1,1 @@
-{"v0": {"validation_accuracy": "0.6771", "epochs_trained": 84, "tensorboard_logs": "https://tensorboard.dev/experiment/VY08BvtgQcegyFdC1BsESA/"}}
+{"v0": {"validation_accuracy": "0.6771", "epochs_trained": 84, "tensorboard_logs": "https://tensorboard.dev/experiment/K5Q0gAk0RayXwP0WsLPpMA/", "pr_author": "ianjjohnson", "pr_link": "https://github.com/keras-team/keras-cv/pull/618"}}

--- a/examples/training/classification/densenet/imagenet/basic_training.json
+++ b/examples/training/classification/densenet/imagenet/basic_training.json
@@ -1,1 +1,1 @@
-{"v0": {"validation_accuracy": "0.6771"}}
+{"v0": {"validation_accuracy": "0.6771", "epochs_trained": 84, "tensorboard_logs": "https://tensorboard.dev/experiment/VY08BvtgQcegyFdC1BsESA/"}}

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -1,84 +1,46 @@
 import json
 import os
 import sys
-
 import tensorboard as tb
+
 from absl import flags
 
 flags.DEFINE_string("tensorboard_logs_path", None, "Path to tensorboard logs to load")
 flags.DEFINE_string("training_script_path", None, "Path to the training script")
-flags.DEFINE_string(
-    "weights_version",
-    None,
-    "The version of the training script used to produce the latest weights. For example, v0",
-)
-flags.DEFINE_string(
-    "pr_number", None, "The PR number that merged the training script into KerasCV"
-)
-flags.DEFINE_string(
-    "pr_author", None, "The GitHub username of the author of the training script"
-)
+flags.DEFINE_string("weights_version", None, "The version of the training script used to produce the latest weights. For example, v0")
+flags.DEFINE_string("pr_number", None, "The PR number that merged the training script into KerasCV")
+flags.DEFINE_string("pr_author", None, "The GitHub username of the author of the training script")
 
 FLAGS = flags.FLAGS
 FLAGS(sys.argv)
 
-weights_version = FLAGS.weights_version or input(
-    "Input the weights version for your script\n"
-)
+weights_version = FLAGS.weights_version or input("Input the weights version for your script\n")
 
-training_script_path = FLAGS.training_script_path or input(
-    "Input the path to your training script\n"
-)
+training_script_path = FLAGS.training_script_path or input("Input the path to your training script\n")
 training_script_json_path = training_script_path.replace(".py", ".json")
 full_training_script_path = os.path.abspath(training_script_path)
 
 # Build an experiment name structured as dataset/task-version (this experiment name will then match the name of the weights in GCS)
-training_script_rooted_at_training = full_training_script_path[
-    full_training_script_path.index("keras-cv/examples/training/") + 27 :
-]
-training_script_dirs = training_script_rooted_at_training.split("/")
-tensorboard_experiment_name = (
-    f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
-)
+training_script_rooted_at_training = full_training_script_path[full_training_script_path.index("keras-cv/examples/training/")+27:]
+training_script_dirs = training_script_rooted_at_training.split('/')
+tensorboard_experiment_name = f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
 
-tensorboard_logs_path = FLAGS.tensorboard_logs_path or input(
-    "Input the path to the TensorBoard logs\n"
-)
-tensorboard_experiment_id = (
-    os.popen(
-        f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0"
-    )
-    .read()
-    .split("/")[-2]
-)
+tensorboard_logs_path = FLAGS.tensorboard_logs_path or input('Input the path to the TensorBoard logs\n')
+tensorboard_experiment_id = os.popen(f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0").read().split('/')[-2]
 
-tensorboard_experiment = tb.data.experimental.ExperimentFromDev(
-    tensorboard_experiment_id
-)
+tensorboard_experiment = tb.data.experimental.ExperimentFromDev(tensorboard_experiment_id)
 
 tensorboard_results = tensorboard_experiment.get_scalars()
 
 training_epochs = max(tensorboard_results[tensorboard_results.run == "train"].step)
-max_validation_accuracy = max(
-    tensorboard_results[
-        (tensorboard_results.run == "validation")
-        & (tensorboard_results.tag == "epoch_accuracy")
-    ].value
-)
+max_validation_accuracy = max(tensorboard_results[(tensorboard_results.run == "validation") & (tensorboard_results.tag == "epoch_accuracy")].value)
 max_validation_accuracy = f"{max_validation_accuracy:.4f}"
 
-new_results = {
-    "validation_accuracy": max_validation_accuracy,
-    "epochs_trained": training_epochs,
-    "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/",
-}
+pr_link = f"https://github.com/keras-team/keras-cv/pull/{FLAGS.pr_number}" if FLAGS.pr_number else None
+pr_link = pr_link or input("Input a link to the PR that merged your script into KerasCV\n")
+pr_author = FLAGS.pr_author or input("Input your GitHub username (or the username of the PR author, if you're not the author)\n")
 
-pr_number = FLAGS.pr_number or input(
-    "Input the PR number that merged your script into KerasCV\n"
-)
-pr_number = FLAGS.pr_number or input(
-    "Input your GitHub username (or the username of the PR author, if you're not the author)\n"
-)
+new_results = {"validation_accuracy": max_validation_accuracy, "epochs_trained": training_epochs, "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/", "pr_author": pr_author, "pr_link": pr_link}
 
 # Check if the JSON file already exists
 results_file = open(training_script_json_path, "r")

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -1,46 +1,91 @@
 import json
 import os
 import sys
-import tensorboard as tb
 
+import tensorboard as tb
 from absl import flags
 
 flags.DEFINE_string("tensorboard_logs_path", None, "Path to tensorboard logs to load")
 flags.DEFINE_string("training_script_path", None, "Path to the training script")
-flags.DEFINE_string("weights_version", None, "The version of the training script used to produce the latest weights. For example, v0")
-flags.DEFINE_string("pr_number", None, "The PR number that merged the training script into KerasCV")
-flags.DEFINE_string("pr_author", None, "The GitHub username of the author of the training script")
+flags.DEFINE_string(
+    "weights_version",
+    None,
+    "The version of the training script used to produce the latest weights. For example, v0",
+)
+flags.DEFINE_string(
+    "pr_number", None, "The PR number that merged the training script into KerasCV"
+)
+flags.DEFINE_string(
+    "pr_author", None, "The GitHub username of the author of the training script"
+)
 
 FLAGS = flags.FLAGS
 FLAGS(sys.argv)
 
-weights_version = FLAGS.weights_version or input("Input the weights version for your script\n")
+weights_version = FLAGS.weights_version or input(
+    "Input the weights version for your script\n"
+)
 
-training_script_path = FLAGS.training_script_path or input("Input the path to your training script\n")
+training_script_path = FLAGS.training_script_path or input(
+    "Input the path to your training script\n"
+)
 training_script_json_path = training_script_path.replace(".py", ".json")
 full_training_script_path = os.path.abspath(training_script_path)
 
 # Build an experiment name structured as dataset/task-version (this experiment name will then match the name of the weights in GCS)
-training_script_rooted_at_training = full_training_script_path[full_training_script_path.index("keras-cv/examples/training/")+27:]
-training_script_dirs = training_script_rooted_at_training.split('/')
-tensorboard_experiment_name = f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
+training_script_rooted_at_training = full_training_script_path[
+    full_training_script_path.index("keras-cv/examples/training/") + 27 :
+]
+training_script_dirs = training_script_rooted_at_training.split("/")
+tensorboard_experiment_name = (
+    f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
+)
 
-tensorboard_logs_path = FLAGS.tensorboard_logs_path or input('Input the path to the TensorBoard logs\n')
-tensorboard_experiment_id = os.popen(f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0").read().split('/')[-2]
+tensorboard_logs_path = FLAGS.tensorboard_logs_path or input(
+    "Input the path to the TensorBoard logs\n"
+)
+tensorboard_experiment_id = (
+    os.popen(
+        f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0"
+    )
+    .read()
+    .split("/")[-2]
+)
 
-tensorboard_experiment = tb.data.experimental.ExperimentFromDev(tensorboard_experiment_id)
+tensorboard_experiment = tb.data.experimental.ExperimentFromDev(
+    tensorboard_experiment_id
+)
 
 tensorboard_results = tensorboard_experiment.get_scalars()
 
 training_epochs = max(tensorboard_results[tensorboard_results.run == "train"].step)
-max_validation_accuracy = max(tensorboard_results[(tensorboard_results.run == "validation") & (tensorboard_results.tag == "epoch_accuracy")].value)
+max_validation_accuracy = max(
+    tensorboard_results[
+        (tensorboard_results.run == "validation")
+        & (tensorboard_results.tag == "epoch_accuracy")
+    ].value
+)
 max_validation_accuracy = f"{max_validation_accuracy:.4f}"
 
-pr_link = f"https://github.com/keras-team/keras-cv/pull/{FLAGS.pr_number}" if FLAGS.pr_number else None
-pr_link = pr_link or input("Input a link to the PR that merged your script into KerasCV\n")
-pr_author = FLAGS.pr_author or input("Input your GitHub username (or the username of the PR author, if you're not the author)\n")
+pr_link = (
+    f"https://github.com/keras-team/keras-cv/pull/{FLAGS.pr_number}"
+    if FLAGS.pr_number
+    else None
+)
+pr_link = pr_link or input(
+    "Input a link to the PR that merged your script into KerasCV\n"
+)
+pr_author = FLAGS.pr_author or input(
+    "Input your GitHub username (or the username of the PR author, if you're not the author)\n"
+)
 
-new_results = {"validation_accuracy": max_validation_accuracy, "epochs_trained": training_epochs, "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/", "pr_author": pr_author, "pr_link": pr_link}
+new_results = {
+    "validation_accuracy": max_validation_accuracy,
+    "epochs_trained": training_epochs,
+    "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/",
+    "pr_author": pr_author,
+    "pr_link": pr_link,
+}
 
 # Check if the JSON file already exists
 results_file = open(training_script_json_path, "r")

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -1,48 +1,84 @@
 import json
 import os
-import struct
 import sys
+
 import tensorboard as tb
-
-from tensorflow.python.summary.summary_iterator import summary_iterator
-
 from absl import flags
 
 flags.DEFINE_string("tensorboard_logs_path", None, "Path to tensorboard logs to load")
 flags.DEFINE_string("training_script_path", None, "Path to the training script")
-flags.DEFINE_string("weights_version", None, "The version of the training script used to produce the latest weights. For example, v0")
-flags.DEFINE_string("pr_number", None, "The PR number that merged the training script into KerasCV")
-flags.DEFINE_string("pr_author", None, "The GitHub username of the author of the training script")
+flags.DEFINE_string(
+    "weights_version",
+    None,
+    "The version of the training script used to produce the latest weights. For example, v0",
+)
+flags.DEFINE_string(
+    "pr_number", None, "The PR number that merged the training script into KerasCV"
+)
+flags.DEFINE_string(
+    "pr_author", None, "The GitHub username of the author of the training script"
+)
 
 FLAGS = flags.FLAGS
 FLAGS(sys.argv)
 
-weights_version = FLAGS.weights_version or input("Input the weights version for your script\n")
+weights_version = FLAGS.weights_version or input(
+    "Input the weights version for your script\n"
+)
 
-training_script_path = FLAGS.training_script_path or input("Input the path to your training script\n")
+training_script_path = FLAGS.training_script_path or input(
+    "Input the path to your training script\n"
+)
 training_script_json_path = training_script_path.replace(".py", ".json")
 full_training_script_path = os.path.abspath(training_script_path)
 
 # Build an experiment name structured as dataset/task-version (this experiment name will then match the name of the weights in GCS)
-training_script_rooted_at_training = full_training_script_path[full_training_script_path.index("keras-cv/examples/training/")+27:]
-training_script_dirs = training_script_rooted_at_training.split('/')
-tensorboard_experiment_name = f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
+training_script_rooted_at_training = full_training_script_path[
+    full_training_script_path.index("keras-cv/examples/training/") + 27 :
+]
+training_script_dirs = training_script_rooted_at_training.split("/")
+tensorboard_experiment_name = (
+    f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
+)
 
-tensorboard_logs_path = FLAGS.tensorboard_logs_path or input('Input the path to the TensorBoard logs\n')
-tensorboard_experiment_id = os.popen(f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0").read().split('/')[-2]
+tensorboard_logs_path = FLAGS.tensorboard_logs_path or input(
+    "Input the path to the TensorBoard logs\n"
+)
+tensorboard_experiment_id = (
+    os.popen(
+        f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0"
+    )
+    .read()
+    .split("/")[-2]
+)
 
-tensorboard_experiment = tb.data.experimental.ExperimentFromDev(tensorboard_experiment_id)
+tensorboard_experiment = tb.data.experimental.ExperimentFromDev(
+    tensorboard_experiment_id
+)
 
 tensorboard_results = tensorboard_experiment.get_scalars()
 
 training_epochs = max(tensorboard_results[tensorboard_results.run == "train"].step)
-max_validation_accuracy = max(tensorboard_results[(tensorboard_results.run == "validation") & (tensorboard_results.tag == "epoch_accuracy")].value)
+max_validation_accuracy = max(
+    tensorboard_results[
+        (tensorboard_results.run == "validation")
+        & (tensorboard_results.tag == "epoch_accuracy")
+    ].value
+)
 max_validation_accuracy = f"{max_validation_accuracy:.4f}"
 
-new_results = {"validation_accuracy": max_validation_accuracy, "epochs_trained": training_epochs, "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/"}
+new_results = {
+    "validation_accuracy": max_validation_accuracy,
+    "epochs_trained": training_epochs,
+    "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/",
+}
 
-pr_number = FLAGS.pr_number or input("Input the PR number that merged your script into KerasCV\n")
-pr_number = FLAGS.pr_number or input("Input your GitHub username (or the username of the PR author, if you're not the author)\n")
+pr_number = FLAGS.pr_number or input(
+    "Input the PR number that merged your script into KerasCV\n"
+)
+pr_number = FLAGS.pr_number or input(
+    "Input your GitHub username (or the username of the PR author, if you're not the author)\n"
+)
 
 # Check if the JSON file already exists
 results_file = open(training_script_json_path, "r")

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -6,13 +6,30 @@ import tensorboard as tb
 
 from tensorflow.python.summary.summary_iterator import summary_iterator
 
-training_script_path = input("Input the path to your training script\n")
+from absl import flags
+
+flags.DEFINE_string("tensorboard_logs_path", None, "Path to tensorboard logs to load")
+flags.DEFINE_string("training_script_path", None, "Path to the training script")
+flags.DEFINE_string("weights_version", None, "The version of the training script used to produce the latest weights. For example, v0")
+flags.DEFINE_string("pr_number", None, "The PR number that merged the training script into KerasCV")
+flags.DEFINE_string("pr_author", None, "The GitHub username of the author of the training script")
+
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
+
+weights_version = FLAGS.weights_version or input("Input the weights version for your script\n")
+
+training_script_path = FLAGS.training_script_path or input("Input the path to your training script\n")
 training_script_json_path = training_script_path.replace(".py", ".json")
+full_training_script_path = os.path.abspath(training_script_path)
 
-weights_version = input("Input the weights version for your script\n")
+# Build an experiment name structured as dataset/task-version (this experiment name will then match the name of the weights in GCS)
+training_script_rooted_at_training = full_training_script_path[full_training_script_path.index("keras-cv/examples/training/")+27:]
+training_script_dirs = training_script_rooted_at_training.split('/')
+tensorboard_experiment_name = f"{training_script_dirs[2]}/{training_script_dirs[0]}-{weights_version}"
 
-tensorboard_logs_path = input('Input the path to the TensorBoard logs\n')
-tensorboard_experiment_id = os.popen(f"tensorboard dev upload --logdir {tensorboard_logs_path} --one_shot --verbose 0").read().split('/')[-2]
+tensorboard_logs_path = FLAGS.tensorboard_logs_path or input('Input the path to the TensorBoard logs\n')
+tensorboard_experiment_id = os.popen(f"tensorboard dev upload --logdir {tensorboard_logs_path} --name {tensorboard_experiment_name} --one_shot --verbose 0").read().split('/')[-2]
 
 tensorboard_experiment = tb.data.experimental.ExperimentFromDev(tensorboard_experiment_id)
 
@@ -20,24 +37,20 @@ tensorboard_results = tensorboard_experiment.get_scalars()
 
 training_epochs = max(tensorboard_results[tensorboard_results.run == "train"].step)
 max_validation_accuracy = max(tensorboard_results[(tensorboard_results.run == "validation") & (tensorboard_results.tag == "epoch_accuracy")].value)
+max_validation_accuracy = f"{max_validation_accuracy:.4f}"
 
+new_results = {"validation_accuracy": max_validation_accuracy, "epochs_trained": training_epochs, "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/"}
 
+pr_number = FLAGS.pr_number or input("Input the PR number that merged your script into KerasCV\n")
+pr_number = FLAGS.pr_number or input("Input your GitHub username (or the username of the PR author, if you're not the author)\n")
 
+# Check if the JSON file already exists
+results_file = open(training_script_json_path, "r")
+results_string = results_file.read()
+results = json.loads(results_string) if results_string != "" else {}
+results_file.close()
 
-
-###
-#
-# max_validation_accuracy = None
-#
-# new_results = {weights_version: {"validation_accuracy": max_validation_accuracy, "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}}/"}}
-#
-# # Check if the file already exists
-# results_file = open(FLAGS.training_script_json, "r")
-# results_string = results_file.read()
-# results = json.loads(results_string) if results_string != "" else {}
-# results_file.close()
-#
-# results_file = open(FLAGS.training_script_json, "w")
-# results[FLAGS.weights_version] = {"validation_accuracy": max_validation_accuracy}
-# json.dump(results, results_file)
-# results_file.close()
+results_file = open(training_script_json_path, "w")
+results[weights_version] = new_results
+json.dump(results, results_file)
+results_file.close()


### PR DESCRIPTION
This changes update_training_history.py to upload tensorboard logs to tensorboard.dev, and then use tensorboard.dev's API to load relevant metrics from training logs.

This also switches the script to support both flags and CLI input to give the user some flexibility.

@LukeWood 