### PR TITLE
Fix FocalLoss reduction, SmoothL1 reduction, and add extra loss validation to RetinaNet model

### DIFF
--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -86,7 +86,7 @@ class FocalLoss(tf.keras.losses.Loss):
         alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
-        return K.mean(loss, axis=-1)
+        return K.sum(loss, axis=-1)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -86,7 +86,7 @@ class FocalLoss(tf.keras.losses.Loss):
         alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
-        return loss
+        return tf.math.reduce_sum(loss, axis=-1)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -86,7 +86,7 @@ class FocalLoss(tf.keras.losses.Loss):
         alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
-        return tf.math.reduce_sum(loss, axis=-1)
+        return K.mean(loss, axis=-1)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -86,6 +86,14 @@ class FocalLoss(tf.keras.losses.Loss):
         alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
+        # In most losses you mean over the final axis to achieve a scalar
+        # Focal loss however is a special case in that it is meant to focus on
+        # a small number of hard examples in a batch.  Most of the time this
+        # comes in the form of thousands of background class boxes and a few
+        # positive boxes.
+        # If you mean over the final axis you will get a number close to 0,
+        # which will encourage your model to exclusively predict background
+        # class boxes.
         return K.sum(loss, axis=-1)
 
     def get_config(self):

--- a/keras_cv/losses/focal_test.py
+++ b/keras_cv/losses/focal_test.py
@@ -40,7 +40,7 @@ class FocalTest(tf.test.TestCase):
 
         self.assertAllEqual(
             focal_loss(y_true, y_pred).shape,
-            [2, 5],
+            [2,],
         )
 
     def test_output_shape_from_logits(self):
@@ -52,30 +52,14 @@ class FocalTest(tf.test.TestCase):
             shape=[2, 5], minval=-10, maxval=10, dtype=tf.float32
         )
 
-        focal_loss = FocalLoss()
+        focal_loss = FocalLoss(reduction="none", from_logits=True)
 
-        self.assertAllEqual(focal_loss(y_true, y_pred).shape, [])
+        self.assertAllEqual(focal_loss(y_true, y_pred).shape, [2,])
 
-    def test_1d_output(self):
-        y_true = [0.0, 1.0, 1.0]
-        y_pred = [0.1, 0.7, 0.9]
-
-        focal_loss = FocalLoss()
-
-        self.assertAllClose(focal_loss(y_true, y_pred), 0.00302626)
-
-    def test_1d_output_from_logits(self):
-        y_true = [0.0, 1.0, 1.0]
-        y_pred = [-2.1972246, 0.8472978, 2.1972241]
-
-        focal_loss = FocalLoss(from_logits=True)
-
-        self.assertAllClose(focal_loss(y_true, y_pred), 0.00302626)
 
     def test_from_logits_argument(self):
         y_true = tf.random.uniform((2, 8, 10))
         y_logits = tf.random.uniform((2, 8, 10), minval=-1000, maxval=1000)
-
         y_pred = tf.nn.sigmoid(y_logits)
 
         focal_loss_on_logits = FocalLoss(from_logits=True)

--- a/keras_cv/losses/focal_test.py
+++ b/keras_cv/losses/focal_test.py
@@ -40,7 +40,9 @@ class FocalTest(tf.test.TestCase):
 
         self.assertAllEqual(
             focal_loss(y_true, y_pred).shape,
-            [2,],
+            [
+                2,
+            ],
         )
 
     def test_output_shape_from_logits(self):
@@ -54,8 +56,12 @@ class FocalTest(tf.test.TestCase):
 
         focal_loss = FocalLoss(reduction="none", from_logits=True)
 
-        self.assertAllEqual(focal_loss(y_true, y_pred).shape, [2,])
-
+        self.assertAllEqual(
+            focal_loss(y_true, y_pred).shape,
+            [
+                2,
+            ],
+        )
 
     def test_from_logits_argument(self):
         y_true = tf.random.uniform((2, 8, 10))

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -48,7 +48,7 @@ class ModelGardenFocalLoss(tf.keras.losses.Loss):
 
 
 class FocalLossModelGardenComparisonTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(("sum", "sum"))
+    @parameterized.named_parameters(("sum_over_batch_size", "sum_over_batch_size"), ("auto", "auto"))
     def test_model_garden_implementation_has_same_outputs(self, reduction):
 
         focal_loss = FocalLoss(

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -48,7 +48,7 @@ class ModelGardenFocalLoss(tf.keras.losses.Loss):
 
 
 class FocalLossModelGardenComparisonTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(("auto", "auto"), ("sum", "sum"))
+    @parameterized.named_parameters(("sum", "sum"))
     def test_model_garden_implementation_has_same_outputs(self, reduction):
 
         focal_loss = FocalLoss(

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -48,7 +48,9 @@ class ModelGardenFocalLoss(tf.keras.losses.Loss):
 
 
 class FocalLossModelGardenComparisonTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(("sum", "sum"),)
+    @parameterized.named_parameters(
+        ("sum", "sum"),
+    )
     def test_model_garden_implementation_has_same_outputs(self, reduction):
 
         focal_loss = FocalLoss(

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -48,7 +48,7 @@ class ModelGardenFocalLoss(tf.keras.losses.Loss):
 
 
 class FocalLossModelGardenComparisonTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(("sum_over_batch_size", "sum_over_batch_size"), ("auto", "auto"))
+    @parameterized.named_parameters(("sum", "sum"),)
     def test_model_garden_implementation_has_same_outputs(self, reduction):
 
         focal_loss = FocalLoss(

--- a/keras_cv/losses/smooth_l1.py
+++ b/keras_cv/losses/smooth_l1.py
@@ -37,11 +37,11 @@ class SmoothL1Loss(tf.keras.losses.Loss):
         absolute_difference = tf.abs(difference)
         squared_difference = difference**2
         loss = tf.where(
-            tf.less(absolute_difference, self.l1_cutoff),
+            absolute_difference < self.l1_cutoff,
             0.5 * squared_difference,
             absolute_difference - 0.5,
         )
-        return loss
+        return tf.keras.backend.mean(loss, axis=-1)
 
     def get_config(self):
         config = {

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -20,7 +20,7 @@ import keras_cv
 
 class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
-        ("none", "none", (20, 300)),
+        ("none", "none", (20,)),
         ("sum", "sum", ()),
         ("sum_over_batch_size", "sum_over_batch_size", ()),
     )

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -327,11 +327,6 @@ class RetinaNet(ObjectDetectionBaseModel):
 
         classification_loss = self.classification_loss(cls_labels, cls_predictions)
         box_loss = self.box_loss(box_labels, box_predictions)
-
-        classification_loss = tf.where(
-            tf.equal(ignore_mask, 1.0), 0.0, classification_loss
-        )
-
         if len(classification_loss.shape) != 2:
             raise ValueError(
                 "RetinaNet expects the output shape of `classification_loss` to be "
@@ -341,8 +336,6 @@ class RetinaNet(ObjectDetectionBaseModel):
                 "Try passing `reduction='none'` to your classification_loss's "
                 "constructor."
             )
-        box_loss = tf.where(tf.equal(positive_mask, 1.0), box_loss, 0.0)
-
         if len(box_loss.shape) != 2:
             raise ValueError(
                 "RetinaNet expects the output shape of `box_loss` to be "
@@ -352,6 +345,12 @@ class RetinaNet(ObjectDetectionBaseModel):
                 "Try passing `reduction='none'` to your box_loss's "
                 "constructor."
             )
+        classification_loss = tf.where(
+            tf.equal(ignore_mask, 1.0), 0.0, classification_loss
+        )
+
+        box_loss = tf.where(tf.equal(positive_mask, 1.0), box_loss, 0.0)
+
         normalizer = tf.reduce_sum(positive_mask, axis=-1)
         classification_loss = tf.math.divide_no_nan(
             tf.reduce_sum(classification_loss, axis=-1), normalizer

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -120,23 +120,29 @@ class RetinaNetTest(tf.test.TestCase):
             backbone_weights=None,
             include_rescaling=True,
         )
-        xs, ys = _create_bounding_box_dataset('xywh')
+        xs, ys = _create_bounding_box_dataset("xywh")
 
         # all metric formats must match
         retina_net.compile(
             optimizer="adam",
             box_loss=keras_cv.losses.SmoothL1Loss(reduction="none"),
-            classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="sum"),
+            classification_loss=keras_cv.losses.FocalLoss(
+                from_logits=True, reduction="sum"
+            ),
         )
 
-        with self.assertRaisesRegex(ValueError, "output shape of `classification_loss`"):
+        with self.assertRaisesRegex(
+            ValueError, "output shape of `classification_loss`"
+        ):
             retina_net.fit(x=xs, y=ys, epochs=1)
 
         # all metric formats must match
         retina_net.compile(
             optimizer="adam",
             box_loss=keras_cv.losses.SmoothL1Loss(reduction="sum"),
-            classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="none"),
+            classification_loss=keras_cv.losses.FocalLoss(
+                from_logits=True, reduction="none"
+            ),
         )
         with self.assertRaisesRegex(ValueError, "output shape of `box_loss`"):
             retina_net.fit(x=xs, y=ys, epochs=1)
@@ -173,8 +179,10 @@ class RetinaNetTest(tf.test.TestCase):
 
         retina_net.compile(
             optimizer=optimizers.SGD(learning_rate=0.25),
-            classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction='none'),
-            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction='none'),
+            classification_loss=keras_cv.losses.FocalLoss(
+                from_logits=True, reduction="none"
+            ),
+            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
         )
 
     # TODO(lukewood): configure for other coordinate systems.

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -126,7 +126,7 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net.compile(
             optimizer="adam",
             box_loss=keras_cv.losses.SmoothL1Loss(reduction="none"),
-            classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="auto"),
+            classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="sum"),
         )
 
         with self.assertRaisesRegex(ValueError, "output shape of `classification_loss`"):
@@ -135,7 +135,7 @@ class RetinaNetTest(tf.test.TestCase):
         # all metric formats must match
         retina_net.compile(
             optimizer="adam",
-            box_loss=keras_cv.losses.SmoothL1Loss(reduction="auto"),
+            box_loss=keras_cv.losses.SmoothL1Loss(reduction="sum"),
             classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="none"),
         )
         with self.assertRaisesRegex(ValueError, "output shape of `box_loss`"):


### PR DESCRIPTION
This fixes convergence issues in the tutorial and prevents others from falling into the same issue.

If you reduce your results on too many axes, you cannot mask out the ignore mask in your samples.