### PR TITLE
Convergence tests for ResNetV2 (experimental)

### DIFF
--- a/cloudbuild/cloudbuild-convergence.yaml
+++ b/cloudbuild/cloudbuild-convergence.yaml
@@ -1,0 +1,79 @@
+substitutions:
+  # GCS bucket name.
+  _GCS_BUCKET: 'gs://keras-cv-github-test'
+  # GKE cluster name.
+  _CLUSTER_NAME: 'keras-cv-test-cluster'
+  # Location of GKE cluster.
+  _CLUSTER_ZONE: 'us-west1-b'
+  # Image name.
+  _IMAGE_NAME: 'us-west1-docker.pkg.dev/keras-team-test/keras-cv-test/keras-cv-image'
+steps:
+- name: 'docker'
+  id: build-image
+  args: [
+    'build',
+    '.',
+    '-f', 'cloudbuild/Dockerfile',
+    '-t', '$_IMAGE_NAME:$BUILD_ID',
+  ]
+- name: 'docker'
+  id: push-image
+  waitFor:
+  - build-image
+  args: ['push', '$_IMAGE_NAME:$BUILD_ID']
+- name: 'golang'
+  id: download-jsonnet
+  waitFor: ['-']
+  entrypoint: 'go'
+  args: [
+    'install',
+    'github.com/google/go-jsonnet/cmd/jsonnet@latest',
+  ]
+- name: 'google/cloud-sdk'
+  id: clone-templates
+  waitFor: ['-']
+  entrypoint: 'git'
+  args: [
+    'clone',
+    'https://github.com/GoogleCloudPlatform/ml-testing-accelerators.git',
+  ]
+- name: 'golang'
+  id: build-templates
+  waitFor:
+  - download-jsonnet
+  - clone-templates
+  entrypoint: 'jsonnet'
+  args: [
+    'cloudbuild/convergence_test_jobs.jsonnet',
+    '--string',
+    '-J', 'ml-testing-accelerators',
+    '--ext-str', 'image=$_IMAGE_NAME',
+    '--ext-str', 'tag_name=$BUILD_ID',
+    '--ext-str', 'gcs_bucket=$_GCS_BUCKET',
+    '-o', 'output.yaml',
+  ]
+- name: 'google/cloud-sdk'
+  id: create-job
+  waitFor:
+  - push-image
+  - build-templates
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -u
+    set -e
+    set -x
+    gcloud container clusters get-credentials $_CLUSTER_NAME --zone $_CLUSTER_ZONE --project keras-team-test
+    job_name=$(kubectl create -f output.yaml -o name)
+    sleep 5
+    pod_name=$(kubectl wait --for condition=ready --timeout=10m pod -l job-name=${job_name#job.batch/} -o name)
+    kubectl logs -f $pod_name --container=train
+    sleep 5
+    gcloud artifacts docker images delete $_IMAGE_NAME:$BUILD_ID
+    exit $(kubectl get $pod_name -o jsonpath={.status.containerStatuses[0].state.terminated.exitCode})
+timeout: 1800s  # 30 minutes
+options:
+  volumes:
+  - name: go-modules
+    path: /go

--- a/cloudbuild/convergence_test_jobs.jsonnet
+++ b/cloudbuild/convergence_test_jobs.jsonnet
@@ -1,0 +1,36 @@
+local base = import 'templates/base.libsonnet';
+local gpus = import 'templates/gpus.libsonnet';
+
+local image = std.extVar('image');
+local tagName = std.extVar('tag_name');
+local gcsBucket = std.extVar('gcs_bucket');
+
+local unittest = base.BaseTest {
+  // Configure job name.
+  frameworkPrefix: "tf",
+  modelName: "keras-cv",
+  mode: "unit-tests",
+  timeout: 7200, # 2 hours, in seconds
+
+  // Set up runtime environment.
+  image: image,
+  imageTag: tagName,
+  accelerator: gpus.teslaT4,
+  outputBucket: gcsBucket,
+
+  entrypoint: [
+    'bash',
+    '-c',
+    |||
+      export CONVERGENCE=true
+      # Run whatever is in `command` here.
+      ${@:0}
+    |||
+  ],
+  command: [
+    'pytest',
+    'keras_cv',
+  ],
+};
+
+std.manifestYamlDoc(unittest.oneshotJob, quote_keys=false)

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -152,7 +152,7 @@ class ModelsTest:
 
         results = model.fit(train_ds)
 
-        self.assertAlmostEqual(results.history["accuracy"][0], accuracy)
+        self.assertGreaterEqual(results.history["accuracy"][0], accuracy)
 
 
 if __name__ == "__main__":

--- a/keras_cv/models/resnet_v2_test.py
+++ b/keras_cv/models/resnet_v2_test.py
@@ -23,9 +23,9 @@ from keras_cv.models import resnet_v2
 from .models_test import ModelsTest
 
 MODEL_LIST = [
-    (resnet_v2.ResNet50V2, 2048, {}, 0.8938000),
-    (resnet_v2.ResNet101V2, 2048, {}, 0.8741000),
-    (resnet_v2.ResNet152V2, 2048, {}, 0.8531000),
+    (resnet_v2.ResNet50V2, 2048, {}, 0.892),
+    (resnet_v2.ResNet101V2, 2048, {}, 0.873),
+    (resnet_v2.ResNet152V2, 2048, {}, 0.852),
 ]
 
 

--- a/keras_cv/models/resnet_v2_test.py
+++ b/keras_cv/models/resnet_v2_test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -20,32 +23,42 @@ from keras_cv.models import resnet_v2
 from .models_test import ModelsTest
 
 MODEL_LIST = [
-    (resnet_v2.ResNet50V2, 2048, {}),
-    (resnet_v2.ResNet101V2, 2048, {}),
-    (resnet_v2.ResNet152V2, 2048, {}),
+    (resnet_v2.ResNet50V2, 2048, {}, 0.8938000),
+    (resnet_v2.ResNet101V2, 2048, {}, 0.8741000),
+    (resnet_v2.ResNet152V2, 2048, {}, 0.8531000),
 ]
 
 
 class ResNetV2Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(*MODEL_LIST)
-    def test_application_base(self, app, _, args):
-        super()._test_application_base(app, _, args)
+    def test_application_base(self, app, last_dim, args, accuracy):
+        super()._test_application_base(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_application_with_rescaling(self, app, last_dim, args):
+    def test_application_with_rescaling(self, app, last_dim, args, accuracy):
         super()._test_application_with_rescaling(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_application_pooling(self, app, last_dim, args):
+    def test_application_pooling(self, app, last_dim, args, accuracy):
         super()._test_application_pooling(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_application_variable_input_channels(self, app, last_dim, args):
+    def test_application_variable_input_channels(self, app, last_dim, args, accuracy):
         super()._test_application_variable_input_channels(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args, accuracy):
         super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+    @pytest.mark.skipif(
+        "CONVERGENCE" not in os.environ or os.environ["CONVERGENCE"] != "true",
+        reason="Takes a long time to run, only runs when CONVERGENCE "
+        "environment variable is set.  To run the test please run: \n"
+        "`CONVERGENCE=true pytest keras_cv/",
+    )
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_convergence(self, app, _, args, accuracy):
+        super()._test_model_convergence(app, args, accuracy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@LukeWood This is a proof-of-concept for convergence testing using Google Cloud Build.

I've created a separate cloudbuild YAML, and a separate JSONNet configuration.
I've also set up a separate cloudbuild trigger set up to run these tests on a schedule.

If this approach LG, we can extend it afterwards to cover all of the classification models, and also add some assertions about step_time.

Some discussion points:
- It's possible that upstream framework changes (e.g. in Keras) could slightly change the results produced by these tests. So we may want to use a custom higher tolerance for the assertions to allow some wiggle room.
- We may want to host the dataset on a connected GCS bucket. This would give us some more flexibility which TFDS doesn't offer, for example we could only load a small fraction of the dataset. (alternatively, we could generate data in the tests)

We can also explore an entirely different avenue, and make a separate folder in this repo for convergence testing, storing all the necessary code in that repo. This would let us skip the test decorators for the `CONVERGENCE` environment variable, and would separate convergence testing from all other tests (which has the benefit of making convergence testing self-contained and the downside of sharding our testing)

What do you think?