### PR TITLE
Make contrastive API private

### DIFF
--- a/keras_cv/losses/simclr_loss_test.py
+++ b/keras_cv/losses/simclr_loss_test.py
@@ -14,7 +14,7 @@
 
 import tensorflow as tf
 
-from keras_cv.losses.simclr_loss import SimCLRLoss
+from keras_cv.losses.simclr_loss import _SimCLRLoss
 
 
 class SimCLRLossTest(tf.test.TestCase):
@@ -26,7 +26,7 @@ class SimCLRLossTest(tf.test.TestCase):
             shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
         )
 
-        simclr_loss = SimCLRLoss(temperature=1)
+        simclr_loss = _SimCLRLoss(temperature=1)
 
         self.assertAllEqual(simclr_loss(projections_1, projections_2).shape, ())
 
@@ -38,7 +38,7 @@ class SimCLRLossTest(tf.test.TestCase):
             shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
         )
 
-        simclr_loss = SimCLRLoss(temperature=1, reduction="none")
+        simclr_loss = _SimCLRLoss(temperature=1, reduction="none")
 
         self.assertAllEqual(simclr_loss(projections_1, projections_2).shape, (10,))
 
@@ -55,8 +55,8 @@ class SimCLRLossTest(tf.test.TestCase):
             [4.0, 3.0, 2.0, 1.0],
         ]
 
-        simclr_loss = SimCLRLoss(temperature=0.5)
+        simclr_loss = _SimCLRLoss(temperature=0.5)
         self.assertAllClose(simclr_loss(projections_1, projections_2), 3.566689)
 
-        simclr_loss = SimCLRLoss(temperature=0.1)
+        simclr_loss = _SimCLRLoss(temperature=0.1)
         self.assertAllClose(simclr_loss(projections_1, projections_2), 5.726100)

--- a/keras_cv/losses/simclr_loss_test.py
+++ b/keras_cv/losses/simclr_loss_test.py
@@ -14,7 +14,7 @@
 
 import tensorflow as tf
 
-from keras_cv.losses.simclr_loss import _SimCLRLoss
+from keras_cv.losses.simclr_loss import SimCLRLoss
 
 
 class SimCLRLossTest(tf.test.TestCase):
@@ -26,7 +26,7 @@ class SimCLRLossTest(tf.test.TestCase):
             shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
         )
 
-        simclr_loss = _SimCLRLoss(temperature=1)
+        simclr_loss = SimCLRLoss(temperature=1)
 
         self.assertAllEqual(simclr_loss(projections_1, projections_2).shape, ())
 
@@ -38,7 +38,7 @@ class SimCLRLossTest(tf.test.TestCase):
             shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
         )
 
-        simclr_loss = _SimCLRLoss(temperature=1, reduction="none")
+        simclr_loss = SimCLRLoss(temperature=1, reduction="none")
 
         self.assertAllEqual(simclr_loss(projections_1, projections_2).shape, (10,))
 
@@ -55,8 +55,8 @@ class SimCLRLossTest(tf.test.TestCase):
             [4.0, 3.0, 2.0, 1.0],
         ]
 
-        simclr_loss = _SimCLRLoss(temperature=0.5)
+        simclr_loss = SimCLRLoss(temperature=0.5)
         self.assertAllClose(simclr_loss(projections_1, projections_2), 3.566689)
 
-        simclr_loss = _SimCLRLoss(temperature=0.1)
+        simclr_loss = SimCLRLoss(temperature=0.1)
         self.assertAllClose(simclr_loss(projections_1, projections_2), 5.726100)

--- a/keras_cv/training/__init__.py
+++ b/keras_cv/training/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_cv.training.contrastive.contrastive_trainer import ContrastiveTrainer
-from keras_cv.training.contrastive.simclr_trainer import SimCLRAugmenter
-from keras_cv.training.contrastive.simclr_trainer import SimCLRTrainer
+from keras_cv.training.contrastive.contrastive_trainer import _ContrastiveTrainer
+from keras_cv.training.contrastive.simclr_trainer import _SimCLRAugmenter
+from keras_cv.training.contrastive.simclr_trainer import _SimCLRTrainer

--- a/keras_cv/training/contrastive/contrastive_trainer.py
+++ b/keras_cv/training/contrastive/contrastive_trainer.py
@@ -19,7 +19,7 @@ from tensorflow import keras
 from keras_cv.utils.train import convert_inputs_to_tf_dataset
 
 
-class ContrastiveTrainer(keras.Model):
+class _ContrastiveTrainer(keras.Model):
     """Creates a self-supervised contrastive trainer for a model.
 
     Args:

--- a/keras_cv/training/contrastive/contrastive_trainer_test.py
+++ b/keras_cv/training/contrastive/contrastive_trainer_test.py
@@ -21,12 +21,12 @@ from tensorflow.keras import optimizers
 from keras_cv.layers import preprocessing
 from keras_cv.losses import SimCLRLoss
 from keras_cv.models import DenseNet121
-from keras_cv.training import ContrastiveTrainer
+from keras_cv.training import _ContrastiveTrainer
 
 
 class ContrastiveTrainerTest(tf.test.TestCase):
     def test_probe_requires_probe_optimizer(self):
-        trainer = ContrastiveTrainer(
+        trainer = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
@@ -39,13 +39,13 @@ class ContrastiveTrainerTest(tf.test.TestCase):
             )
 
     def test_targets_required_if_probing(self):
-        trainer_with_probing = ContrastiveTrainer(
+        trainer_with_probing = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
             probe=self.build_probe(),
         )
-        trainer_without_probing = ContrastiveTrainer(
+        trainer_without_probing = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
@@ -69,7 +69,7 @@ class ContrastiveTrainerTest(tf.test.TestCase):
             trainer_with_probing.fit(images)
 
     def test_train_with_probing(self):
-        trainer_with_probing = ContrastiveTrainer(
+        trainer_with_probing = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
@@ -90,7 +90,7 @@ class ContrastiveTrainerTest(tf.test.TestCase):
         trainer_with_probing.fit(images, targets)
 
     def test_train_without_probing(self):
-        trainer_without_probing = ContrastiveTrainer(
+        trainer_without_probing = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
@@ -109,7 +109,7 @@ class ContrastiveTrainerTest(tf.test.TestCase):
         trainer_without_probing.fit(images, targets)
 
     def test_inference_not_supported(self):
-        trainer = ContrastiveTrainer(
+        trainer = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=self.build_augmenter(),
             projector=self.build_projector(),
@@ -125,7 +125,7 @@ class ContrastiveTrainerTest(tf.test.TestCase):
 
     def test_encoder_must_have_flat_output(self):
         with self.assertRaises(ValueError):
-            _ = ContrastiveTrainer(
+            _ = _ContrastiveTrainer(
                 # A DenseNet without pooling does not have a flat output
                 encoder=DenseNet121(include_rescaling=False, include_top=False),
                 augmenter=self.build_augmenter(),
@@ -142,7 +142,7 @@ class ContrastiveTrainerTest(tf.test.TestCase):
             [projector0, layers.ReLU(), layers.Dense(64, name="projector1")]
         )
 
-        trainer_without_probing = ContrastiveTrainer(
+        trainer_without_probing = _ContrastiveTrainer(
             encoder=self.build_encoder(),
             augmenter=(augmenter0, augmenter1),
             projector=(projector0, projector1),

--- a/keras_cv/training/contrastive/simclr_trainer.py
+++ b/keras_cv/training/contrastive/simclr_trainer.py
@@ -16,10 +16,10 @@ from tensorflow import keras
 from tensorflow.keras import layers
 
 from keras_cv.layers import preprocessing
-from keras_cv.training import ContrastiveTrainer
+from keras_cv.training import _ContrastiveTrainer
 
 
-class SimCLRTrainer(ContrastiveTrainer):
+class _SimCLRTrainer(_ContrastiveTrainer):
     """Creates a SimCLRTrainer.
 
     References:
@@ -50,7 +50,7 @@ class SimCLRTrainer(ContrastiveTrainer):
         )
 
 
-class SimCLRAugmenter(preprocessing.Augmenter):
+class _SimCLRAugmenter(preprocessing.Augmenter):
     def __init__(
         self,
         value_range,

--- a/keras_cv/training/contrastive/simclr_trainer_test.py
+++ b/keras_cv/training/contrastive/simclr_trainer_test.py
@@ -17,15 +17,15 @@ from tensorflow.keras import optimizers
 
 from keras_cv.losses import SimCLRLoss
 from keras_cv.models import ResNet50V2
-from keras_cv.training import SimCLRAugmenter
-from keras_cv.training import SimCLRTrainer
+from keras_cv.training import _SimCLRAugmenter
+from keras_cv.training import _SimCLRTrainer
 
 
 class SimCLRTrainerTest(tf.test.TestCase):
     def test_train_without_probing(self):
-        simclr_without_probing = SimCLRTrainer(
+        simclr_without_probing = _SimCLRTrainer(
             self.build_encoder(),
-            augmenter=SimCLRAugmenter(value_range=(0, 255)),
+            augmenter=_SimCLRAugmenter(value_range=(0, 255)),
         )
 
         images = tf.random.uniform((10, 512, 512, 3))


### PR DESCRIPTION
As requested by @tanzhenyu (since API has not been formally approved yet)

@tanzhenyu @fchollet PTAL at the contrastive learning design doc so that we can finalize this API and make it public in KerasCV

@LukeWood 