### PR TITLE
Add all of the no-op segmentation mask augmentations

### DIFF
--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -70,6 +70,9 @@ class AutoContrast(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update({"value_range": self.value_range})

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -28,7 +28,7 @@ TARGETS = "targets"
 BOUNDING_BOXES = "bounding_boxes"
 KEYPOINTS = "keypoints"
 RAGGED_BOUNDING_BOXES = "ragged_bounding_boxes"
-SEGMENTATION_MASK = "segmentation_mask"
+SEGMENTATION_MASK = "segmentation_masks"
 IS_DICT = "is_dict"
 USE_TARGETS = "use_targets"
 

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -28,7 +28,7 @@ TARGETS = "targets"
 BOUNDING_BOXES = "bounding_boxes"
 KEYPOINTS = "keypoints"
 RAGGED_BOUNDING_BOXES = "ragged_bounding_boxes"
-SEGMENTATION_MASK = "segmentation_masks"
+SEGMENTATION_MASKS = "segmentation_masks"
 IS_DICT = "is_dict"
 USE_TARGETS = "use_targets"
 
@@ -276,7 +276,7 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
         label = inputs.get(LABELS, None)
         bounding_boxes = inputs.get(BOUNDING_BOXES, None)
         keypoints = inputs.get(KEYPOINTS, None)
-        segmentation_mask = inputs.get(SEGMENTATION_MASK, None)
+        segmentation_mask = inputs.get(SEGMENTATION_MASKS, None)
         transformation = self.get_random_transformation(
             image=image,
             label=label,
@@ -321,7 +321,7 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
                 segmentation_mask,
                 transformation=transformation,
             )
-            result[SEGMENTATION_MASK] = segmentation_mask
+            result[SEGMENTATION_MASKS] = segmentation_mask
 
         # preserve any additional inputs unmodified by this layer.
         for key in inputs.keys() - result.keys():

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -44,6 +44,9 @@ class RandomAddLayer(BaseImageAugmentationLayer):
     def augment_keypoints(self, keypoints, transformation, **kwargs):
         return keypoints + transformation
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask + transformation
+
 
 class VectorizeDisabledLayer(BaseImageAugmentationLayer):
     def __init__(self, **kwargs):
@@ -148,15 +151,22 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         images = np.random.random(size=(8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(3, 5)).astype("float32")
         keypoints = np.random.random(size=(3, 5, 2)).astype("float32")
+        segmentation_mask = np.random.random(size=(8, 8, 3)).astype("float32")
 
         output = add_layer(
-            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+            {
+                "images": images,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_mask": segmentation_mask,
+            }
         )
 
         expected_output = {
             "images": images + 2.0,
             "bounding_boxes": bounding_boxes + 2.0,
             "keypoints": keypoints + 2.0,
+            "segmentation_mask": segmentation_mask + 2.0,
         }
         self.assertAllClose(output, expected_output)
 
@@ -165,53 +175,78 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 5)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
+        segmentation_mask = np.random.random(size=(2, 8, 8, 3)).astype("float32")
 
         output = add_layer(
-            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+            {
+                "images": images,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_mask": segmentation_mask,
+            }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
+        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
+        self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
 
         @tf.function
         def in_tf_function(inputs):
             return add_layer(inputs)
 
         output = in_tf_function(
-            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+            {
+                "images": images,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_mask": segmentation_mask,
+            }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
+        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
+        self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
 
     def test_augment_all_data_in_tf_function(self):
         add_layer = RandomAddLayer()
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 5)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
+        segmentation_mask = np.random.random(size=(2, 8, 8, 3)).astype("float32")
 
         @tf.function
         def in_tf_function(inputs):
             return add_layer(inputs)
 
         output = in_tf_function(
-            {"images": images, "bounding_boxes": bounding_boxes, "keypoints": keypoints}
+            {
+                "images": images,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_mask": segmentation_mask,
+            }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
+        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
+        self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
 
     def test_raise_error_missing_class_id(self):
         add_layer = RandomAddLayer()
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 4)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
+        segmentation_mask = np.random.random(size=(2, 8, 8, 3)).astype("float32")
+
         with self.assertRaisesRegex(
             ValueError,
             "Bounding boxes are missing class_id. If you would like to pad the "
@@ -223,5 +258,6 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
                     "images": images,
                     "bounding_boxes": bounding_boxes,
                     "keypoints": keypoints,
+                    "segmentation_mask": segmentation_mask,
                 }
             )

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -158,7 +158,7 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
                 "images": images,
                 "bounding_boxes": bounding_boxes,
                 "keypoints": keypoints,
-                "segmentation_mask": segmentation_mask,
+                "segmentation_masks": segmentation_mask,
             }
         )
 
@@ -166,7 +166,7 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
             "images": images + 2.0,
             "bounding_boxes": bounding_boxes + 2.0,
             "keypoints": keypoints + 2.0,
-            "segmentation_mask": segmentation_mask + 2.0,
+            "segmentation_masks": segmentation_mask + 2.0,
         }
         self.assertAllClose(output, expected_output)
 
@@ -175,20 +175,20 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 5)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
-        segmentation_mask = np.random.random(size=(2, 8, 8, 1)).astype("float32")
+        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype("float32")
 
         output = add_layer(
             {
                 "images": images,
                 "bounding_boxes": bounding_boxes,
                 "keypoints": keypoints,
-                "segmentation_mask": segmentation_mask,
+                "segmentation_masks": segmentation_masks,
             }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
-        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
+        segmentation_mask_diff = output["segmentation_masks"] - segmentation_masks
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
         self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
@@ -202,13 +202,13 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
                 "images": images,
                 "bounding_boxes": bounding_boxes,
                 "keypoints": keypoints,
-                "segmentation_mask": segmentation_mask,
+                "segmentation_masks": segmentation_masks,
             }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
-        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
+        segmentation_mask_diff = output["segmentation_masks"] - segmentation_masks
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
         self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
@@ -218,7 +218,7 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 5)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
-        segmentation_mask = np.random.random(size=(2, 8, 8, 1)).astype("float32")
+        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype("float32")
 
         @tf.function
         def in_tf_function(inputs):
@@ -229,13 +229,13 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
                 "images": images,
                 "bounding_boxes": bounding_boxes,
                 "keypoints": keypoints,
-                "segmentation_mask": segmentation_mask,
+                "segmentation_masks": segmentation_masks,
             }
         )
 
         bounding_boxes_diff = output["bounding_boxes"] - bounding_boxes
         keypoints_diff = output["keypoints"] - keypoints
-        segmentation_mask_diff = output["segmentation_mask"] - segmentation_mask
+        segmentation_mask_diff = output["segmentation_masks"] - segmentation_masks
         self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
         self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
         self.assertNotAllClose(segmentation_mask_diff[0], segmentation_mask_diff[1])
@@ -245,7 +245,7 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 3, 4)).astype("float32")
         keypoints = np.random.random(size=(2, 3, 5, 2)).astype("float32")
-        segmentation_mask = np.random.random(size=(2, 8, 8, 1)).astype("float32")
+        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype("float32")
 
         with self.assertRaisesRegex(
             ValueError,
@@ -258,6 +258,6 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
                     "images": images,
                     "bounding_boxes": bounding_boxes,
                     "keypoints": keypoints,
-                    "segmentation_mask": segmentation_mask,
+                    "segmentation_masks": segmentation_masks,
                 }
             )

--- a/keras_cv/layers/preprocessing/channel_shuffle.py
+++ b/keras_cv/layers/preprocessing/channel_shuffle.py
@@ -83,6 +83,9 @@ class ChannelShuffle(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update({"groups": self.groups, "seed": self.seed})

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -118,6 +118,9 @@ class Equalization(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update({"bins": self.bins, "value_range": self.value_range})

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -76,6 +76,9 @@ class Grayscale(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = {
             "output_channels": self.output_channels,

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -241,6 +241,9 @@ class GridMask(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = {
             "ratio_factor": self.ratio_factor,

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -93,6 +93,9 @@ class Posterization(BaseImageAugmentationLayer):
     def augment_bounding_boxes(self, bounding_boxes, **kwargs):
         return bounding_boxes
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def _batch_augment(self, inputs):
         # Skip the use of vectorized_map or map_fn as the implementation is already
         # vectorized

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -97,6 +97,9 @@ class RandomChannelShift(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -68,6 +68,9 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update({"factor": self.factor, "seed": self.seed})

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -138,6 +138,9 @@ class RandomColorJitter(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -89,6 +89,9 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     @staticmethod
     def get_kernel(factor, filter_size):
         x = tf.cast(

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -77,6 +77,9 @@ class RandomHue(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = {
             "factor": self.factor,

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -67,6 +67,9 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update({"factor": self.factor, "seed": self.seed})

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -77,6 +77,9 @@ class RandomSaturation(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = {
             "factor": self.factor,

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -117,6 +117,9 @@ class RandomSharpness(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = super().get_config()
         config.update(

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -109,6 +109,9 @@ class Solarization(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
     def get_config(self):
         config = {
             "threshold_factor": self.threshold_factor,

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -99,7 +99,9 @@ class WithLabelsTest(tf.test.TestCase, parameterized.TestCase):
         labels = tf.ones((3,), dtype=tf.float32)
 
         inputs = {"images": img, "labels": labels}
-        _ = layer(inputs)
+        outputs = layer(inputs)
+
+        self.assertIn("labels", outputs)
 
     # this has to be a separate test case to exclude CutMix and MixUp
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
@@ -111,4 +113,6 @@ class WithLabelsTest(tf.test.TestCase, parameterized.TestCase):
         labels = tf.ones((), dtype=tf.float32)
 
         inputs = {"images": img, "labels": labels}
-        _ = layer(inputs)
+        outputs = layer(inputs)
+
+        self.assertIn("labels", outputs)

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -73,33 +73,43 @@ TEST_CONFIGURATIONS = [
 class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
     def test_can_run_with_segmentation_masks(self, layer_cls, init_args):
+        classes = 10
         layer = layer_cls(**init_args)
 
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
         segmentation_masks = tf.random.uniform(
-            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.int32
+            shape=(3, 512, 512, 1), minval=0, maxval=classes, dtype=tf.int32
         )
 
         inputs = {"images": img, "segmentation_masks": segmentation_masks}
         outputs = layer(inputs)
 
         self.assertIn("segmentation_masks", outputs)
+        # This currently asserts that all layers are no-ops.
+        # When preprocessing layers are updated to mutate segmentation masks,
+        # this condition should only be asserted for no-op layers.
+        self.assertAllClose(inputs["segmentation_masks"], outputs["segmentation_masks"])
 
     # This has to be a separate test case to exclude CutMix and MixUp
     # (which are not yet supported for segmentation mask augmentation)
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
     def test_can_run_with_segmentation_mask_single_image(self, layer_cls, init_args):
+        classes = 10
         layer = layer_cls(**init_args)
         img = tf.random.uniform(
             shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
         segmentation_mask = tf.random.uniform(
-            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.int32
+            shape=(512, 512, 1), minval=0, maxval=classes, dtype=tf.int32
         )
 
         inputs = {"images": img, "segmentation_masks": segmentation_mask}
         outputs = layer(inputs)
 
         self.assertIn("segmentation_masks", outputs)
+        # This currently asserts that all layers are no-ops.
+        # When preprocessing layers are updated to mutate segmentation masks,
+        # this condition should only be asserted for no-op layers.
+        self.assertAllClose(inputs["segmentation_masks"], outputs["segmentation_masks"])

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -83,7 +83,9 @@ class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
         )
 
         inputs = {"images": img, "segmentation_masks": segmentation_masks}
-        _ = layer(inputs)
+        outputs = layer(inputs)
+
+        self.assertIn("segmentation_masks", outputs)
 
     # This has to be a separate test case to exclude CutMix and MixUp
     # (which are not yet supported for segmentation mask augmentation)
@@ -98,4 +100,6 @@ class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
         )
 
         inputs = {"images": img, "segmentation_masks": segmentation_mask}
-        _ = layer(inputs)
+        outputs = layer(inputs)
+
+        self.assertIn("segmentation_masks", outputs)

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -20,15 +20,6 @@ TEST_CONFIGURATIONS = [
     ("AutoContrast", preprocessing.AutoContrast, {"value_range": (0, 255)}),
     ("ChannelShuffle", preprocessing.ChannelShuffle, {}),
     ("Equalization", preprocessing.Equalization, {"value_range": (0, 255)}),
-    (
-        "RandomResizedCrop",
-        preprocessing.RandomResizedCrop,
-        {
-            "target_size": (224, 224),
-            "crop_area_factor": (0.8, 1.0),
-            "aspect_ratio_factor": (3 / 4, 4 / 3),
-        },
-    ),
     ("Grayscale", preprocessing.Grayscale, {}),
     ("GridMask", preprocessing.GridMask, {}),
     (
@@ -40,11 +31,6 @@ TEST_CONFIGURATIONS = [
         "RandomColorDegeneration",
         preprocessing.RandomColorDegeneration,
         {"factor": 0.5},
-    ),
-    (
-        "RandomCutout",
-        preprocessing.RandomCutout,
-        {"height_factor": 0.2, "width_factor": 0.2},
     ),
     (
         "RandomHue",
@@ -80,35 +66,36 @@ TEST_CONFIGURATIONS = [
         preprocessing.RandomSharpness,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
-    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
     ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
 ]
 
 
-class WithLabelsTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(
-        *TEST_CONFIGURATIONS,
-        ("CutMix", preprocessing.CutMix, {}),
-    )
-    def test_can_run_with_labels(self, layer_cls, init_args):
+class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    def test_can_run_with_segmentation_masks(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
 
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((3,), dtype=tf.float32)
+        segmentation_masks = tf.random.uniform(
+            shape=(3, 512, 512, 3), minval=0, maxval=1, dtype=tf.int32
+        )
 
-        inputs = {"images": img, "labels": labels}
+        inputs = {"images": img, "segmentation_masks": segmentation_masks}
         _ = layer(inputs)
 
-    # this has to be a separate test case to exclude CutMix and MixUp
+    # This has to be a separate test case to exclude CutMix and MixUp
+    # (which are not yet supported for segmentation mask augmentation)
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
-    def test_can_run_with_labels_single_image(self, layer_cls, init_args):
+    def test_can_run_with_segmentation_mask_single_image(self, layer_cls, init_args):
         layer = layer_cls(**init_args)
         img = tf.random.uniform(
             shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.float32
         )
-        labels = tf.ones((), dtype=tf.float32)
+        segmentation_mask = tf.random.uniform(
+            shape=(512, 512, 3), minval=0, maxval=1, dtype=tf.int32
+        )
 
-        inputs = {"images": img, "labels": labels}
+        inputs = {"images": img, "segmentation_masks": segmentation_mask}
         _ = layer(inputs)


### PR DESCRIPTION
This adds "segmentation map support" to all the layers that shouldn't change a segmentation map (mostly because they're just color adjustments)