### PR TITLE
Make ReduceLrOnPlateau a bit less patient for basic imagenet training

### DIFF
--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -220,7 +220,7 @@ We use EarlyStopping, BackupAndRestore, and a model checkpointing callback.
 
 callbacks = [
     callbacks.ReduceLROnPlateau(
-        monitor="val_loss", factor=0.1, patience=10, min_lr=0.0001
+        monitor="val_loss", factor=0.1, patience=5, min_delta=0.001, min_lr=0.0001
     ),
     callbacks.EarlyStopping(patience=20),
     callbacks.BackupAndRestore(FLAGS.backup_path),

--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -220,7 +220,7 @@ We use EarlyStopping, BackupAndRestore, and a model checkpointing callback.
 
 callbacks = [
     callbacks.ReduceLROnPlateau(
-        monitor="val_loss", factor=0.1, patience=5, min_delta=0.001, min_lr=0.0001
+        monitor="val_loss", factor=0.1, patience=10, min_delta=0.001, min_lr=0.0001
     ),
     callbacks.EarlyStopping(patience=20),
     callbacks.BackupAndRestore(FLAGS.backup_path),


### PR DESCRIPTION
The recent training runs have spent a lot of epochs (30+) dancing around improvements of about .0001 to validation accuracy, so I think we should make this a bit more agressive.

@LukeWood 