### PR TITLE
Add augmenter layer

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -32,6 +32,7 @@ from keras_cv.layers.object_detection.retina_net_label_encoder import (
     RetinaNetLabelEncoder,
 )
 from keras_cv.layers.preprocessing.aug_mix import AugMix
+from keras_cv.layers.preprocessing.augmenter import Augmenter
 from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -27,6 +27,7 @@ from tensorflow.keras.layers import Rescaling
 from tensorflow.keras.layers import Resizing
 
 from keras_cv.layers.preprocessing.aug_mix import AugMix
+from keras_cv.layers.preprocessing.augmenter import Augmenter
 from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/augmenter.py
+++ b/keras_cv/layers/preprocessing/augmenter.py
@@ -1,0 +1,37 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class Augmenter(tf.keras.layers.Layer):
+    """Augmenter performs a series of preprocessing operations on input data.
+    Args:
+        layers: A list of Keras layers to be applied in sequence to input data.
+    """
+
+    def __init__(self, layers, **kwargs):
+        super().__init__(**kwargs)
+        self.layers = layers
+
+    def call(self, inputs):
+        for layer in self.layers:
+            inputs = layer(inputs)
+        return inputs
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"layers": self.layers})
+        return config

--- a/keras_cv/layers/preprocessing/augmenter_test.py
+++ b/keras_cv/layers/preprocessing/augmenter_test.py
@@ -1,0 +1,63 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+
+class AugmenterTest(tf.test.TestCase):
+    def test_return_shapes(self):
+        input = tf.ones((2, 512, 512, 3))
+
+        layer = preprocessing.Augmenter(
+            [
+                preprocessing.Grayscale(
+                    output_channels=1,
+                ),
+                preprocessing.RandomResizedCrop(
+                    target_size=(100, 100),
+                    crop_area_factor=(1, 1),
+                    aspect_ratio_factor=(1, 1),
+                ),
+            ]
+        )
+
+        output = layer(input, training=True)
+
+        self.assertEqual(output.shape, [2, 100, 100, 1])
+
+    def test_in_tf_function(self):
+        input = tf.ones((2, 512, 512, 3))
+
+        layer = preprocessing.Augmenter(
+            [
+                preprocessing.Grayscale(
+                    output_channels=1,
+                ),
+                preprocessing.RandomResizedCrop(
+                    target_size=(100, 100),
+                    crop_area_factor=(1, 1),
+                    aspect_ratio_factor=(1, 1),
+                ),
+            ]
+        )
+
+        @tf.function
+        def augment(x):
+            return layer(x, training=True)
+
+        output = augment(input)
+
+        self.assertEqual(output.shape, [2, 100, 100, 1])


### PR DESCRIPTION
This is a piece of the contrastive learning PR #699 which I'm breaking out for its own review.

The open question currently is:
- Does this belong in a `training` namespace, or just as a preprocessing layer?