### PR TITLE
Target gather

### DIFF
--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -1,0 +1,143 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from email.mime import image
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+
+
+class ROIPooler(tf.keras.layers.Layer):
+    """
+    Pooling feature map of dynamic shape into region of interest (ROI) of fixed shape.
+
+    Mainly used in Region CNN (RCNN) networks. This works for a single-level
+    input feature map.
+
+    This layer splits the feature map into [target_size[0], target_size[1]] areas,
+    and performs max pooling for each area. The area coordinates will be quantized.
+
+    Args:
+        bounding_box_format: a case-insensitive string.
+            For detailed information on the supported format, see the
+            [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
+        target_size: List or Tuple of 2 integers of the pooled shape
+        image_shape: List of Tuple of 3 integers, or `TensorShape` of the image shape.
+
+    Usage:
+    ```python
+    feature_map = tf.random.normal([2, 16, 16, 512])
+    roi_pooler = ROIPooler("yxyx", [7, 7], [224, 224, 3])
+    rois = tf.constant([[[15., 30., 25., 45.]], [[22., 1., 30., 32.]]])
+    pooled_feature_map = roi_pooler(feature_map, rois)
+    ```
+    """
+
+    def __init__(
+        self,
+        bounding_box_format,
+        target_size,
+        image_shape,
+        **kwargs,
+    ):
+        if not isinstance(target_size, (tuple, list)):
+            raise ValueError(
+                f"Expected `target_size` to be tuple or list, got {type(target_size)}"
+            )
+        if len(target_size) != 2:
+            raise ValueError(
+                f"Expected `target_size` to be size 2, got {len(target_size)}"
+            )
+        super().__init__(**kwargs)
+        self.bounding_box_format = bounding_box_format
+        self.target_height = target_size[0]
+        self.target_width = target_size[1]
+        self.image_shape = image_shape
+        self.built = True
+
+    def call(self, feature_map, rois):
+        """
+        Args:
+          feature_map: [batch_size, H, W, C] float Tensor, the feature map extracted from image.
+          rois: [batch_size, N, 4] float Tensor, the region of interests to be pooled.
+        Returns:
+          pooled_feature_map: [batch_size, N, target_size, C] float Tensor
+        """
+        # convert to relative format given feature map shape != image shape
+        rois = bounding_box.convert_format(
+            rois,
+            source=self.bounding_box_format,
+            target="rel_yxyx",
+            image_shape=self.image_shape,
+        )
+        pooled_feature_map = tf.vectorized_map(
+            self._pool_single_sample, (feature_map, rois)
+        )
+        return pooled_feature_map
+
+    def _pool_single_sample(self, args):
+        """
+        Args: tuple of
+          feature_map: [H, W, C] float Tensor
+          rois: [N, 4] float Tensor
+        Returns:
+          pooled_feature_map: [target_size, C] float Tensor
+        """
+        feature_map, rois = args
+        N = rois.get_shape().as_list()[0]
+        H, W, C = feature_map.get_shape().as_list()
+        for n in range(N):
+            # [4]
+            roi = rois[n, :]
+            y_start = H * roi[0]
+            x_start = W * roi[1]
+            region_height = H * (roi[2] - roi[0])
+            region_width = W * (roi[3] - roi[1])
+            h_step = region_height / self.target_height
+            w_step = region_width / self.target_width
+            regions = []
+            for i in range(self.target_height):
+                for j in range(self.target_width):
+                    height_start = y_start + i * h_step
+                    height_end = height_start + h_step
+                    height_start = tf.cast(height_start, tf.int32)
+                    height_end = tf.cast(height_end, tf.int32)
+                    # if feature_map shape smaller than roi, h_step would be 0
+                    # in this case the result will be feature_map[0, 0, ...]
+                    height_end = height_start + tf.maximum(1, height_end - height_start)
+                    width_start = x_start + j * w_step
+                    width_end = width_start + w_step
+                    width_start = tf.cast(width_start, tf.int32)
+                    width_end = tf.cast(width_end, tf.int32)
+                    width_end = width_start + tf.maximum(1, width_end - width_start)
+                    # [h_step, w_step, C]
+                    region = feature_map[
+                        height_start:height_end, width_start:width_end, :
+                    ]
+                    # target_height * target_width * [C]
+                    regions.append(tf.reduce_max(region, axis=[0, 1]))
+            regions = tf.reshape(
+                tf.stack(regions), [self.target_height, self.target_width, C]
+            )
+            return regions
+
+    def get_config(self):
+        config = {
+            "bounding_box_format": self.bounding_box_format,
+            "target_size": [self.target_height, self.target_width],
+            "image_shape": self.image_shape,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from email.mime import image
-
 import tensorflow as tf
 
 from keras_cv import bounding_box

--- a/keras_cv/layers/object_detection/roi_pool_test.py
+++ b/keras_cv/layers/object_detection/roi_pool_test.py
@@ -1,0 +1,161 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers.object_detection.roi_pool import ROIPooler
+
+
+class ROIPoolTest(tf.test.TestCase):
+    def test_no_quantize(self):
+        roi_pooler = ROIPooler(
+            "rel_yxyx", target_size=[2, 2], image_shape=[224, 224, 3]
+        )
+        feature_map = tf.expand_dims(tf.reshape(tf.range(64), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 1.0, 1.0]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # the maximum value would be at bottom-right at each block, roi sharded into 2x2 blocks
+        # | 0, 1, 2, 3          | 4, 5, 6, 7            |
+        # | 8, 9, 10, 11        | 12, 13, 14, 15        |
+        # | 16, 17, 18, 19      | 20, 21, 22, 23        |
+        # | 24, 25, 26, 27(max) | 28, 29, 30, 31(max)   |
+        # --------------------------------------------
+        # | 32, 33, 34, 35      | 36, 37, 38, 39        |
+        # | 40, 41, 42, 43      | 44, 45, 46, 47        |
+        # | 48, 49, 50, 51      | 52, 53, 54, 55        |
+        # | 56, 57, 58, 59(max) | 60, 61, 62, 63(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(tf.constant([27, 31, 59, 63]), [1, 2, 2, 1])
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_quantize_y(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[2, 2], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(64), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 224, 220]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # the maximum value would be at bottom-right at each block, roi sharded into 2x2 blocks
+        # | 0, 1, 2             | 3, 4, 5, 6            |
+        # | 8, 9, 10            | 11, 12, 13, 14        |
+        # | 16, 17, 18          | 20, 21, 22, 23        |
+        # | 24, 25, 26(max)     | 27, 28, 29, 30(max)   |
+        # --------------------------------------------
+        # | 32, 33, 34          | 35, 36, 37, 38        |
+        # | 40, 41, 42          | 43, 44, 45, 46        |
+        # | 48, 49, 50          | 51, 52, 53, 54        |
+        # | 56, 57, 58(max)     | 59, 60, 61, 62(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(tf.constant([26, 30, 58, 62]), [1, 2, 2, 1])
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_quantize_x(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[2, 2], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(64), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 220, 224]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # the maximum value would be at bottom-right at each block, roi sharded into 2x2 blocks
+        # | 0, 1, 2, 3          | 4, 5, 6, 7            |
+        # | 8, 9, 10, 11        | 12, 13, 14, 15        |
+        # | 16, 17, 18, 19(max) | 20, 21, 22, 23(max)   |
+        # --------------------------------------------
+        # | 24, 25, 26, 27      | 28, 29, 30, 31        |
+        # | 32, 33, 34, 35      | 36, 37, 38, 39        |
+        # | 40, 41, 42, 43      | 44, 45, 46, 47        |
+        # | 48, 49, 50, 51(max) | 52, 53, 54, 55(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(tf.constant([19, 23, 51, 55]), [1, 2, 2, 1])
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_quantize_h(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[3, 2], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(64), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 224, 224]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # the maximum value would be at bottom-right at each block, roi sharded into 3x2 blocks
+        # | 0, 1, 2, 3          | 4, 5, 6, 7            |
+        # | 8, 9, 10, 11        | 12, 13, 14, 15        |
+        # --------------------------------------------
+        # | 16, 17, 18, 19      | 20, 21, 22, 23        |
+        # | 24, 25, 26, 27      | 28, 29, 30, 31        |
+        # | 32, 33, 34, 35(max) | 36, 37, 38, 39(max)   |
+        # --------------------------------------------
+        # | 40, 41, 42, 43      | 44, 45, 46, 47        |
+        # | 48, 49, 50, 51      | 52, 53, 54, 55        |
+        # | 56, 57, 58, 59(max) | 60, 61, 62, 63(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(
+            tf.constant([11, 15, 35, 39, 59, 63]), [1, 3, 2, 1]
+        )
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_quantize_w(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[2, 3], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(64), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 224, 224]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # the maximum value would be at bottom-right at each block, roi sharded into 2x3 blocks
+        # | 0, 1        | 2, 3, 4           | 5, 6, 7           |
+        # | 8, 9        | 10, 11, 12        | 13, 14, 15        |
+        # | 16, 17      | 18, 19, 20        | 21, 22, 23        |
+        # | 24, 25(max) | 26, 27, 28(max)   | 29, 30, 31(max)   |
+        # --------------------------------------------
+        # | 32, 33      | 34, 35, 36        | 37, 38, 39        |
+        # | 40, 41      | 42, 43, 44        | 45, 46, 47        |
+        # | 48, 49      | 50, 51, 52        | 53, 54, 55        |
+        # | 56, 57(max) | 58, 59, 60(max)   | 61, 62, 63(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(
+            tf.constant([25, 28, 31, 57, 60, 63]), [1, 2, 3, 1]
+        )
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_feature_map_height_smaller_than_roi(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[6, 2], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(16), [4, 4, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 224, 224]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # | 0, 1(max)   | 2, 3(max)     |
+        # ------------------repeated----------------------
+        # | 4, 5(max)   | 6, 7(max)     |
+        # --------------------------------------------
+        # | 8, 9(max)   | 10, 11(max)   |
+        # ------------------repeated----------------------
+        # | 12, 13(max) | 14, 15(max)   |
+        expected_feature_map = tf.reshape(
+            tf.constant([1, 3, 1, 3, 5, 7, 9, 11, 9, 11, 13, 15]), [1, 6, 2, 1]
+        )
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_feature_map_width_smaller_than_roi(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[2, 6], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(16), [4, 4, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 224, 224]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # | 0       | 1         | 2         | 3         |
+        # | 4(max)  | 5(max)    | 6(max)    | 7(max)    |
+        # --------------------------------------------
+        # | 8       | 9         | 10        | 11        |
+        # | 12(max) | 13(max)   | 14(max)   | 15(max)   |
+        # --------------------------------------------
+        expected_feature_map = tf.reshape(
+            tf.constant([4, 4, 5, 6, 6, 7, 12, 12, 13, 14, 14, 15]), [1, 2, 6, 1]
+        )
+        self.assertAllClose(expected_feature_map, pooled_feature_map)
+
+    def test_roi_empty(self):
+        roi_pooler = ROIPooler("yxyx", target_size=[2, 2], image_shape=[224, 224, 3])
+        feature_map = tf.expand_dims(tf.reshape(tf.range(1, 65), [8, 8, 1]), axis=0)
+        rois = tf.reshape(tf.constant([0.0, 0.0, 0.0, 0.0]), [1, 1, 4])
+        pooled_feature_map = roi_pooler(feature_map, rois)
+        # all outputs should be top-left pixel
+        self.assertAllClose(tf.ones([1, 2, 2, 1]), pooled_feature_map)

--- a/keras_cv/ops/target_gather.py
+++ b/keras_cv/ops/target_gather.py
@@ -1,0 +1,123 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import tensorflow as tf
+
+
+def _target_gather(
+    targets: tf.Tensor,
+    indices: tf.Tensor,
+    mask: Optional[tf.Tensor] = None,
+    mask_val: Optional[float] = 0.0,
+):
+    """A utility function wrapping tf.gather, which deals with:
+     1) both batched and unbatched `targets`
+     2) when batched `indices` have empty rows
+     3) target masking.
+
+    Args:
+     targets: [N, ...] or [batch_size, N, ...] Tensor representing targets such
+       as boxes, keypoints, etc.
+     indices: [M] or [batch_size, M] int32 Tensor representing indices within
+       `targets` to gather.
+     mask: optional [M, ...] or [batch_size, M, ...] boolean
+       Tensor representing the masking for each target. `True` means the corresponding
+       entity should be masked to `mask_val`, `False` means the corresponding entity
+       should be the target value.
+     mask_val: optinal float representing the masking value if `mask` is True on
+       the entity.
+
+     Returns:
+       targets: [M, ...] or [batch_size, M, ...] Tensor representing selected targets.
+
+     Raise:
+       ValueError: If `targets` is higher than rank 3.
+    """
+    targets_shape = targets.get_shape().as_list()
+    if len(targets_shape) > 3:
+        raise ValueError(
+            "`target_gather` does not support `targets` with rank "
+            "larger than 3, got {}".format(len(targets.shape))
+        )
+
+    def _gather_unbatched(labels, match_indices, mask, mask_val):
+        """Gather based on unbatched labels and boxes."""
+        num_gt_boxes = tf.shape(labels)[0]
+
+        def _assign_when_rows_empty():
+            if len(labels.shape) > 1:
+                mask_shape = [match_indices.shape[0], labels.shape[-1]]
+            else:
+                mask_shape = [match_indices.shape[0]]
+            return tf.cast(mask_val, labels.dtype) * tf.ones(
+                mask_shape, dtype=labels.dtype
+            )
+
+        def _assign_when_rows_not_empty():
+            targets = tf.gather(labels, match_indices)
+            if mask is None:
+                return targets
+            else:
+                masked_targets = tf.cast(mask_val, labels.dtype) * tf.ones_like(
+                    mask, dtype=labels.dtype
+                )
+                return tf.where(mask, masked_targets, targets)
+
+        return tf.cond(
+            tf.greater(num_gt_boxes, 0),
+            _assign_when_rows_not_empty,
+            _assign_when_rows_empty,
+        )
+
+    def _gather_batched(labels, match_indices, mask, mask_val):
+        """Gather based on batched labels."""
+        batch_size = labels.shape[0]
+        if batch_size == 1:
+            if mask is not None:
+                result = _gather_unbatched(
+                    tf.squeeze(labels, axis=0),
+                    tf.squeeze(match_indices, axis=0),
+                    tf.squeeze(mask, axis=0),
+                    mask_val,
+                )
+            else:
+                result = _gather_unbatched(
+                    tf.squeeze(labels, axis=0),
+                    tf.squeeze(match_indices, axis=0),
+                    None,
+                    mask_val,
+                )
+            return tf.expand_dims(result, axis=0)
+        else:
+            indices_shape = tf.shape(match_indices)
+            indices_dtype = match_indices.dtype
+            batch_indices = tf.expand_dims(
+                tf.range(indices_shape[0], dtype=indices_dtype), axis=-1
+            ) * tf.ones([1, indices_shape[-1]], dtype=indices_dtype)
+            gather_nd_indices = tf.stack([batch_indices, match_indices], axis=-1)
+            targets = tf.gather_nd(labels, gather_nd_indices)
+            if mask is None:
+                return targets
+            else:
+                masked_targets = tf.cast(mask_val, labels.dtype) * tf.ones_like(
+                    mask, dtype=labels.dtype
+                )
+                return tf.where(mask, masked_targets, targets)
+
+    if len(targets_shape) <= 2:
+        return _gather_unbatched(targets, indices, mask, mask_val)
+    elif len(targets_shape) == 3:
+        return _gather_batched(targets, indices, mask, mask_val)

--- a/keras_cv/ops/target_gather_test.py
+++ b/keras_cv/ops/target_gather_test.py
@@ -1,0 +1,63 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.ops.target_gather import _target_gather
+
+
+class TargetGatherTest(tf.test.TestCase):
+    def test_target_gather_boxes_batched(self):
+        target_boxes = tf.constant(
+            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
+        )
+        target_boxes = target_boxes[tf.newaxis, ...]
+        indices = tf.constant([[0, 2]], dtype=tf.int32)
+        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
+        expected_boxes = expected_boxes[tf.newaxis, ...]
+        res = _target_gather(target_boxes, indices)
+        self.assertAllClose(expected_boxes, res)
+
+    def test_target_gather_boxes_unbatched(self):
+        target_boxes = tf.constant(
+            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
+        )
+        indices = tf.constant([0, 2], dtype=tf.int32)
+        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
+        res = _target_gather(target_boxes, indices)
+        self.assertAllClose(expected_boxes, res)
+
+    def test_target_gather_boxes_batched(self):
+        target_classes = tf.constant([[1, 2, 3, 4]])
+        target_classes = target_classes[..., tf.newaxis]
+        indices = tf.constant([[0, 2]], dtype=tf.int32)
+        expected_classes = tf.constant([[1, 3]])
+        expected_classes = expected_classes[..., tf.newaxis]
+        res = _target_gather(target_classes, indices)
+        self.assertAllClose(expected_classes, res)
+
+    def test_target_gather_boxes_unbatched(self):
+        target_classes = tf.constant([1, 2, 3, 4])
+        target_classes = target_classes[..., tf.newaxis]
+        indices = tf.constant([0, 2], dtype=tf.int32)
+        expected_classes = tf.constant([1, 3])
+        expected_classes = expected_classes[..., tf.newaxis]
+        res = _target_gather(target_classes, indices)
+        self.assertAllClose(expected_classes, res)
+
+    def test_target_gather_invalid_rank(self):
+        targets = tf.random.normal([32, 2, 2, 2])
+        indices = tf.constant([0, 1], dtype=tf.int32)
+        with self.assertRaisesRegex(ValueError, "larger than 3"):
+            _ = _target_gather(targets, indices)


### PR DESCRIPTION
# What does this PR do?
Add target gather as private API, given we haven't decided the best naming for it yet. However this is useful in both our OD workflows so we need to have it, to be able to compile with dictionary of loss objects, instead of a hand-made ObjectDetectionLoss
