### PR TITLE
Fix weight loading in RetinaNet and introduce unit tests to ensure weight loading works as intended

### DIFF
--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -112,7 +112,7 @@ class RandomFlip(BaseImageAugmentationLayer):
 
     def _flip_bounding_boxes_horizontal(bounding_boxes):
         x1, x2, x3, x4, rest = tf.split(
-            bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
+            bounding_boxes, [1, 1, 1, 1, tf.shape(bounding_boxes)[-1] - 4], axis=-1
         )
         output = tf.stack(
             [
@@ -130,7 +130,7 @@ class RandomFlip(BaseImageAugmentationLayer):
 
     def _flip_bounding_boxes_vertical(bounding_boxes):
         x1, x2, x3, x4, rest = tf.split(
-            bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
+            bounding_boxes, [1, 1, 1, 1, tf.shape(bounding_boxes)[-1] - 4], axis=-1
         )
         output = tf.stack(
             [
@@ -171,11 +171,6 @@ class RandomFlip(BaseImageAugmentationLayer):
             transformation["flip_vertical"],
             lambda: RandomFlip._flip_bounding_boxes_vertical(bounding_boxes),
             lambda: bounding_boxes,
-        )
-        bounding_boxes = bounding_box.clip_to_image(
-            bounding_boxes,
-            bounding_box_format="rel_xyxy",
-            images=image,
         )
         bounding_boxes = bounding_box.convert_format(
             bounding_boxes,

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -112,7 +112,7 @@ class RandomFlip(BaseImageAugmentationLayer):
 
     def _flip_bounding_boxes_horizontal(bounding_boxes):
         x1, x2, x3, x4, rest = tf.split(
-            bounding_boxes, [1, 1, 1, 1, tf.shape(bounding_boxes)[-1] - 4], axis=-1
+            bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
         )
         output = tf.stack(
             [
@@ -130,7 +130,7 @@ class RandomFlip(BaseImageAugmentationLayer):
 
     def _flip_bounding_boxes_vertical(bounding_boxes):
         x1, x2, x3, x4, rest = tf.split(
-            bounding_boxes, [1, 1, 1, 1, tf.shape(bounding_boxes)[-1] - 4], axis=-1
+            bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
         )
         output = tf.stack(
             [
@@ -171,6 +171,11 @@ class RandomFlip(BaseImageAugmentationLayer):
             transformation["flip_vertical"],
             lambda: RandomFlip._flip_bounding_boxes_vertical(bounding_boxes),
             lambda: bounding_boxes,
+        )
+        bounding_boxes = bounding_box.clip_to_image(
+            bounding_boxes,
+            bounding_box_format="rel_xyxy",
+            images=image,
         )
         bounding_boxes = bounding_box.convert_format(
             bounding_boxes,

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
 class FeaturePyramid(keras.layers.Layer):
     """Builds the Feature Pyramid with the feature maps from the backbone."""
 

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
@@ -34,14 +34,14 @@ class FeaturePyramid(keras.layers.Layer):
 
     def call(self, inputs, training=False):
         c3_output, c4_output, c5_output = inputs
-        p3_output = self.conv_c3_1x1(c3_output)
-        p4_output = self.conv_c4_1x1(c4_output)
-        p5_output = self.conv_c5_1x1(c5_output)
-        p4_output = p4_output + self.upsample_2x(p5_output)
-        p3_output = p3_output + self.upsample_2x(p4_output)
-        p3_output = self.conv_c3_3x3(p3_output)
-        p4_output = self.conv_c4_3x3(p4_output)
-        p5_output = self.conv_c5_3x3(p5_output)
-        p6_output = self.conv_c6_3x3(c5_output)
-        p7_output = self.conv_c7_3x3(tf.nn.relu(p6_output))
+        p3_output = self.conv_c3_1x1(c3_output, training=training)
+        p4_output = self.conv_c4_1x1(c4_output, training=training)
+        p5_output = self.conv_c5_1x1(c5_output, training=training)
+        p4_output = p4_output + self.upsample_2x(p5_output, training=training)
+        p3_output = p3_output + self.upsample_2x(p4_output, training=training)
+        p3_output = self.conv_c3_3x3(p3_output, training=training)
+        p4_output = self.conv_c4_3x3(p4_output, training=training)
+        p5_output = self.conv_c5_3x3(p5_output, training=training)
+        p6_output = self.conv_c6_3x3(c5_output, training=training)
+        p7_output = self.conv_c7_3x3(tf.nn.relu(p6_output), training=training)
         return p3_output, p4_output, p5_output, p6_output, p7_output

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -29,7 +29,7 @@ class PredictionHead(layers.Layer):
       A function representing either the classification
         or the box regression head depending on `output_filters`.
     """
-    def __init__(self, output_filters, bias_initializer, num_conv_layers=0, **kwargs):
+    def __init__(self, output_filters, bias_initializer, num_conv_layers=1, **kwargs):
         super().__init__(**kwargs)
         self.output_filters = output_filters
         self.bias_initializer = bias_initializer

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -16,7 +16,9 @@ import tensorflow as tf
 from tensorflow.keras import initializers
 from tensorflow.keras import layers
 
-def PredictionHead(output_filters, bias_initializer):
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class PredictionHead(layers.Layer):
     """The class/box predictions head.
 
     Arguments:
@@ -27,19 +29,42 @@ def PredictionHead(output_filters, bias_initializer):
       A function representing either the classification
         or the box regression head depending on `output_filters`.
     """
-    return tf.keras.Sequential(
-        [layers.Conv2D(
-            256,
-            3,
-            padding="same",
-            kernel_initializer=initializers.RandomNormal(0.0, 0.01),
-            activation="relu",
-        ) for _ in range(4)] + [layers.Conv2D(
-            output_filters,
-            3,
-            1,
-            padding="same",
-            kernel_initializer=initializers.RandomNormal(0.0, 0.01),
-            bias_initializer=bias_initializer,
-        )]
-    )
+
+    def __init__(self, output_filters, bias_initializer, **kwargs):
+        super().__init__(**kwargs)
+        self.output_filters = output_filters
+        self.bias_initializer = bias_initializer
+        conv_layers = [
+            layers.Conv2D(
+                256,
+                3,
+                padding="same",
+                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+                activation="relu",
+            )
+            for _ in range(4)
+        ]
+        conv_layers += [
+            layers.Conv2D(
+                self.output_filters,
+                3,
+                1,
+                padding="same",
+                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+                bias_initializer=self.bias_initializer,
+            )
+        ]
+        self.conv_layers = conv_layers
+
+    def call(self, x, training=False):
+        for layer in self.conv_layers:
+            x = layer(x, training=training)
+        return x
+
+    def get_config(self):
+        config = {
+            "bias_initializer": self.bias_initializer,
+            "output_filters": self.output_filters,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -39,7 +39,7 @@ class PredictionHead(layers.Layer):
                 256,
                 3,
                 padding="same",
-                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+                kernel_initializer=tf.keras.initializers.Orthogonal(),
                 activation="relu",
             )
             for _ in range(num_conv_layers)
@@ -49,7 +49,7 @@ class PredictionHead(layers.Layer):
             3,
             1,
             padding="same",
-            kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+            kernel_initializer=tf.keras.initializers.Orthogonal(),
             bias_initializer=self.bias_initializer,
         )
 
@@ -63,7 +63,7 @@ class PredictionHead(layers.Layer):
         config = {
             "bias_initializer": self.bias_initializer,
             "output_filters": self.output_filters,
-            "conv_layers": self.num_conv_layers
+            "num_conv_layers": self.num_conv_layers
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -30,7 +30,7 @@ class PredictionHead(layers.Layer):
         or the box regression head depending on `output_filters`.
     """
 
-    def __init__(self, output_filters, bias_initializer, **kwargs):
+    def __init__(self, output_filters, bias_initializer, conv_layers=1, **kwargs):
         super().__init__(**kwargs)
         self.output_filters = output_filters
         self.bias_initializer = bias_initializer
@@ -39,10 +39,9 @@ class PredictionHead(layers.Layer):
                 256,
                 3,
                 padding="same",
-                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
                 activation="relu",
             )
-            for _ in range(4)
+            for _ in range(conv_layers)
         ]
         conv_layers += [
             layers.Conv2D(
@@ -50,7 +49,6 @@ class PredictionHead(layers.Layer):
                 3,
                 1,
                 padding="same",
-                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
                 bias_initializer=self.bias_initializer,
             )
         ]

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -34,9 +34,6 @@ class PredictionHead(layers.Layer):
         super().__init__(**kwargs)
         self.output_filters = output_filters
         self.bias_initializer = bias_initializer
-        self.conv_layers = None
-
-    def build(self, input_shape):
         conv_layers = [
             layers.Conv2D(
                 256,

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -37,7 +37,7 @@ class PredictionHead(layers.Layer):
         self.conv_layers = [
             layers.Conv2D(
                 256,
-                3,
+                kernel_size=1,
                 padding="same",
                 kernel_initializer=tf.keras.initializers.Orthogonal(),
                 activation="relu",
@@ -46,8 +46,8 @@ class PredictionHead(layers.Layer):
         ]
         self.prediction_layer = layers.Conv2D(
             self.output_filters,
-            3,
-            1,
+            kernel_size=3,
+            strides=1,
             padding="same",
             kernel_initializer=tf.keras.initializers.Orthogonal(),
             bias_initializer=self.bias_initializer,

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -39,6 +39,7 @@ class PredictionHead(layers.Layer):
                 256,
                 3,
                 padding="same",
+                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
                 activation="relu",
             )
             for _ in range(conv_layers)
@@ -49,6 +50,7 @@ class PredictionHead(layers.Layer):
                 3,
                 1,
                 padding="same",
+                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
                 bias_initializer=self.bias_initializer,
             )
         ]

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -34,6 +34,7 @@ class PredictionHead(layers.Layer):
         super().__init__(**kwargs)
         self.output_filters = output_filters
         self.bias_initializer = bias_initializer
+        self.num_conv_layers = num_conv_layers
 
         self.conv_layers = [
             layers.Conv2D(

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -29,6 +29,7 @@ class PredictionHead(layers.Layer):
       A function representing either the classification
         or the box regression head depending on `output_filters`.
     """
+
     def __init__(self, output_filters, bias_initializer, num_conv_layers=1, **kwargs):
         super().__init__(**kwargs)
         self.output_filters = output_filters
@@ -63,7 +64,7 @@ class PredictionHead(layers.Layer):
         config = {
             "bias_initializer": self.bias_initializer,
             "output_filters": self.output_filters,
-            "num_conv_layers": self.num_conv_layers
+            "num_conv_layers": self.num_conv_layers,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -15,6 +15,7 @@
 import tensorflow as tf
 from tensorflow.keras import initializers
 from tensorflow.keras import layers
+from tensorflow.keras import regularizers
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
@@ -42,6 +43,7 @@ class PredictionHead(layers.Layer):
                 padding="same",
                 kernel_initializer=tf.keras.initializers.Orthogonal(),
                 activation="relu",
+                kernel_regularizer=regularizers.L1L2(l1=1e-5, l2=1e-4),
             )
             for _ in range(num_conv_layers)
         ]
@@ -52,6 +54,7 @@ class PredictionHead(layers.Layer):
             padding="same",
             kernel_initializer=tf.keras.initializers.Orthogonal(),
             bias_initializer=self.bias_initializer,
+            kernel_regularizer=regularizers.L1L2(l1=1e-5, l2=1e-4),
         )
 
     def call(self, x, training=False):

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -43,7 +43,7 @@ class PredictionHead(layers.Layer):
                 kernel_initializer=initializers.RandomNormal(0.0, 0.01),
                 activation="relu",
             )
-            for _ in range(conv_layers)
+            for _ in range(num_conv_layers)
         ]
         self.prediction_layer = layers.Conv2D(
             self.output_filters,

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import initializers
 from tensorflow.keras import layers
 from tensorflow.keras import regularizers
 

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -29,7 +29,6 @@ class PredictionHead(layers.Layer):
       A function representing either the classification
         or the box regression head depending on `output_filters`.
     """
-
     def __init__(self, output_filters, bias_initializer, num_conv_layers=0, **kwargs):
         super().__init__(**kwargs)
         self.output_filters = output_filters

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -30,7 +30,7 @@ class PredictionHead(layers.Layer):
         or the box regression head depending on `output_filters`.
     """
 
-    def __init__(self, output_filters, bias_initializer, conv_layers=1, **kwargs):
+    def __init__(self, output_filters, bias_initializer, conv_layers=4, **kwargs):
         super().__init__(**kwargs)
         self.output_filters = output_filters
         self.bias_initializer = bias_initializer

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -35,11 +35,11 @@ def PredictionHead(output_filters, bias_initializer):
             kernel_initializer=initializers.RandomNormal(0.0, 0.01),
             activation="relu",
         ) for _ in range(4)] + [layers.Conv2D(
-            self.output_filters,
+            output_filters,
             3,
             1,
             padding="same",
             kernel_initializer=initializers.RandomNormal(0.0, 0.01),
-            bias_initializer=self.bias_initializer,
+            bias_initializer=bias_initializer,
         )]
     )

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -16,9 +16,7 @@ import tensorflow as tf
 from tensorflow.keras import initializers
 from tensorflow.keras import layers
 
-
-@tf.keras.utils.register_keras_serializable(package="keras_cv")
-class PredictionHead(layers.Layer):
+def PredictionHead(output_filters, bias_initializer):
     """The class/box predictions head.
 
     Arguments:
@@ -29,42 +27,19 @@ class PredictionHead(layers.Layer):
       A function representing either the classification
         or the box regression head depending on `output_filters`.
     """
-
-    def __init__(self, output_filters, bias_initializer, **kwargs):
-        super().__init__(**kwargs)
-        self.output_filters = output_filters
-        self.bias_initializer = bias_initializer
-        conv_layers = [
-            layers.Conv2D(
-                256,
-                3,
-                padding="same",
-                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
-                activation="relu",
-            )
-            for _ in range(4)
-        ]
-        conv_layers += [
-            layers.Conv2D(
-                self.output_filters,
-                3,
-                1,
-                padding="same",
-                kernel_initializer=initializers.RandomNormal(0.0, 0.01),
-                bias_initializer=self.bias_initializer,
-            )
-        ]
-        self.conv_layers = conv_layers
-
-    def call(self, x, training=False):
-        for layer in self.conv_layers:
-            x = layer(x)
-        return x
-
-    def get_config(self):
-        config = {
-            "bias_initializer": self.bias_initializer,
-            "output_filters": self.output_filters,
-        }
-        base_config = super().get_config()
-        return dict(list(base_config.items()) + list(config.items()))
+    return tf.keras.Sequential(
+        [layers.Conv2D(
+            256,
+            3,
+            padding="same",
+            kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+            activation="relu",
+        ) for _ in range(4)] + [layers.Conv2D(
+            self.output_filters,
+            3,
+            1,
+            padding="same",
+            kernel_initializer=initializers.RandomNormal(0.0, 0.01),
+            bias_initializer=self.bias_initializer,
+        )]
+    )

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -38,7 +38,7 @@ class PredictionHead(layers.Layer):
         self.conv_layers = [
             layers.Conv2D(
                 256,
-                kernel_size=1,
+                kernel_size=3,
                 padding="same",
                 kernel_initializer=tf.keras.initializers.Orthogonal(),
                 activation="relu",

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -454,13 +454,8 @@ class RetinaNet(ObjectDetectionBaseModel):
         self._update_metrics(y_for_metrics, predictions)
         return {m.name: m.result() for m in self.metrics}
 
-    # make a setter for prediction decoder
-    # bust the train_step... caches
-    # def predict_step(self, x)...
-
-    def predict(self, x, **kwargs):
-        # TODO(lukewood): implement graph mode predict function
-        predictions = super().predict(x, **kwargs)
+    def predict_step(self, x):
+        predictions = super().predict_step(x)
         return self.decode_training_predictions(x, predictions)
 
     def _update_metrics(self, y_true, y_pred):

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -222,9 +222,14 @@ class RetinaNet(ObjectDetectionBaseModel):
         cls_outputs = []
         box_outputs = []
         for feature in features:
-            box_outputs.append(tf.reshape(self.box_head(feature), [N, -1, 4]))
+            box_outputs.append(
+                tf.reshape(self.box_head(feature, training=training), [N, -1, 4])
+            )
             cls_outputs.append(
-                tf.reshape(self.classification_head(feature), [N, -1, self.classes])
+                tf.reshape(
+                    self.classification_head(feature, training=training),
+                    [N, -1, self.classes],
+                )
             )
 
         cls_outputs = tf.concat(cls_outputs, axis=1)

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -161,9 +161,11 @@ class RetinaNet(ObjectDetectionBaseModel):
         self.classification_head = layers_lib.PredictionHead(
             output_filters=9 * classes, bias_initializer=prior_probability
         )
+        self.classification_head.trainable = False
         self.box_head = layers_lib.PredictionHead(
             output_filters=9 * 4, bias_initializer="zeros"
         )
+        self.box_head.trainable = False
         self._metrics_bounding_box_format = None
         self.loss_metric = tf.keras.metrics.Mean(name="loss")
         self.classification_loss_metric = tf.keras.metrics.Mean(

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -430,7 +430,12 @@ class RetinaNet(ObjectDetectionBaseModel):
         self._update_metrics(y_for_metrics, predictions)
         return {m.name: m.result() for m in self.metrics}
 
+    # make a setter for prediction decoder
+    # bust the train_step... caches
+    # def predict_step(self, x)...
+
     def predict(self, x, **kwargs):
+        # TODO(lukewood): implement graph mode predict function
         predictions = super().predict(x, **kwargs)
         return self.decode_training_predictions(x, predictions)
 

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -157,7 +157,7 @@ class RetinaNet(ObjectDetectionBaseModel):
         self.classes = classes
         self.backbone = _parse_backbone(backbone, include_rescaling, backbone_weights)
 
-        self.prediction_decoder = prediction_decoder or cv_layers.NmsPredictionDecoder(
+        self._prediction_decoder = prediction_decoder or cv_layers.NmsPredictionDecoder(
             bounding_box_format=bounding_box_format,
             anchor_generator=anchor_generator,
             classes=classes,
@@ -199,6 +199,17 @@ class RetinaNet(ObjectDetectionBaseModel):
                 f"`prediction_decoder.box_variance={prediction_decoder.box_variance}`, "
                 f"`label_encoder.box_variance={label_encoder.box_variance}`."
             )
+
+    @property
+    def prediction_decoder(self):
+        return self._prediction_decoder
+
+    @prediction_decoder.setter
+    def prediction_decoder(self, prediction_decoder):
+        self._prediction_decoder = prediction_decoder
+        self.make_predict_function(force=True)
+        self.make_test_function(force=True)
+        self.make_train_function(force=True)
 
     @staticmethod
     def default_anchor_generator(bounding_box_format):

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -88,7 +88,11 @@ class RetinaNet(ObjectDetectionBaseModel):
             by the library.  The default feature pyramid network is compatible with all
             standard keras_cv backbones.
         classification_head: (Optional) A `keras.Layer` that performs classification of
-            the bounding boxes.  If not provided, a single Conv layer will be used.
+            the bounding boxes.  If not provided, a simple ConvNet with 1 layer will be
+            used.
+        box_head: (Optional) A `keras.Layer` that performs regression of
+            the bounding boxes.  If not provided, a simple ConvNet with 1 layer will be
+            used.
         evaluate_train_time_metrics: (Optional) whether or not to evaluate metrics
             passed in `compile()` inside of the `train_step()`.  This is NOT
             recommended, as it dramatically reduces performance due to the synchronous

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -166,12 +166,12 @@ class RetinaNet(ObjectDetectionBaseModel):
         self.classification_head = classification_head or layers_lib.PredictionHead(
             output_filters=9 * classes, bias_initializer=prior_probability
         )
-        self.classification_head.trainable = False
-        
+        # self.classification_head.trainable = False
+
         self.box_head = layers_lib.PredictionHead(
             output_filters=9 * 4, bias_initializer="zeros"
         )
-        self.box_head.trainable = False
+        # self.box_head.trainable = False
 
         self._metrics_bounding_box_format = None
         self.loss_metric = tf.keras.metrics.Mean(name="loss")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -96,10 +96,10 @@ class RetinaNetTest(tf.test.TestCase):
 def _get_retina_net_layers(model):
     return [
         model.backbone,
+        model.feature_pyramid,
         model.prediction_decoder,
         model.anchor_generator,
         model.label_encoder,
-        model.feature_pyramid,
         model.classification_head,
         model.box_head,
     ]

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -66,15 +66,30 @@ class RetinaNetTest(tf.test.TestCase):
         for layer_original, layer_new in zip(
             _get_retina_net_layers(retina_net), _get_retina_net_layers(new_retina_net)
         ):
+            print('Layer', layer_original.name, layer_new.name)
             for weight, weight_new in zip(
                 layer_original.get_weights(), layer_new.get_weights()
             ):
                 self.assertAllEqual(weight, weight_new)
 
+
+        # manually check layers to make sure nothing is missed
+        for layer_original, layer_new in zip(
+            retina_net.layers, new_retina_net.layers
+        ):
+            print('Layer', layer_original.name, layer_new.name)
+            for weight, weight_new in zip(
+                layer_original.get_weights(), layer_new.get_weights()
+            ):
+                self.assertAllEqual(weight, weight_new)
+
+
+
         # check if all weights that show up via `get_weights()` are loaded
         for retina_net_weight, post_load_weight in zip(
             retina_net.get_weights(), new_retina_net.get_weights()
         ):
+            print('weight')
             self.assertAllEqual(retina_net_weight, post_load_weight)
 
 

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -50,11 +50,6 @@ class RetinaNetTest(tf.test.TestCase):
             ):
                 self.assertAllEqual(weight, weight_new)
 
-    def test_model_saving_savedmodel_format(self):
-        retina_net, new_retina_net = _create_retina_nets(x=None, y=None, epochs=0)
-        tmp = tempfile.mkdtemp()
-        retina_net.save(f"{tmp}/checkpoint/")
-
     def test_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
         retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -67,6 +67,16 @@ class RetinaNetTest(tf.test.TestCase):
         self.assertNotEqual(new_decoder.suppression_layer.iou_threshold, pretrained_decoder.suppression_layer.iou_threshold)
 
 
+    def test_savedmodel_creation(self):
+        x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
+        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)
+
+        tmp = tempfile.mkdtemp()
+        pretrained_retina_net.save(f"{tmp}/checkpoint/")
+        load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
+        _ = load_model(x)
+
+
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -67,18 +67,12 @@ class RetinaNetTest(tf.test.TestCase):
             ):
                 self.assertAllEqual(weight, weight_new)
 
-        # manually check layers to make sure nothing is missed
+        # manually check layers to make sure nothing is missed in `get_weights()`
         for layer_original, layer_new in zip(retina_net.layers, new_retina_net.layers):
             for weight, weight_new in zip(
                 layer_original.get_weights(), layer_new.get_weights()
             ):
                 self.assertAllEqual(weight, weight_new)
-
-        # check if all weights that show up via `get_weights()` are loaded
-        for retina_net_weight, post_load_weight in zip(
-            retina_net.get_weights(), new_retina_net.get_weights()
-        ):
-            self.assertAllEqual(retina_net_weight, post_load_weight)
 
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -98,7 +98,7 @@ class RetinaNetTest(tf.test.TestCase):
             ),
         )
         pretrained_retina_net.prediction_decoder = prediction_decoder
-        result = pretrained_retina_net.predict(x)
+        _ = pretrained_retina_net.predict(x)
 
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_weight_loading(self):

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -81,7 +81,6 @@ class RetinaNetTest(tf.test.TestCase):
         load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
         _ = load_model(x)
 
-
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_format_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -50,6 +50,7 @@ class RetinaNetTest(tf.test.TestCase):
             ):
                 self.assertAllEqual(weight, weight_new)
 
+    @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
         retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -51,7 +51,7 @@ class RetinaNetTest(tf.test.TestCase):
                 self.assertAllEqual(weight, weight_new)
 
     def test_model_saving_savedmodel_format(self):
-        retina_net, new_retina_net = _create_retina_nets(x=None, y=None, fit=False)
+        retina_net, new_retina_net = _create_retina_nets(x=None, y=None, epochs=0)
         tmp = tempfile.mkdtemp()
         retina_net.save(f"{tmp}/checkpoint/")
 

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -89,8 +89,14 @@ class RetinaNetTest(tf.test.TestCase):
 
         tmp = tempfile.mkdtemp()
         pretrained_retina_net.save_weights(f"{tmp}/checkpoint/")
-        load_model = tf.saved_model.load_weights(f"{tmp}/checkpoint/")
-        _ = load_model(x)
+        new_retina_net.load_weights(f"{tmp}/checkpoint/")
+        for layer_original, layer_new in zip(
+            pretrained_retina_net.layers, new_retina_net.layers
+        ):
+            for weight, weight_new in zip(
+                layer_original.get_weights(), layer_new.get_weights()
+            ):
+                self.assertAllEqual(weight, weight_new)
 
     def test_set_prediction_decoder(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -74,11 +74,22 @@ class RetinaNetTest(tf.test.TestCase):
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_creation(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
-        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)
+        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=0)
 
         tmp = tempfile.mkdtemp()
         pretrained_retina_net.save(f"{tmp}/checkpoint/")
         load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
+        _ = load_model(x)
+
+
+    @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
+    def test_savedmodel_format_weight_loading(self):
+        x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
+        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=0)
+
+        tmp = tempfile.mkdtemp()
+        pretrained_retina_net.save_weights(f"{tmp}/checkpoint/")
+        load_model = tf.saved_model.load_weights(f"{tmp}/checkpoint/")
         _ = load_model(x)
 
     def test_set_prediction_decoder(self):

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -28,8 +28,6 @@ class RetinaNetTest(tf.test.TestCase):
         yield
         tf.keras.backend.clear_session()
 
-            )
-
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
         reason="Takes a long time to run, only runs when INTEGRATION "
@@ -58,8 +56,6 @@ class RetinaNetTest(tf.test.TestCase):
             ):
                 self.assertAllEqual(weight, weight_new)
 
-            )
-
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
         reason="Takes a long time to run, only runs when INTEGRATION "
@@ -87,8 +83,6 @@ class RetinaNetTest(tf.test.TestCase):
             pretrained_decoder.suppression_layer.iou_threshold,
         )
 
-            )
-
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
         reason="Takes a long time to run, only runs when INTEGRATION "
@@ -104,8 +98,6 @@ class RetinaNetTest(tf.test.TestCase):
         pretrained_retina_net.save(f"{tmp}/checkpoint/")
         load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
         _ = load_model(x)
-
-            )
 
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -1,0 +1,157 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import statistics
+import tempfile
+
+import pytest
+import tensorflow as tf
+from tensorflow.keras import optimizers
+
+import keras_cv
+
+
+class RetinaNetTest(tf.test.TestCase):
+    @pytest.fixture(autouse=True)
+    def cleanup_global_session(self):
+        # Code before yield runs before the test
+        yield
+        tf.keras.backend.clear_session()
+
+    def test_weight_setting(self):
+        retina_net, new_retina_net = _create_retina_nets(fit=True)
+        tmp = tempfile.mkdtemp()
+        retina_net.save_weights(f"{tmp}/checkpoint.h5")
+
+        retina_net_weights = retina_net.get_weights()
+        original_weights = new_retina_net.get_weights()
+        new_retina_net.set_weights(retina_net.get_weights())
+        new_weights = new_retina_net.get_weights()
+
+        for retina_net_weight, post_load_weights in zip(
+            retina_net_weights, new_weights
+        ):
+            self.assertAllEqual(retina_net_weight, post_load_weights)
+
+    def test_model_saving_savedmodel_format(self):
+        retina_net, new_retina_net = _create_retina_nets(fit=True)
+        tmp = tempfile.mkdtemp()
+        retina_net.save(f"{tmp}/checkpoint/")
+
+    def test_weight_loading(self):
+        retina_net, new_retina_net = _create_retina_nets(fit=True)
+
+        tmp = tempfile.mkdtemp()
+        retina_net.save_weights(f"{tmp}/checkpoint.h5")
+        new_retina_net.load_weights(f"{tmp}/checkpoint.h5")
+
+        # check if all weights that show up via `get_weights()` are loaded
+        for retina_net_weight, post_load_weight in zip(
+            retina_net.get_weights(), new_retina_net.get_weights()
+        ):
+            self.assertAllEqual(retina_net_weight, post_load_weight)
+
+        # manually check layers to make sure nothing is missed
+        for layer_original, layer_new in zip(
+            _get_retina_net_layers(retina_net), _get_retina_net_layers(new_retina_net)
+        ):
+            for weight, weight_new in zip(
+                layer_original.get_weights(), layer_new.get_weights()
+            ):
+                self.assertAllEqual(weight, weight_new)
+
+
+def _get_retina_net_layers(model):
+    return [
+        model.backbone,
+        model.prediction_decoder,
+        model.anchor_generator,
+        model.label_encoder,
+        model.feature_pyramid,
+        model.classification_head,
+        model.box_head,
+    ]
+
+
+def _create_retina_nets(fit=True):
+    retina_net = keras_cv.models.RetinaNet(
+        classes=20,
+        bounding_box_format="xywh",
+        backbone="resnet50",
+        backbone_weights="imagenet",
+        include_rescaling=True,
+    )
+    retina_net.compile(
+        classification_loss=keras_cv.losses.FocalLoss(
+            from_logits=True,
+            reduction="none",
+        ),
+        box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+        optimizer="adam",
+        metrics=[
+            keras_cv.metrics.COCOMeanAveragePrecision(
+                class_ids=range(20),
+                bounding_box_format="xyxy",
+                name="Standard MaP",
+            ),
+        ],
+    )
+    retina_net.build((None, None, None, 3))
+
+    x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
+    if fit:
+        retina_net.fit(x, y)
+    # Custom prediction decoder
+    prediction_decoder = keras_cv.layers.NmsPredictionDecoder(
+        bounding_box_format="xywh",
+        anchor_generator=keras_cv.models.RetinaNet.default_anchor_generator(
+            bounding_box_format="xywh"
+        ),
+        suppression_layer=keras_cv.layers.NonMaxSuppression(
+            iou_threshold=0.75,
+            bounding_box_format="xywh",
+            classes=20,
+            confidence_threshold=0.85,
+        ),
+    )
+    new_retina_net = keras_cv.models.RetinaNet(
+        prediction_decoder=prediction_decoder,
+        classes=20,
+        bounding_box_format="xywh",
+        backbone="resnet50",
+        backbone_weights=None,
+        include_rescaling=True,
+    )
+    new_retina_net.build((None, None, None, 3))
+    return retina_net, new_retina_net
+
+
+def _create_bounding_box_dataset(bounding_box_format):
+
+    # Just about the easiest dataset you can have, all classes are 0, all boxes are
+    # exactly the same.  [1, 1, 2, 2] are the coordinates in xyxy
+    xs = tf.ones((10, 512, 512, 3), dtype=tf.float32)
+    y_classes = tf.zeros((10, 10, 1), dtype=tf.float32)
+
+    ys = tf.constant([0.25, 0.25, 0.1, 0.1], dtype=tf.float32)
+    ys = tf.expand_dims(ys, axis=0)
+    ys = tf.expand_dims(ys, axis=0)
+    ys = tf.tile(ys, [10, 10, 1])
+    ys = tf.concat([ys, y_classes], axis=-1)
+
+    ys = keras_cv.bounding_box.convert_format(
+        ys, source="rel_xywh", target=bounding_box_format, images=xs, dtype=tf.float32
+    )
+    return xs, ys

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -52,7 +52,9 @@ class RetinaNetTest(tf.test.TestCase):
 
     def test_decoder_doesnt_get_updated(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
-        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1, custom_decoder=True)
+        pretrained_retina_net, new_retina_net = _create_retina_nets(
+            x, y, epochs=1, custom_decoder=True
+        )
         new_retina_net.set_weights(pretrained_retina_net.get_weights())
 
         # check if all weights that show up via `get_weights()` are loaded
@@ -64,8 +66,10 @@ class RetinaNetTest(tf.test.TestCase):
         pretrained_decoder = pretrained_retina_net.prediction_decoder
         new_decoder = new_retina_net.prediction_decoder
         self.assertEqual(new_decoder.suppression_layer.iou_threshold, 0.75)
-        self.assertNotEqual(new_decoder.suppression_layer.iou_threshold, pretrained_decoder.suppression_layer.iou_threshold)
-
+        self.assertNotEqual(
+            new_decoder.suppression_layer.iou_threshold,
+            pretrained_decoder.suppression_layer.iou_threshold,
+        )
 
     def test_savedmodel_creation(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
@@ -75,7 +79,6 @@ class RetinaNetTest(tf.test.TestCase):
         pretrained_retina_net.save(f"{tmp}/checkpoint/")
         load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
         _ = load_model(x)
-
 
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_weight_loading(self):
@@ -194,7 +197,7 @@ def _create_retina_nets(x, y, epochs=1, custom_decoder=False):
         backbone="resnet50",
         backbone_weights=None,
         include_rescaling=True,
-        prediction_decoder=prediction_decoder
+        prediction_decoder=prediction_decoder,
     )
     new_retina_net.compile(
         classification_loss=keras_cv.losses.FocalLoss(

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -74,7 +74,7 @@ class RetinaNetTest(tf.test.TestCase):
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_creation(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
-        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=0)
+        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)
 
         tmp = tempfile.mkdtemp()
         pretrained_retina_net.save(f"{tmp}/checkpoint/")
@@ -84,7 +84,7 @@ class RetinaNetTest(tf.test.TestCase):
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_format_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
-        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=0)
+        pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)
 
         tmp = tempfile.mkdtemp()
         pretrained_retina_net.save_weights(f"{tmp}/checkpoint/")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -28,6 +28,14 @@ class RetinaNetTest(tf.test.TestCase):
         yield
         tf.keras.backend.clear_session()
 
+            )
+
+    @pytest.mark.skipif(
+        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
+        reason="Takes a long time to run, only runs when INTEGRATION "
+        "environment variable is set.  To run the test please run: \n"
+        "`INTEGRATION=true pytest keras_cv/",
+    )
     def test_weight_setting(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
         pretrained_retina_net, new_retina_net = _create_retina_nets(x, y, epochs=1)
@@ -50,6 +58,14 @@ class RetinaNetTest(tf.test.TestCase):
             ):
                 self.assertAllEqual(weight, weight_new)
 
+            )
+
+    @pytest.mark.skipif(
+        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
+        reason="Takes a long time to run, only runs when INTEGRATION "
+        "environment variable is set.  To run the test please run: \n"
+        "`INTEGRATION=true pytest keras_cv/",
+    )
     def test_decoder_doesnt_get_updated(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
         pretrained_retina_net, new_retina_net = _create_retina_nets(
@@ -71,6 +87,14 @@ class RetinaNetTest(tf.test.TestCase):
             pretrained_decoder.suppression_layer.iou_threshold,
         )
 
+            )
+
+    @pytest.mark.skipif(
+        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
+        reason="Takes a long time to run, only runs when INTEGRATION "
+        "environment variable is set.  To run the test please run: \n"
+        "`INTEGRATION=true pytest keras_cv/",
+    )
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_creation(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
@@ -81,6 +105,14 @@ class RetinaNetTest(tf.test.TestCase):
         load_model = tf.saved_model.load(f"{tmp}/checkpoint/")
         _ = load_model(x)
 
+            )
+
+    @pytest.mark.skipif(
+        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
+        reason="Takes a long time to run, only runs when INTEGRATION "
+        "environment variable is set.  To run the test please run: \n"
+        "`INTEGRATION=true pytest keras_cv/",
+    )
     @pytest.mark.skipif(os.name == "nt", reason="tempfile does not work on windows")
     def test_savedmodel_format_weight_loading(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -94,8 +94,8 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net.save_weights(f"{tmp}/checkpoint.h5")
         new_retina_net.load_weights(f"{tmp}/checkpoint.h5")
 
-        metrics = retina_net.evaluate(x, y)
-        new_metrics = new_retina_net.evaluate(x, y)
+        metrics = retina_net.evaluate(x, y, return_dict=True)
+        new_metrics = new_retina_net.evaluate(x, y, return_dict=True)
 
         for key in metrics:
             self.assertEqual(metrics[key], new_metrics[key])

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -88,7 +88,7 @@ class RetinaNetTest(tf.test.TestCase):
     )
     def test_weight_loading_via_metrics(self):
         x, y = _create_bounding_box_dataset(bounding_box_format="xywh")
-        retina_net, new_retina_net = _create_retina_nets(x, y, epochs=10)
+        retina_net, new_retina_net = _create_retina_nets(x, y, epochs=30)
 
         tmp = tempfile.mkdtemp()
         retina_net.save_weights(f"{tmp}/checkpoint.h5")

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -302,7 +302,7 @@ class RetinaNetTest(tf.test.TestCase):
         xs, ys = _create_bounding_box_dataset(bounding_box_format)
 
         for _ in range(50):
-            history = retina_net.fit(x=xs, y=ys, epochs=1)
+            history = retina_net.fit(x=xs, y=ys, epochs=10)
             metrics = history.history
             metrics = [metrics["Recall"], metrics["MaP"]]
             metrics = [statistics.mean(metric) for metric in metrics]

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -210,16 +210,22 @@ class RetinaNetTest(tf.test.TestCase):
         _ = retina_net(xs)
         original_fpn_weights = retina_net.feature_pyramid.get_weights()
         original_box_head_weights = retina_net.box_head.get_weights()
-        original_classification_head_weights = retina_net.classification_head.get_weights()
+        original_classification_head_weights = (
+            retina_net.classification_head.get_weights()
+        )
 
         retina_net.fit(x=xs, y=ys, epochs=1)
         fpn_after_fit = retina_net.feature_pyramid.get_weights()
         box_head_after_fit_weights = retina_net.box_head.get_weights()
-        classification_head_after_fit_weights = retina_net.classification_head.get_weights()
+        classification_head_after_fit_weights = (
+            retina_net.classification_head.get_weights()
+        )
 
         # print('after_fit', after_fit)
 
-        for w1, w2 in zip(original_classification_head_weights, classification_head_after_fit_weights):
+        for w1, w2 in zip(
+            original_classification_head_weights, classification_head_after_fit_weights
+        ):
             self.assertNotAllClose(w1, w2)
 
         for w1, w2 in zip(original_box_head_weights, box_head_after_fit_weights):

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -304,9 +304,9 @@ class RetinaNetTest(tf.test.TestCase):
         for _ in range(50):
             history = retina_net.fit(x=xs, y=ys, epochs=1)
             metrics = history.history
-            metrics = [metrics["loss"], metrics["Recall"], metrics["MaP"]]
+            metrics = [metrics["Recall"], metrics["MaP"]]
             metrics = [statistics.mean(metric) for metric in metrics]
-            nonzero = [x != 0.0 for x in metrics]
+            nonzero = [x > 0.3 for x in metrics]
             if all(nonzero):
                 return
         raise ValueError("Did not achieve better than 0.5 for all metrics in 50 epochs")

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -306,10 +306,14 @@ class RetinaNetTest(tf.test.TestCase):
             metrics = history.history
             metrics = [metrics["Recall"], metrics["MaP"]]
             metrics = [statistics.mean(metric) for metric in metrics]
-            nonzero = [x > 0.3 for x in metrics]
+            minimum = 0.3
+            nonzero = [x > minimum for x in metrics]
             if all(nonzero):
                 return
-        raise ValueError("Did not achieve better than 0.5 for all metrics in 50 epochs")
+
+        raise ValueError(
+            f"Did not achieve better than {minimum} for all metrics in 50 epochs"
+        )
 
 
 def _create_bounding_box_dataset(bounding_box_format):

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -185,6 +185,31 @@ class RetinaNetTest(tf.test.TestCase):
             box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
         )
 
+    def test_weights_contained_in_trainable_variables(self):
+        bounding_box_format = "xywh"
+        retina_net = keras_cv.models.RetinaNet(
+            classes=1,
+            bounding_box_format=bounding_box_format,
+            backbone="resnet50",
+            backbone_weights=None,
+            include_rescaling=False,
+            evaluate_train_time_metrics=False,
+        )
+        retina_net.backbone.trainable = False
+        retina_net.compile(
+            optimizer=optimizers.Adam(),
+            classification_loss=keras_cv.losses.FocalLoss(
+                from_logits=True, reduction="none"
+            ),
+            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+            metrics=[],
+        )
+        xs, ys = _create_bounding_box_dataset(bounding_box_format)
+
+        # call once
+        _ = retina_net(xs)
+        print([x.name for x in retina_net.trainable_variables])
+
     def test_weights_change(self):
         bounding_box_format = "xywh"
         retina_net = keras_cv.models.RetinaNet(


### PR DESCRIPTION
Before this PR there was a bug where Keras failed to track the weights of some of the weights.  This was caused by the fact that weight tracking is handled in `keras.Model` during attribute assignment by checking if the assigned member is a keras layer.  If you use a closure style "layer" by assignment and then use the assigned layer in a custom model, you will not track the weights.

This PR fixes that bug - `load_weights(path)` case and `set_weights(weights)` both work now.

Fixes:
- https://github.com/keras-team/keras-cv/issues/767
- https://github.com/keras-team/keras-cv/issues/766