### PR TITLE
Restructure model tests to try to reduce OOM

### DIFF
--- a/keras_cv/models/csp_darknet_test.py
+++ b/keras_cv/models/csp_darknet_test.py
@@ -1,0 +1,50 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import csp_darknet
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (csp_darknet.CSPDarkNet, 1024, {}),
+]
+
+
+class CSPDarkNetTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/darknet_test.py
+++ b/keras_cv/models/darknet_test.py
@@ -1,0 +1,51 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import darknet
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (darknet.DarkNet21, 512, {}),
+    (darknet.DarkNet53, 512, {}),
+]
+
+
+class DarkNetTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/densenet_test.py
+++ b/keras_cv/models/densenet_test.py
@@ -1,0 +1,52 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import densenet
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (densenet.DenseNet121, 1024, {}),
+    (densenet.DenseNet169, 1664, {}),
+    (densenet.DenseNet201, 1920, {}),
+]
+
+
+class DenseNetTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/mlp_mixer_test.py
+++ b/keras_cv/models/mlp_mixer_test.py
@@ -1,0 +1,64 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import mlp_mixer
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (
+        mlp_mixer.MLPMixerB16,
+        768,
+        {"patch_size": (16, 16), "input_shape": (224, 224, 3)},
+    ),
+    (
+        mlp_mixer.MLPMixerB32,
+        768,
+        {"patch_size": (32, 32), "input_shape": (224, 224, 3)},
+    ),
+    (
+        mlp_mixer.MLPMixerL16,
+        1024,
+        {"patch_size": (16, 16), "input_shape": (224, 224, 3)},
+    ),
+]
+
+
+class MLPMixerTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/mobilenet_v3_test.py
+++ b/keras_cv/models/mobilenet_v3_test.py
@@ -1,0 +1,51 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import mobilenet_v3
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (mobilenet_v3.MobileNetV3Small, 576, {}),
+    (mobilenet_v3.MobileNetV3Large, 960, {}),
+]
+
+
+class MobileNetV3Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -15,54 +15,11 @@
 
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
 from tensorflow import keras
 from tensorflow.keras import backend
 
-from keras_cv.models import csp_darknet
-from keras_cv.models import darknet
-from keras_cv.models import densenet
-from keras_cv.models import mlp_mixer
-from keras_cv.models import mobilenet_v3
-from keras_cv.models import resnet_v1
-from keras_cv.models import resnet_v2
-from keras_cv.models import vgg19
 
-MODEL_LIST = [
-    (csp_darknet.CSPDarkNet, 1024, {}),
-    (darknet.DarkNet21, 512, {}),
-    (darknet.DarkNet53, 512, {}),
-    (densenet.DenseNet121, 1024, {}),
-    (densenet.DenseNet169, 1664, {}),
-    (densenet.DenseNet201, 1920, {}),
-    (resnet_v1.ResNet50, 2048, {}),
-    (resnet_v1.ResNet101, 2048, {}),
-    (resnet_v1.ResNet152, 2048, {}),
-    (resnet_v2.ResNet50V2, 2048, {}),
-    (resnet_v2.ResNet101V2, 2048, {}),
-    (resnet_v2.ResNet152V2, 2048, {}),
-    (mobilenet_v3.MobileNetV3Small, 576, {}),
-    (mobilenet_v3.MobileNetV3Large, 960, {}),
-    (
-        mlp_mixer.MLPMixerB16,
-        768,
-        {"patch_size": (16, 16), "input_shape": (224, 224, 3)},
-    ),
-    (
-        mlp_mixer.MLPMixerB32,
-        768,
-        {"patch_size": (32, 32), "input_shape": (224, 224, 3)},
-    ),
-    (
-        mlp_mixer.MLPMixerL16,
-        1024,
-        {"patch_size": (16, 16), "input_shape": (224, 224, 3)},
-    ),
-    (vgg19.VGG19, 512, {}),
-]
-
-
-class ModelsTest(tf.test.TestCase, parameterized.TestCase):
+class ModelsTest:
     def assertShapeEqual(self, shape1, shape2):
         self.assertEqual(tf.TensorShape(shape1), tf.TensorShape(shape2))
 
@@ -72,8 +29,7 @@ class ModelsTest(tf.test.TestCase, parameterized.TestCase):
         yield
         tf.keras.backend.clear_session()
 
-    @parameterized.parameters(*MODEL_LIST)
-    def test_application_base(self, app, _, args):
+    def _test_application_base(self, app, _, args):
         # Can be instantiated with default arguments
         model = app(include_top=True, classes=1000, include_rescaling=False, **args)
 
@@ -86,21 +42,16 @@ class ModelsTest(tf.test.TestCase, parameterized.TestCase):
         with self.assertRaises(ValueError):
             model.get_layer(name="rescaling")
 
-    @parameterized.parameters(*MODEL_LIST)
-    def test_application_with_rescaling(self, app, last_dim, args):
+    def _test_application_with_rescaling(self, app, last_dim, args):
         model = app(include_rescaling=True, include_top=False, **args)
         self.assertIsNotNone(model.get_layer(name="rescaling"))
 
-    @pytest.mark.skip(reason="temporarily reducing test load to prevent OOM")
-    @parameterized.parameters(*MODEL_LIST)
-    def test_application_pooling(self, app, last_dim, args):
+    def _test_application_pooling(self, app, last_dim, args):
         model = app(include_rescaling=False, include_top=False, pooling="avg", **args)
 
         self.assertShapeEqual(model.output_shape, (None, last_dim))
 
-    @pytest.mark.skip(reason="temporarily reducing test load to prevent OOM")
-    @parameterized.parameters(*MODEL_LIST)
-    def test_application_variable_input_channels(self, app, last_dim, args):
+    def _test_application_variable_input_channels(self, app, last_dim, args):
         # Make a local copy of args because we modify them in the test
         args = dict(args)
 
@@ -151,9 +102,7 @@ class ModelsTest(tf.test.TestCase, parameterized.TestCase):
             num_patches = 49
             self.assertShapeEqual(output_shape, (None, num_patches, last_dim))
 
-    @pytest.mark.skip(reason="temporarily reducing test load to prevent OOM")
-    @parameterized.parameters(*MODEL_LIST)
-    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+    def _test_model_can_be_used_as_backbone(self, app, last_dim, args):
         inputs = keras.layers.Input(shape=(224, 224, 3))
         backbone = app(
             include_rescaling=False,
@@ -170,7 +119,3 @@ class ModelsTest(tf.test.TestCase, parameterized.TestCase):
 
         model = keras.Model(inputs=inputs, outputs=[backbone_output])
         model.compile()
-
-
-if __name__ == "__main__":
-    tf.test.main()

--- a/keras_cv/models/resnet_v1_test.py
+++ b/keras_cv/models/resnet_v1_test.py
@@ -1,0 +1,52 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import resnet_v1
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (resnet_v1.ResNet50, 2048, {}),
+    (resnet_v1.ResNet101, 2048, {}),
+    (resnet_v1.ResNet152, 2048, {}),
+]
+
+
+class ResNetV1Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/resnet_v2_test.py
+++ b/keras_cv/models/resnet_v2_test.py
@@ -1,0 +1,52 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import resnet_v2
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (resnet_v2.ResNet50V2, 2048, {}),
+    (resnet_v2.ResNet101V2, 2048, {}),
+    (resnet_v2.ResNet152V2, 2048, {}),
+]
+
+
+class ResNetV2Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/keras_cv/models/vgg19_test.py
+++ b/keras_cv/models/vgg19_test.py
@@ -1,0 +1,50 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import vgg19
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (vgg19.VGG19, 512, {}),
+]
+
+
+class VGG19Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()


### PR DESCRIPTION
My opinion is that if these are too slow overall, we might want to consider just making all of the tests under /models run separately as integration tests only.

What are your thoughts? @LukeWood 