### PR TITLE
Add ROIGenerator.

### DIFF
--- a/keras_cv/layers/object_detection/nms_prediction_decoder.py
+++ b/keras_cv/layers/object_detection/nms_prediction_decoder.py
@@ -77,6 +77,7 @@ class NmsPredictionDecoder(tf.keras.layers.Layer):
         self.box_variance = tf.convert_to_tensor(box_variance, dtype=tf.float32)
         self.built = True
 
+    # TODO(lukewood): provide this as general utility on top of bounding_box_format.
     def _decode_box_predictions(self, anchor_boxes, box_predictions):
         boxes = box_predictions * self.box_variance
         boxes = tf.concat(

--- a/keras_cv/layers/object_detection/roi_generator.py
+++ b/keras_cv/layers/object_detection/roi_generator.py
@@ -1,0 +1,183 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Mapping
+from typing import Optional
+from typing import Tuple
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+
+
+class ROIGenerator(tf.keras.layers.Layer):
+    """
+    Generates region of interests (ROI, or proposal) from scores.
+
+    This works for a multi-level input, both boxes and scores are dictionary
+    inputs with the same set of keys.
+
+    Users can configure topk and threshold differently in train and inference.
+
+    Users can choose to combine all levels if nms across all levels are desired.
+
+    The following steps are applied to pair of (boxes, scores):
+    1) pre_nms_topk scores and boxes sorted and selected per level
+    2) nms applied and selected post_nms_topk scores and rois per level
+    3) combined scores and rois across all levels
+    4) post_nms_topk scores and rois sorted and selected
+
+    Args:
+        bounding_box_format: a case-insensitive string which is one of `"xyxy"`,
+            `"rel_xyxy"`, `"xyWH"`, `"center_xyWH"`, `"yxyx"`, `"rel_yxyx"`. The
+            position and shape of the bounding box will be followed by the class and
+            confidence values (in that order). This is required for proper ranking of
+            the bounding boxes. Therefore, each bounding box is defined by 6 values.
+            For detailed information on the supported format, see the
+            [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
+        pre_nms_topk_train: int. number of top k scoring proposals to keep before applying NMS in training mode.
+            When RPN is run on multiple feature maps / levels (as in FPN) this number is per
+            feature map / level.
+        nms_score_threshold_train: float. score threshold to use for NMS in training mode.
+        nms_iou_threshold_train: float. IOU threshold to use for NMS in training mode.
+        post_nms_topk_train: int. number of top k scoring proposals to keep after applying NMS in training mode.
+            When RPN is run on multiple feature maps / levels (as in FPN) this number is per
+            feature map / level.
+        pre_nms_topk_test: int. number of top k scoring proposals to keep before applying NMS in inference mode.
+            When RPN is run on multiple feature maps / levels (as in FPN) this number is per
+            feature map / level.
+        nms_score_threshold_test: float. score threshold to use for NMS in inference mode.
+        nms_iou_threshold_test: float. IOU threshold to use for NMS in inference mode.
+        post_nms_topk_test: int. number of top k scoring proposals to keep after applying NMS in inference mode.
+            When RPN is run on multiple feature maps / levels (as in FPN) this number is per
+            feature map / level.
+
+    """
+
+    def __init__(
+        self,
+        bounding_box_format,
+        pre_nms_topk_train: int = 2000,
+        nms_score_threshold_train: float = 0.0,
+        nms_iou_threshold_train: float = 0.7,
+        post_nms_topk_train: int = 1000,
+        pre_nms_topk_test: int = 1000,
+        nms_score_threshold_test: float = 0.0,
+        nms_iou_threshold_test: float = 0.7,
+        post_nms_topk_test: int = 1000,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.bounding_box_format = bounding_box_format
+        self.pre_nms_topk_train = pre_nms_topk_train
+        self.nms_score_threshold_train = nms_score_threshold_train
+        self.nms_iou_threshold_train = nms_iou_threshold_train
+        self.post_nms_topk_train = post_nms_topk_train
+        self.pre_nms_topk_test = pre_nms_topk_test
+        self.nms_score_threshold_test = nms_score_threshold_test
+        self.nms_iou_threshold_test = nms_iou_threshold_test
+        self.post_nms_topk_test = post_nms_topk_test
+        self.built = True
+
+    def call(
+        self,
+        multi_level_boxes: Mapping[str, tf.Tensor],
+        multi_level_scores: Mapping[str, tf.Tensor],
+        training: Optional[bool] = None,
+    ) -> Tuple[tf.Tensor, tf.Tensor]:
+        """
+        Args:
+          multi_level_boxes: float Tensor. A dictionary of boxes, one per level. shape is
+            [batch_size, num_boxes, 4] each level, in `bounding_box_format`.
+            The boxes from RPNs are usually encoded as deltas w.r.t to anchors,
+            they need to be decoded before passing in here.
+          multi_level_scores: float Tensor. A dictionary of scores, usually confidence scores,
+            one per level. shape is [batch_size, num_boxes] each level.
+
+        Returns:
+          rois: float Tensor of [batch_size, post_nms_topk, 4]
+          roi_scores: float Tensor of [batch_size, post_nms_topk]
+        """
+
+        if training:
+            pre_nms_topk = self.pre_nms_topk_train
+            post_nms_topk = self.post_nms_topk_train
+            nms_score_threshold = self.nms_score_threshold_train
+            nms_iou_threshold = self.nms_iou_threshold_train
+        else:
+            pre_nms_topk = self.pre_nms_topk_test
+            post_nms_topk = self.post_nms_topk_test
+            nms_score_threshold = self.nms_score_threshold_test
+            nms_iou_threshold = self.nms_iou_threshold_test
+
+        rois = []
+        roi_scores = []
+        for level in sorted(multi_level_scores.keys()):
+            scores = multi_level_scores[level]
+            boxes = multi_level_boxes[level]
+            _, num_boxes = scores.get_shape().as_list()
+            level_pre_nms_topk = min(num_boxes, pre_nms_topk)
+            level_post_nms_topk = min(num_boxes, post_nms_topk)
+            scores, sorted_indices = tf.nn.top_k(
+                scores, k=level_pre_nms_topk, sorted=True
+            )
+            boxes = tf.gather(boxes, sorted_indices, batch_dims=1)
+            # convert from input format to yxyx for the TF NMS operation
+            boxes = bounding_box.convert_format(
+                boxes,
+                source=self.bounding_box_format,
+                target="yxyx",
+            )
+            # TODO(tanzhenyu): consider supporting soft / batched nms for accl
+            selected_indices, num_valid = tf.image.non_max_suppression_padded(
+                boxes,
+                scores,
+                max_output_size=level_post_nms_topk,
+                iou_threshold=nms_iou_threshold,
+                score_threshold=nms_score_threshold,
+                pad_to_max_output_size=True,
+                sorted_input=True,
+                canonicalized_coordinates=True,
+            )
+            # convert back to input format
+            boxes = bounding_box.convert_format(
+                boxes,
+                source="yxyx",
+                target=self.bounding_box_format,
+            )
+            level_rois = tf.gather(boxes, selected_indices, batch_dims=1)
+            level_roi_scores = tf.gather(scores, selected_indices, batch_dims=1)
+            level_rois = level_rois * tf.cast(
+                tf.reshape(tf.range(level_post_nms_topk), [1, -1, 1])
+                < tf.reshape(num_valid, [-1, 1, 1]),
+                level_rois.dtype,
+            )
+            level_roi_scores = level_roi_scores * tf.cast(
+                tf.reshape(tf.range(level_post_nms_topk), [1, -1])
+                < tf.reshape(num_valid, [-1, 1]),
+                level_roi_scores.dtype,
+            )
+            rois.append(level_rois)
+            roi_scores.append(level_roi_scores)
+
+        rois = tf.concat(rois, axis=1)
+        roi_scores = tf.concat(roi_scores, axis=1)
+        _, num_valid_rois = roi_scores.get_shape().as_list()
+        overall_top_k = min(num_valid_rois, post_nms_topk)
+        roi_scores, sorted_indices = tf.nn.top_k(
+            roi_scores, k=overall_top_k, sorted=True
+        )
+        rois = tf.gather(rois, sorted_indices, batch_dims=1)
+
+        return rois, roi_scores

--- a/keras_cv/layers/object_detection/roi_generator.py
+++ b/keras_cv/layers/object_detection/roi_generator.py
@@ -25,6 +25,8 @@ class ROIGenerator(tf.keras.layers.Layer):
     """
     Generates region of interests (ROI, or proposal) from scores.
 
+    Mainly used in Region CNN (RCNN) networks.
+
     This works for a multi-level input, both boxes and scores are dictionary
     inputs with the same set of keys.
 
@@ -39,11 +41,7 @@ class ROIGenerator(tf.keras.layers.Layer):
     4) post_nms_topk scores and rois sorted and selected
 
     Args:
-        bounding_box_format: a case-insensitive string which is one of `"xyxy"`,
-            `"rel_xyxy"`, `"xyWH"`, `"center_xyWH"`, `"yxyx"`, `"rel_yxyx"`. The
-            position and shape of the bounding box will be followed by the class and
-            confidence values (in that order). This is required for proper ranking of
-            the bounding boxes. Therefore, each bounding box is defined by 6 values.
+        bounding_box_format: a case-insensitive string.
             For detailed information on the supported format, see the
             [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
         pre_nms_topk_train: int. number of top k scoring proposals to keep before applying NMS in training mode.

--- a/keras_cv/layers/object_detection/roi_generator.py
+++ b/keras_cv/layers/object_detection/roi_generator.py
@@ -195,10 +195,10 @@ class ROIGenerator(tf.keras.layers.Layer):
             "nms_score_threshold_train": self.nms_score_threshold_train,
             "nms_iou_threshold_train": self.nms_iou_threshold_train,
             "post_nms_topk_train": self.post_nms_topk_train,
-            "pre_nms_topk_train": self.pre_nms_topk_test,
-            "nms_score_threshold_train": self.nms_score_threshold_test,
-            "nms_iou_threshold_train": self.nms_iou_threshold_test,
-            "post_nms_topk_train": self.post_nms_topk_test,
+            "pre_nms_topk_test": self.pre_nms_topk_test,
+            "nms_score_threshold_test": self.nms_score_threshold_test,
+            "nms_iou_threshold_test": self.nms_iou_threshold_test,
+            "post_nms_topk_test": self.post_nms_topk_test,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/object_detection/roi_generator_test.py
+++ b/keras_cv/layers/object_detection/roi_generator_test.py
@@ -1,0 +1,178 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers.object_detection.roi_generator import ROIGenerator
+
+
+class ROIGeneratorTest(tf.test.TestCase):
+    def test_singlelevel_singlebatch_roi_ignore_box(self):
+        roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.96)
+        rpn_boxes = tf.constant(
+            [
+                [[0, 0, 10, 10], [0.1, 0.1, 9.9, 9.9], [5, 5, 10, 10], [2, 2, 8, 8]],
+            ]
+        )
+        expected_rois = tf.gather(rpn_boxes, [[1, 3, 2]], batch_dims=1)
+        expected_rois = tf.concat([expected_rois, tf.zeros([1, 1, 4])], axis=1)
+        rpn_boxes = {"2": rpn_boxes}
+        rpn_scores = tf.constant(
+            [
+                [0.6, 0.9, 0.2, 0.3],
+            ]
+        )
+        # selecting the 1st, then 3rd, then 2nd as they don't overlap
+        # 0th box overlaps with 1st box
+        expected_roi_scores = tf.gather(rpn_scores, [[1, 3, 2]], batch_dims=1)
+        expected_roi_scores = tf.concat([expected_roi_scores, tf.zeros([1, 1])], axis=1)
+        rpn_scores = {"2": rpn_scores}
+        rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
+        self.assertAllClose(expected_rois, rois)
+        self.assertAllClose(expected_roi_scores, roi_scores)
+        # print(rois)
+        # print(expected_rois)
+        # print(roi_scores)
+        # print(expected_roi_scores)
+
+    def test_singlelevel_singlebatch_roi_all_box(self):
+        roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.97)
+        rpn_boxes = tf.constant(
+            [
+                [[0, 0, 10, 10], [0.1, 0.1, 9.9, 9.9], [5, 5, 10, 10], [2, 2, 8, 8]],
+            ]
+        )
+        expected_rois = tf.gather(rpn_boxes, [[1, 0, 3, 2]], batch_dims=1)
+        rpn_boxes = {"2": rpn_boxes}
+        rpn_scores = tf.constant(
+            [
+                [0.6, 0.9, 0.2, 0.3],
+            ]
+        )
+        # selecting the 1st, then 0th, then 3rd, then 2nd as they don't overlap
+        expected_roi_scores = tf.gather(rpn_scores, [[1, 0, 3, 2]], batch_dims=1)
+        rpn_scores = {"2": rpn_scores}
+        rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
+        self.assertAllClose(expected_rois, rois)
+        self.assertAllClose(expected_roi_scores, roi_scores)
+
+    def test_singlelevel_propose_rois(self):
+        roi_generator = ROIGenerator("xyxy")
+        rpn_boxes = tf.constant(
+            [
+                [[0, 0, 10, 10], [0.1, 0.1, 9.9, 9.9], [5, 5, 10, 10], [2, 2, 8, 8]],
+                [[2, 2, 4, 4], [3, 3, 6, 6], [3.1, 3.1, 6.1, 6.1], [1, 1, 8, 8]],
+            ]
+        )
+        expected_rois = tf.gather(rpn_boxes, [[1, 3, 2], [1, 3, 0]], batch_dims=1)
+        expected_rois = tf.concat([expected_rois, tf.zeros([2, 1, 4])], axis=1)
+        rpn_boxes = {"2": rpn_boxes}
+        rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
+        # 1st batch -- selecting the 1st, then 3rd, then 2nd as they don't overlap
+        # 2nd batch -- selecting the 1st, then 3rd, then 0th as they don't overlap
+        expected_roi_scores = tf.gather(
+            rpn_scores, [[1, 3, 2], [1, 3, 0]], batch_dims=1
+        )
+        expected_roi_scores = tf.concat([expected_roi_scores, tf.zeros([2, 1])], axis=1)
+        rpn_scores = {"2": rpn_scores}
+        rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
+        self.assertAllClose(expected_rois, rois)
+        self.assertAllClose(expected_roi_scores, roi_scores)
+
+    def test_twolevel_singlebatch_propose_rois_ignore_box(self):
+        roi_generator = ROIGenerator("xyxy")
+        rpn_boxes = tf.constant(
+            [
+                [[0, 0, 10, 10], [0.1, 0.1, 9.9, 9.9], [5, 5, 10, 10], [2, 2, 8, 8]],
+                [[2, 2, 4, 4], [3, 3, 6, 6], [3.1, 3.1, 6.1, 6.1], [1, 1, 8, 8]],
+            ]
+        )
+        expected_rois = tf.constant(
+            [
+                [
+                    [0.1, 0.1, 9.9, 9.9],
+                    [3, 3, 6, 6],
+                    [1, 1, 8, 8],
+                    [2, 2, 8, 8],
+                    [5, 5, 10, 10],
+                    [2, 2, 4, 4],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ]
+            ]
+        )
+        rpn_boxes = {"2": rpn_boxes[0:1], "3": rpn_boxes[1:2]}
+        rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
+        # 1st batch -- selecting the 1st, then 3rd, then 2nd as they don't overlap
+        # 2nd batch -- selecting the 1st, then 3rd, then 0th as they don't overlap
+        expected_roi_scores = [
+            [
+                0.9,
+                0.8,
+                0.5,
+                0.3,
+                0.2,
+                0.1,
+                0.0,
+                0.0,
+            ]
+        ]
+        rpn_scores = {"2": rpn_scores[0:1], "3": rpn_scores[1:2]}
+        rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
+        self.assertAllClose(expected_rois, rois)
+        self.assertAllClose(expected_roi_scores, roi_scores)
+
+    def test_twolevel_singlebatch_propose_rois_all_box(self):
+        roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.99)
+        rpn_boxes = tf.constant(
+            [
+                [[0, 0, 10, 10], [0.1, 0.1, 9.9, 9.9], [5, 5, 10, 10], [2, 2, 8, 8]],
+                [[2, 2, 4, 4], [3, 3, 6, 6], [3.1, 3.1, 6.1, 6.1], [1, 1, 8, 8]],
+            ]
+        )
+        expected_rois = tf.constant(
+            [
+                [
+                    [0.1, 0.1, 9.9, 9.9],
+                    [3, 3, 6, 6],
+                    [0, 0, 10, 10],
+                    [1, 1, 8, 8],
+                    [2, 2, 8, 8],
+                    [3.1, 3.1, 6.1, 6.1],
+                    [5, 5, 10, 10],
+                    [2, 2, 4, 4],
+                ]
+            ]
+        )
+        rpn_boxes = {"2": rpn_boxes[0:1], "3": rpn_boxes[1:2]}
+        rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
+        # 1st batch -- selecting the 1st, then 0th, then 3rd, then 2nd as they don't overlap
+        # 2nd batch -- selecting the 1st, then 3rd, then 2nd, then 0th as they don't overlap
+        expected_roi_scores = [
+            [
+                0.9,
+                0.8,
+                0.6,
+                0.5,
+                0.3,
+                0.3,
+                0.2,
+                0.1,
+            ]
+        ]
+        rpn_scores = {"2": rpn_scores[0:1], "3": rpn_scores[1:2]}
+        rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
+        print(rois)
+        self.assertAllClose(expected_rois, rois)
+        self.assertAllClose(expected_roi_scores, roi_scores)

--- a/keras_cv/layers/object_detection/roi_generator_test.py
+++ b/keras_cv/layers/object_detection/roi_generator_test.py
@@ -18,7 +18,7 @@ from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 
 
 class ROIGeneratorTest(tf.test.TestCase):
-    def test_singlelevel_singlebatch_roi_ignore_box(self):
+    def test_single_level_single_batch_roi_ignore_box(self):
         roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.96)
         rpn_boxes = tf.constant(
             [
@@ -27,7 +27,7 @@ class ROIGeneratorTest(tf.test.TestCase):
         )
         expected_rois = tf.gather(rpn_boxes, [[1, 3, 2]], batch_dims=1)
         expected_rois = tf.concat([expected_rois, tf.zeros([1, 1, 4])], axis=1)
-        rpn_boxes = {"2": rpn_boxes}
+        rpn_boxes = {2: rpn_boxes}
         rpn_scores = tf.constant(
             [
                 [0.6, 0.9, 0.2, 0.3],
@@ -37,16 +37,14 @@ class ROIGeneratorTest(tf.test.TestCase):
         # 0th box overlaps with 1st box
         expected_roi_scores = tf.gather(rpn_scores, [[1, 3, 2]], batch_dims=1)
         expected_roi_scores = tf.concat([expected_roi_scores, tf.zeros([1, 1])], axis=1)
-        rpn_scores = {"2": rpn_scores}
+        rpn_scores = {2: rpn_scores}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
         self.assertAllClose(expected_rois, rois)
         self.assertAllClose(expected_roi_scores, roi_scores)
-        # print(rois)
-        # print(expected_rois)
-        # print(roi_scores)
-        # print(expected_roi_scores)
 
-    def test_singlelevel_singlebatch_roi_all_box(self):
+    def test_single_level_single_batch_roi_all_box(self):
+        # for iou between 1st and 2nd box is 0.9604, so setting to 0.97 to
+        # such that NMS would treat them as different ROIs
         roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.97)
         rpn_boxes = tf.constant(
             [
@@ -54,7 +52,7 @@ class ROIGeneratorTest(tf.test.TestCase):
             ]
         )
         expected_rois = tf.gather(rpn_boxes, [[1, 0, 3, 2]], batch_dims=1)
-        rpn_boxes = {"2": rpn_boxes}
+        rpn_boxes = {2: rpn_boxes}
         rpn_scores = tf.constant(
             [
                 [0.6, 0.9, 0.2, 0.3],
@@ -62,12 +60,12 @@ class ROIGeneratorTest(tf.test.TestCase):
         )
         # selecting the 1st, then 0th, then 3rd, then 2nd as they don't overlap
         expected_roi_scores = tf.gather(rpn_scores, [[1, 0, 3, 2]], batch_dims=1)
-        rpn_scores = {"2": rpn_scores}
+        rpn_scores = {2: rpn_scores}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
         self.assertAllClose(expected_rois, rois)
         self.assertAllClose(expected_roi_scores, roi_scores)
 
-    def test_singlelevel_propose_rois(self):
+    def test_single_level_propose_rois(self):
         roi_generator = ROIGenerator("xyxy")
         rpn_boxes = tf.constant(
             [
@@ -77,7 +75,7 @@ class ROIGeneratorTest(tf.test.TestCase):
         )
         expected_rois = tf.gather(rpn_boxes, [[1, 3, 2], [1, 3, 0]], batch_dims=1)
         expected_rois = tf.concat([expected_rois, tf.zeros([2, 1, 4])], axis=1)
-        rpn_boxes = {"2": rpn_boxes}
+        rpn_boxes = {2: rpn_boxes}
         rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
         # 1st batch -- selecting the 1st, then 3rd, then 2nd as they don't overlap
         # 2nd batch -- selecting the 1st, then 3rd, then 0th as they don't overlap
@@ -85,12 +83,12 @@ class ROIGeneratorTest(tf.test.TestCase):
             rpn_scores, [[1, 3, 2], [1, 3, 0]], batch_dims=1
         )
         expected_roi_scores = tf.concat([expected_roi_scores, tf.zeros([2, 1])], axis=1)
-        rpn_scores = {"2": rpn_scores}
+        rpn_scores = {2: rpn_scores}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
         self.assertAllClose(expected_rois, rois)
         self.assertAllClose(expected_roi_scores, roi_scores)
 
-    def test_twolevel_singlebatch_propose_rois_ignore_box(self):
+    def test_two_level_single_batch_propose_rois_ignore_box(self):
         roi_generator = ROIGenerator("xyxy")
         rpn_boxes = tf.constant(
             [
@@ -112,7 +110,7 @@ class ROIGeneratorTest(tf.test.TestCase):
                 ]
             ]
         )
-        rpn_boxes = {"2": rpn_boxes[0:1], "3": rpn_boxes[1:2]}
+        rpn_boxes = {2: rpn_boxes[0:1], 3: rpn_boxes[1:2]}
         rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
         # 1st batch -- selecting the 1st, then 3rd, then 2nd as they don't overlap
         # 2nd batch -- selecting the 1st, then 3rd, then 0th as they don't overlap
@@ -128,12 +126,12 @@ class ROIGeneratorTest(tf.test.TestCase):
                 0.0,
             ]
         ]
-        rpn_scores = {"2": rpn_scores[0:1], "3": rpn_scores[1:2]}
+        rpn_scores = {2: rpn_scores[0:1], 3: rpn_scores[1:2]}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
         self.assertAllClose(expected_rois, rois)
         self.assertAllClose(expected_roi_scores, roi_scores)
 
-    def test_twolevel_singlebatch_propose_rois_all_box(self):
+    def test_two_level_single_batch_propose_rois_all_box(self):
         roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.99)
         rpn_boxes = tf.constant(
             [
@@ -155,7 +153,7 @@ class ROIGeneratorTest(tf.test.TestCase):
                 ]
             ]
         )
-        rpn_boxes = {"2": rpn_boxes[0:1], "3": rpn_boxes[1:2]}
+        rpn_boxes = {2: rpn_boxes[0:1], 3: rpn_boxes[1:2]}
         rpn_scores = tf.constant([[0.6, 0.9, 0.2, 0.3], [0.1, 0.8, 0.3, 0.5]])
         # 1st batch -- selecting the 1st, then 0th, then 3rd, then 2nd as they don't overlap
         # 2nd batch -- selecting the 1st, then 3rd, then 2nd, then 0th as they don't overlap
@@ -171,7 +169,7 @@ class ROIGeneratorTest(tf.test.TestCase):
                 0.1,
             ]
         ]
-        rpn_scores = {"2": rpn_scores[0:1], "3": rpn_scores[1:2]}
+        rpn_scores = {2: rpn_scores[0:1], 3: rpn_scores[1:2]}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
         print(rois)
         self.assertAllClose(expected_rois, rois)

--- a/keras_cv/layers/object_detection/roi_generator_test.py
+++ b/keras_cv/layers/object_detection/roi_generator_test.py
@@ -171,6 +171,5 @@ class ROIGeneratorTest(tf.test.TestCase):
         ]
         rpn_scores = {2: rpn_scores[0:1], 3: rpn_scores[1:2]}
         rois, roi_scores = roi_generator(rpn_boxes, rpn_scores, training=True)
-        print(rois)
         self.assertAllClose(expected_rois, rois)
         self.assertAllClose(expected_roi_scores, roi_scores)


### PR DESCRIPTION
# What does this PR do?
Add ROIGenerator for RPN network.
This replaces the ROIFilter proposed by [RFC](https://github.com/keras-team/governance/blob/master/rfcs/20220804-keras-cv-two-stage-2d-object-detection.md)