### PR TITLE
Fixes `label_smoothing` in `FocalLoss`

### DIFF
--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -76,14 +76,16 @@ class FocalLoss(tf.keras.losses.Loss):
         y_true = tf.cast(y_true, y_pred.dtype)
 
         if self.label_smoothing:
-            y_true = self._smooth_labels(y_true)
+            y_smoothed = self._smooth_labels(y_true)
+        else:
+            y_smoothed = y_true
 
         if self.from_logits:
             y_pred = tf.nn.sigmoid(y_pred)
 
-        cross_entropy = K.binary_crossentropy(y_true, y_pred)
+        cross_entropy = K.binary_crossentropy(y_smoothed, y_pred)
 
-        alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
+        alpha = self._alpha * y_true + (1.0 - self._alpha) * (1.0 - y_true)
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
 

--- a/keras_cv/losses/focal_test.py
+++ b/keras_cv/losses/focal_test.py
@@ -86,3 +86,10 @@ class FocalTest(tf.test.TestCase):
         self.assertAllClose(
             focal_loss_on_logits(y_true, y_logits), focal_loss(y_true, y_pred)
         )
+
+    def test_smoothed_output(self):
+        y_true = [0.0, 1.0, 1.0]
+        y_pred = [0.1, 0.7, 0.9]
+
+        focal_loss = FocalLoss(label_smoothing=0.1)
+        self.assertAllClose(focal_loss(y_true, y_pred), 0.00371020)


### PR DESCRIPTION
# What does this PR do?

Fixes label smoothing in `FocalLoss`.

Also as a code style, uses the same formulation for `alpha` and `pt` and computation

Fixes #672


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
Yes added a test for precomputed values from : https://docs.google.com/spreadsheets/d/1umGKfnSXzmz5NDeUO-s850ZDbJ_92kyD4MGbwEZGyLQ/edit?usp=sharing


## Who can review?

@LukeWood @quantumalaviya 
