### PR TITLE
Add accelerator count to training history

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -1,6 +1,7 @@
 {
     "densenet121": {
         "v0": {
+            "accelerators": 2,
             "args": {
                 "batch_size": "64"
             },
@@ -16,6 +17,7 @@
     },
     "densenet169": {
         "v0": {
+            "accelerators": 2,
             "args": {
                 "batch_size": "64"
             },
@@ -31,6 +33,7 @@
     },
     "resnet50v2": {
         "v0": {
+            "accelerators": 2,
             "args": {
                 "batch_size": "64",
                 "initial_learning_rate": "0.005"
@@ -45,6 +48,7 @@
             "validation_accuracy": "0.6337"
         },
         "v1": {
+            "accelerators": 2,
             "args": {
                 "batch_size": "128"
             },

--- a/shell/weights/update_training_history.py
+++ b/shell/weights/update_training_history.py
@@ -23,6 +23,9 @@ flags.DEFINE_string(
 flags.DEFINE_string(
     "contributor", None, "The GitHub username of the contributor of these results"
 )
+flags.DEFINE_string(
+    "accelerators", None, "The number of accelerators used for training."
+)
 
 FLAGS = flags.FLAGS
 FLAGS(sys.argv)
@@ -84,6 +87,10 @@ contributor = FLAGS.contributor or input(
     "Input your GitHub username (or the username of the contributor, if it's not you)\n"
 )
 
+accelerators = FLAGS.accelerators or input(
+    "Input the number of accelerators used during training.\n"
+)
+
 args = input(
     "Input any training arguments used for the training script.\n"
     "Use comma-separate, colon-split key-value pairs. For example:\n"
@@ -104,6 +111,7 @@ new_results = {
     "tensorboard_logs": f"https://tensorboard.dev/experiment/{tensorboard_experiment_id}/",
     "contributor": contributor,
     "args": args_dict,
+    "accelerators": int(accelerators),
 }
 
 # Check if the JSON file already exists


### PR DESCRIPTION
This is relevant now because we're scaling learning rate and batch size based on the number of accelerators in #757