### PR TITLE
Fix classes docstring to match code behavior

### DIFF
--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -73,8 +73,7 @@ def CSPDarkNet(
         use_depthwise: a boolean value used to decide whether a depthwise conv block
             should be used over a regular darknet block. Defaults to False
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -46,8 +46,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         include_top: whether to include the fully-connected layer at the top of
             the network.  If provided, `classes` must be provided.
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
@@ -100,8 +99,7 @@ def DarkNet(
         include_top: whether to include the fully-connected layer at the top of
             the network.  If provided, `classes` must be provided.
         classes: optional number of classes to classify imagesinto, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight
             file path.
         input_shape: optional shape tuple, defaults to (None, None, 3).

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -44,8 +44,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         include_top: whether to include the fully-connected layer at the top of the
             network.  If provided, classes must be provided.
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), a pretrained weight file
             path, or a reference to pre-trained weights (e.g. 'imagenet/classification') (see available pre-trained weights in weights.py)
         input_shape: optional shape tuple, defaults to (None, None, 3).
@@ -181,8 +180,7 @@ def DenseNet(
         include_top: whether to include the fully-connected layer at the top of the
             network.  If provided, classes must be provided.
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).

--- a/keras_cv/models/mlp_mixer.py
+++ b/keras_cv/models/mlp_mixer.py
@@ -122,8 +122,7 @@ def MLPMixer(
       include_top: whether to include the fully-connected
         layer at the top of the network.  If provided, classes must be provided.
       classes: optional number of classes to classify images
-        into, only to be specified if `include_top` is True, and
-        if no `weights` argument is specified.
+        into, only to be specified if `include_top` is True.
       weights: one of `None` (random initialization), or a pretrained
         weight file path.
       input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -63,8 +63,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         include_top: whether to include the fully-connected layer at the top of the
             network.  If provided, classes must be provided.
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
@@ -205,8 +204,7 @@ def ResNet(
             - `max` means that global max pooling will
                 be applied.
         classes: optional number of classes to classify images
-            into, only to be specified if `include_top` is True, and
-            if no `weights` argument is specified.
+            into, only to be specified if `include_top` is True.
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -62,8 +62,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         include_top: whether to include the fully-connected layer at the top of the
             network.  If provided, classes must be provided.
         classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True, and if no `weights` argument is
-            specified.
+            specified if `include_top` is True.
         weights: one of `None` (random initialization), or a pretrained weight file
             path.
         input_shape: optional shape tuple, defaults to (None, None, 3).
@@ -211,8 +210,7 @@ def ResNetV2(
             - `max` means that global max pooling will
                 be applied.
         classes: optional number of classes to classify images
-            into, only to be specified if `include_top` is True, and
-            if no `weights` argument is specified.
+            into, only to be specified if `include_top` is True.
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -51,8 +51,7 @@ def VGG19(
       include_top: whether to include the 3 fully-connected
         layers at the top of the network. If provided, classes must be provided.
       classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is
-        specified.
+        specified if `include_top` is True.
       weights: one of `None` (random initialization), or a pretrained weight file path.
       input_shape: optional shape tuple, defaults to (224, 224, 3).
       input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)


### PR DESCRIPTION
Currently, the code expects `classes` to be specified anytime `include_top=True`, but the docstring implies that we infer `classes` based on weights (which we don't)

@LukeWood 