### PR TITLE
Migrate to rely on GCB from GitHub actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,37 +6,6 @@ on:
   release:
     types: [created]
 jobs:
-  test:
-    name: Test the code
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        python -m pip install --upgrade pip setuptools
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        pip install tensorflow==2.9.1
-        pip install -e ".[tests]" --progress-bar off --upgrade
-    - name: Test with pytest
-      run: |
-        pytest keras_cv/
   format:
     name: Check the code format
     runs-on: ubuntu-latest


### PR DESCRIPTION
we unfortunately have hit the point where we cannot keep using GitHub actions due to scaling concerns.  GCB allows us to configure out own CI cluster and timeouts - as such we will need to rely on that going forward.

