### PR TITLE
Add pre-trained weights for MobileNetV3Small

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -31,6 +31,22 @@
             "validation_accuracy": "0.6613"
         }
     },
+    "mobilenetv3small": {
+        "v0": {
+            "accelerators": 8,
+            "args": {
+                "batch_size": "512"
+            },
+            "contributor": "ianstenbit",
+            "epochs_trained": 90,
+            "script": {
+                "name": "basic_training.py",
+                "version": "b0b349612e00ab34c25af5467ddd3b48d6fbf7a3"
+            },
+            "tensorboard_logs": "https://tensorboard.dev/experiment/kvJfKX8XQSy4v1C31HO4Rw/",
+            "validation_accuracy": "0.5224"
+        }
+    },
     "resnet50v2": {
         "v0": {
             "accelerators": 2,

--- a/keras_cv/models/mobilenet_v3.py
+++ b/keras_cv/models/mobilenet_v3.py
@@ -486,7 +486,7 @@ def MobileNetV3Small(
         include_rescaling=include_rescaling,
         include_top=include_top,
         classes=classes,
-        weights=weights,
+        weights=parse_weights(weights, include_top, "mobilenetv3small-minimalistic" if minimalistic else "mobilenetv3small")
         input_shape=input_shape,
         input_tensor=input_tensor,
         pooling=pooling,

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -47,6 +47,10 @@ ALIASES = {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },
+    "mobilenetv3small": {
+        "imagenet": "imagenet/classification-v0",
+        "imagenet/classification": "imagenet/classification-v0",
+    },
     "resnet50v2": {
         "imagenet": "imagenet/classification-v1",
         "imagenet/classification": "imagenet/classification-v1",
@@ -63,6 +67,10 @@ WEIGHTS_CONFIG = {
         "imagenet/classification-v0-notop": "a99d1bb2cbe1a59a1cdd1f435fb265453a97c2a7b723d26f4ebee96e5fb49d62",
     },
     "densenet201": {},
+    "mobilenetv3small": {
+        "imagenet/classification-v0": "16a9086f9376ea7264429a245bc7295eadf445c0babeac8d1cb3757b63ab11b6",
+        "imagenet/classification-v0-notop": "84ab0f7152b6b017add89dd03fa44c6c411008b064dfe5c8555fc71ac5b5497d",
+    },
     "resnet50v2": {
         "imagenet/classification-v0": "11bde945b54d1dca65101be2648048abca8a96a51a42820d87403486389790db",
         "imagenet/classification-v0-notop": "5b4aca4932c433d84f6aef58135472a4312ed2fa565d53fedcd6b0c24b54ab4a",


### PR DESCRIPTION
@LukeWood 

This is the first model for which our basic_training script did not yield a result close to SOTA for a specific model. In this case, it's about 10% worse on top-1 validation accuracy than the paper-claimed results for this model.

Based on the look of the tensorboard logs, I think this may be due to having a too-high initial learning rate, so we could re-run this with a lower initial LR.

I think I'm indifferent about whether we add these weights -- they're a decent first set for MobileNetV3Small but they're not great. Feel free to close this PR if you'd prefer to wait for a re-run with better results.