### PR TITLE
Silence E402 linter error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ max-line-length = 88
 max-doc-length = 200
 per-file-ignores =
     ./keras_cv/__init__.py:E402, F401
-    ./keras_cv/examples/training/*:E402
+    ./examples/**/*:E402
     **/__init__.py:F401
 ignore =
     # Conflicts with black

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ max-line-length = 88
 max-doc-length = 200
 per-file-ignores =
     ./keras_cv/__init__.py:E402, F401
+    ./keras_cv/examples/training/*:E402
     **/__init__.py:F401
 ignore =
     # Conflicts with black

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -22,7 +22,7 @@ fi
 [ $# -eq 0  ] && echo "no issues with isort"
 
 # Allow --max-line-length=200 to support long links in docstrings
-flake8 --max-line-length=200 --ignore E402 $files
+flake8 --max-line-length=200 $files
 if ! [ $? -eq 0 ]
 then
   echo "Please fix the code style issue."

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -22,7 +22,7 @@ fi
 [ $# -eq 0  ] && echo "no issues with isort"
 
 # Allow --max-line-length=200 to support long links in docstrings
-flake8 --max-line-length=200 $files
+flake8 --max-line-length=200 --ignore E402 $files
 if ! [ $? -eq 0 ]
 then
   echo "Please fix the code style issue."


### PR DESCRIPTION
E402 disallows imports from being anywhere other than the top of a file. This is necessary for Keras.io tutorial-style training scripts.

@LukeWood 