### PR TITLE
Introduce a PascalVOC loader as an API

### DIFF
--- a/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
@@ -22,7 +22,6 @@ import sys
 
 import matplotlib.pyplot as plt
 import tensorflow as tf
-import tensorflow_datasets as tfds
 import wandb
 from absl import flags
 from tensorflow.keras import callbacks as callbacks_lib

--- a/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
@@ -50,74 +50,32 @@ if FLAGS.wandb_entity:
 """
 ## Data loading
 
-First, let's define the data-loading function: `load_pascal_voc()`.  KerasCV supports a
-`bounding_box_format` argument in all components that process bounding boxes.  To match
-the KerasCV API style, it is recommended that when writing a data loader, you support a
-`bounding_box_format` argument.  This makes it clear to those invoking your
-data loader what format the bounding boxes are in.
+In this guide, we use the data-loading function: `keras_cv.loaders.pascal_voc.load()`.
+KerasCV supports a `bounding_box_format` argument in all components that process
+bounding boxes.  To match the KerasCV API style, it is recommended that when writing a
+custom data loader, you also support a `bounding_box_format` argument.
+This makes it clear to those invoking your data loader what format the bounding boxes
+are in.
 
 For example:
 
 ```python
-train_ds = load_pascal_voc(split='train', bounding_box_format='xywh', batch_size=8)
+train_ds, ds_info = keras_cv.loaders.pascal_voc.load(split='train', bounding_box_format='xywh', batch_size=8)
 ```
 
 Clearly yields bounding boxes in the format `xywh`.  You can read more about
 KerasCV bounding box formats [in the API docs](https://keras.io/api/keras_cv/bounding_box/formats/).
-"""
 
-
-def curry_map_function(bounding_box_format, img_size):
-    """Mapping function to create batched image and bbox coordinates"""
-
-    resizing = keras.layers.Resizing(
-        height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
-    )
-
-    def apply(inputs):
-        inputs["image"] = resizing(inputs["image"])
-        inputs["objects"]["bbox"] = bounding_box.convert_format(
-            inputs["objects"]["bbox"],
-            images=inputs["image"],
-            source="rel_yxyx",
-            target=bounding_box_format,
-        )
-
-        bounding_boxes = inputs["objects"]["bbox"]
-        labels = tf.cast(inputs["objects"]["label"], tf.float32)
-        labels = tf.expand_dims(labels, axis=-1)
-        bounding_boxes = tf.concat([bounding_boxes, labels], axis=-1)
-        return {"images": inputs["image"], "bounding_boxes": bounding_boxes}
-
-    return apply
-
-
-def load_pascal_voc(
-    split, bounding_box_format, batch_size, shuffle=True, img_size=(512, 512)
-):
-    dataset, dataset_info = tfds.load(
-        "voc/2007", split=split, shuffle_files=shuffle, with_info=True
-    )
-    dataset = dataset.map(
-        curry_map_function(bounding_box_format=bounding_box_format, img_size=img_size),
-        num_parallel_calls=tf.data.AUTOTUNE,
-    )
-    dataset = dataset.shuffle(8 * batch_size)
-    dataset = dataset.apply(
-        tf.data.experimental.dense_to_ragged_batch(batch_size=batch_size)
-    )
-    return dataset, dataset_info
-
-
-"""
-Great!  Our data is now loaded into the format
+Our data comesloaded into the format
 `{"images": images, "bounding_boxes": bounding_boxes}`.  This format is supported in all
 KerasCV preprocessing components.
 
 Lets load some data and verify that our data looks as we expect it to.
 """
 
-dataset, _ = load_pascal_voc(split="train", bounding_box_format="xywh", batch_size=9)
+dataset, _ = keras_cv.loaders.pascal_voc.load(
+    split="train", bounding_box_format="xywh", batch_size=9
+)
 
 
 def visualize_dataset(dataset, bounding_box_format):
@@ -160,10 +118,10 @@ friendly data augmentation inside of a `tf.data` pipeline.
 
 # train_ds is batched as a (images, bounding_boxes) tuple
 # bounding_boxes are ragged
-train_ds, _ = load_pascal_voc(
+train_ds, _ = keras_cv.loaders.pascal_voc.load(
     bounding_box_format="xywh", split="train", batch_size=FLAGS.batch_size
 )
-val_ds, _ = load_pascal_voc(
+val_ds, _ = keras_cv.loaders.pascal_voc.load(
     bounding_box_format="xywh", split="validation", batch_size=FLAGS.batch_size
 )
 

--- a/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/basic/pascal_voc/train.py
@@ -25,12 +25,10 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 import wandb
 from absl import flags
-from tensorflow import keras
 from tensorflow.keras import callbacks as callbacks_lib
 from tensorflow.keras import optimizers
 
 import keras_cv
-from keras_cv import bounding_box
 
 flags.DEFINE_integer("batch_size", 8, "Training and eval batch size.")
 flags.DEFINE_integer("epochs", 1, "Number of training epochs.")

--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -19,6 +19,7 @@ version_check.check_tf_version()
 # isort:on
 
 from keras_cv import layers
+from keras_cv import loaders
 from keras_cv import losses
 from keras_cv import metrics
 from keras_cv import models

--- a/keras_cv/loaders/__init__.py
+++ b/keras_cv/loaders/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/keras_cv/loaders/pascal_voc/__init__.py
+++ b/keras_cv/loaders/pascal_voc/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.loaders.pascal_voc.load import load

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -2,6 +2,8 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow import keras
 
+from keras_cv import bounding_box
+
 
 def curry_map_function(bounding_box_format, img_size):
     """Mapping function to create batched image and bbox coordinates"""
@@ -9,6 +11,7 @@ def curry_map_function(bounding_box_format, img_size):
     resizing = keras.layers.Resizing(
         height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
     )
+
     # TODO(lukewood): update `keras.layers.Resizing` to support bounding boxes.
     def apply(inputs):
         inputs["image"] = resizing(inputs["image"])

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -32,7 +32,12 @@ def curry_map_function(bounding_box_format, img_size):
 
 
 def load(
-    split, bounding_box_format, batch_size=None, shuffle=True, shuffle_buffer=None, img_size=(512, 512)
+    split,
+    bounding_box_format,
+    batch_size=None,
+    shuffle=True,
+    shuffle_buffer=None,
+    img_size=(512, 512),
 ):
     """Loads the PascalVOC 2007 dataset.
 

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -32,7 +32,7 @@ def curry_map_function(bounding_box_format, img_size):
 
 
 def load(
-    split, bounding_box_format, batch_size=None, shuffle=True, img_size=(512, 512)
+    split, bounding_box_format, batch_size=None, shuffle=True, shuffle_buffer=None, img_size=(512, 512)
 ):
     """Loads the PascalVOC 2007 dataset.
 
@@ -63,7 +63,15 @@ def load(
         curry_map_function(bounding_box_format=bounding_box_format, img_size=img_size),
         num_parallel_calls=tf.data.AUTOTUNE,
     )
-    dataset = dataset.shuffle(8 * batch_size)
+
+    if shuffle:
+        if not batch_size and not shuffle_buffer:
+            raise ValueError(
+                "If `shuffle=True`, either a `batch_size` or `shuffle_buffer` must be "
+                "provided to `keras_cv.loaders.pascal_voc.load().`"
+            )
+        shuffle_buffer = shuffle_buffer or 8 * batch_size
+        dataset = dataset.shuffle(shuffle_buffer)
 
     if batch_size is not None:
         dataset = dataset.apply(

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -44,11 +44,16 @@ def load(
     ```
 
     Args:
-        split:
-        bounding_box_format:
-        batch_size:
-        shuffle:
-        img_size:
+        split: the split string passed to the `tensorflow_datasets.load()` call.  Should
+            be one of "train", "test", or "validation."
+        bounding_box_format: the keras_cv bounding box format to load the boxes into.
+            For a list of supported formats, please  Refer
+            [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
+            for more details on supported bounding box formats.
+        batch_size: how many instances to include in batches after loading
+        shuffle: whether or not to shuffle the dataset.  Defaults to True.
+        shuffle_buffer: the size of the buffer to use in shuffling.
+        img_size: the size to resize the images to.
 
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -1,3 +1,8 @@
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from tensorflow import keras
+
+
 def curry_map_function(bounding_box_format, img_size):
     """Mapping function to create batched image and bbox coordinates"""
 

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -1,0 +1,42 @@
+def curry_map_function(bounding_box_format, img_size):
+    """Mapping function to create batched image and bbox coordinates"""
+
+    resizing = keras.layers.Resizing(
+        height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
+    )
+    # TODO(lukewood): update `keras.layers.Resizing` to support bounding boxes.
+    def apply(inputs):
+        inputs["image"] = resizing(inputs["image"])
+        inputs["objects"]["bbox"] = bounding_box.convert_format(
+            inputs["objects"]["bbox"],
+            images=inputs["image"],
+            source="rel_yxyx",
+            target=bounding_box_format,
+        )
+
+        bounding_boxes = inputs["objects"]["bbox"]
+        labels = tf.cast(inputs["objects"]["label"], tf.float32)
+        labels = tf.expand_dims(labels, axis=-1)
+        bounding_boxes = tf.concat([bounding_boxes, labels], axis=-1)
+        return {"images": inputs["image"], "bounding_boxes": bounding_boxes}
+
+    return apply
+
+
+def load(
+    split, bounding_box_format, batch_size=None, shuffle=True, img_size=(512, 512)
+):
+    dataset, dataset_info = tfds.load(
+        "voc/2007", split=split, shuffle_files=shuffle, with_info=True
+    )
+    dataset = dataset.map(
+        curry_map_function(bounding_box_format=bounding_box_format, img_size=img_size),
+        num_parallel_calls=tf.data.AUTOTUNE,
+    )
+    dataset = dataset.shuffle(8 * batch_size)
+
+    if batch_size is not None:
+        dataset = dataset.apply(
+            tf.data.experimental.dense_to_ragged_batch(batch_size=batch_size)
+        )
+    return dataset, dataset_info

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -1,3 +1,17 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow import keras

--- a/keras_cv/loaders/pascal_voc/load.py
+++ b/keras_cv/loaders/pascal_voc/load.py
@@ -34,6 +34,28 @@ def curry_map_function(bounding_box_format, img_size):
 def load(
     split, bounding_box_format, batch_size=None, shuffle=True, img_size=(512, 512)
 ):
+    """Loads the PascalVOC 2007 dataset.
+
+    Usage:
+    ```python
+    dataset, ds_info = keras_cv.loaders.pascal_voc.load(
+        split="train", bounding_box_format="xywh", batch_size=9
+    )
+    ```
+
+    Args:
+        split:
+        bounding_box_format:
+        batch_size:
+        shuffle:
+        img_size:
+
+    Returns:
+        tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing
+        keys {"images": images, "bounding_boxes": bounding_boxes} where images is a
+        Tensor of shape [batch, H, W, 3] and bounding_boxes is a `tf.RaggedTensor` of
+        shape [batch, None, 5].
+    """
     dataset, dataset_info = tfds.load(
         "voc/2007", split=split, shuffle_files=shuffle, with_info=True
     )

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -17,6 +17,8 @@ isort -c $files
 if ! [ $? -eq 0 ]
 then
   echo "Please run \"sh shell/format.sh\" to format the code."
+  isort --version
+  black --version
   exit 1
 fi
 [ $# -eq 0  ] && echo "no issues with isort"


### PR DESCRIPTION
This will help users get quickstarted with the OD API.

To mitigate against the "users need to reverse engineer data loading" issue, we can offer a tutorial on writing a custom loader.