### PR TITLE
Add ROISampler.

### DIFF
--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -1,0 +1,157 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+from keras_cv.bounding_box.iou import compute_iou
+from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
+from keras_cv.ops.sampling import balanced_sample
+from keras_cv.ops.target_gather import _target_gather
+
+
+class _ROISampler(tf.keras.layers.Layer):
+    """
+    Sample ROIs for loss related calucation.
+
+    With proposals (ROIs) and ground truth, tt performs the following:
+    1) compute IOU similarity matrix
+    2) match each proposal to ground truth box based on IOU
+    3) samples positive matches and negative matches and return
+
+    `append_gt_boxes` augments proposals with ground truth boxes. This is
+    useful in 2 stage detection networks during initialization where the
+    1st stage often cannot produce good proposals for 2nd stage. Setting it
+    to True will allow it to generate more reasonable proposals at the begining.
+
+    `background_class` allow users to set the labels for background proposals. Default
+    is 0, where users need to manually shift the incoming `gt_classes` if its range is
+    [0, num_classes).
+
+    Args:
+      bounding_box_format: The format of bounding boxes to generate. Refer
+        [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
+        for more details on supported bounding box formats.
+      roi_matcher: a `ArgmaxBoxMatcher` object that matches proposals
+        with ground truth boxes. the positive match must be 1 and negative match must be -1.
+        Such assumption is not being validated here.
+      positive_fraction: the positive ratio w.r.t `num_sampled_rois`. Defaults to 0.25.
+      background_class: the background class which is used to map returned the sampled
+        ground truth which is classified as background.
+      num_sampled_rois: the number of sampled proposals per image for
+        further (loss) calculation. Defaults to 256.
+      append_gt_boxes: boolean, whether gt_boxes will be appended to rois
+        before sample the rois. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        bounding_box_format: str,
+        roi_matcher: ArgmaxBoxMatcher,
+        positive_fraction: float = 0.25,
+        background_class: int = 0,
+        num_sampled_rois: int = 256,
+        append_labels: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.bounding_box_format = bounding_box_format
+        self.roi_matcher = roi_matcher
+        self.positive_fraction = positive_fraction
+        self.background_class = background_class
+        self.num_sampled_rois = num_sampled_rois
+        self.append_labels = append_labels
+        self.built = True
+
+    def call(
+        self,
+        rois: tf.Tensor,
+        gt_boxes: tf.Tensor,
+        gt_classes: tf.Tensor,
+    ):
+        """
+        Args:
+          rois: [batch_size, num_rois, 4]
+          gt_boxes: [batch_size, num_gt, 4]
+          gt_classes: [batch_size, num_gt, 1]
+        Returns:
+          sampled_rois: [batch_size, num_sampled_rois, 4]
+          sampled_gt_boxes: [batch_size, num_sampled_rois, 4]
+          sampled_gt_classes: [batch_size, num_sampled_rois, 1]
+        """
+        # TODO (tanzhenyu): Add masking in bounding_box.compute_iou
+        if self.append_labels:
+            # num_rois += num_gt
+            rois = tf.concat([rois, gt_boxes], axis=1)
+        num_rois = rois.get_shape().as_list()[1]
+        if num_rois is None:
+            raise ValueError(f"`rois` must have static shape, got {rois.get_shape()}")
+        if num_rois < self.num_sampled_rois:
+            raise ValueError(
+                f"num_rois must be less than `num_sampled_rois` ({self.num_sampled_rois}), got {num_rois}"
+            )
+        rois = bounding_box.convert_format(
+            rois, source=self.bounding_box_format, target="xyxy"
+        )
+        gt_boxes = bounding_box.convert_format(
+            gt_boxes, source=self.bounding_box_format, target="xyxy"
+        )
+        # [batch_size, num_rois, num_gt]
+        iou = compute_iou(rois, gt_boxes, bounding_box_format="xyxy")
+        # [batch_size, num_rois] | [batch_size, num_rois]
+        matched_gt_cols, matched_vals = self.roi_matcher(iou)
+        # [batch_size, num_rois]
+        positive_matches = tf.math.equal(matched_vals, 1)
+        negative_matches = tf.math.equal(matched_vals, -1)
+        # [batch_size, num_rois, 1]
+        background_mask = tf.expand_dims(tf.logical_not(positive_matches), axis=-1)
+        # [batch_size, num_rois, 1]
+        matched_gt_classes = _target_gather(
+            gt_classes, matched_gt_cols, background_mask
+        )
+        # also set all background matches to `background_class`
+        matched_gt_classes = tf.where(
+            background_mask,
+            tf.cast(
+                self.background_class * tf.ones_like(matched_gt_classes),
+                gt_classes.dtype,
+            ),
+            matched_gt_classes,
+        )
+        # [batch_size, num_rois, 4]
+        matched_gt_boxes = _target_gather(
+            gt_boxes, matched_gt_cols, tf.tile(background_mask, [1, 1, 4])
+        )
+        # also set all background matches to 0 coordinates
+        matched_gt_boxes = tf.where(
+            background_mask, tf.zeros_like(matched_gt_boxes), matched_gt_boxes
+        )
+        # [batch_size, num_rois]
+        sampled_indicators = balanced_sample(
+            positive_matches,
+            negative_matches,
+            self.num_sampled_rois,
+            self.positive_fraction,
+        )
+        # [batch_size, num_sampled_rois] in the range of [0, num_rois)
+        _, sampled_indices = tf.math.top_k(
+            sampled_indicators, k=self.num_sampled_rois, sorted=True
+        )
+        # [batch_size, num_sampled_rois, 4]
+        sampled_rois = _target_gather(rois, sampled_indices)
+        # [batch_size, num_sampled_rois, 4]
+        sampled_gt_boxes = _target_gather(matched_gt_boxes, sampled_indices)
+        # [batch_size, num_sampled_rois, 1]
+        sampled_gt_classes = _target_gather(matched_gt_classes, sampled_indices)
+        return sampled_rois, sampled_gt_boxes, sampled_gt_classes

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -159,3 +159,22 @@ class _ROISampler(tf.keras.layers.Layer):
             matched_gt_classes, sampled_indices
         )
         return sampled_rois, sampled_gt_boxes, sampled_gt_classes
+
+    def get_config(self):
+        config = {
+            "bounding_box_format": self.bounding_box_format,
+            "positive_fraction": self.positive_fraction,
+            "background_class": self.background_class,
+            "num_sampled_rois": self.num_sampled_rois,
+            "append_gt_boxes": self.append_gt_boxes,
+            "roi_matcher": self.roi_matcher.get_config(),
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        roi_matcher = box_matcher.ArgmaxBoxMatcher.from_config(
+            config.pop("roi_matcher")
+        )
+        return cls(roi_matcher=roi_matcher, **config)

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -174,7 +174,6 @@ class _ROISampler(tf.keras.layers.Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
-        roi_matcher = box_matcher.ArgmaxBoxMatcher.from_config(
-            config.pop("roi_matcher")
-        )
+        roi_matcher_config = config.pop("roi_matcher")
+        roi_matcher = box_matcher.ArgmaxBoxMatcher(**roi_matcher_config)
         return cls(roi_matcher=roi_matcher, **config)

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -151,7 +151,11 @@ class _ROISampler(tf.keras.layers.Layer):
         # [batch_size, num_sampled_rois, 4]
         sampled_rois = target_gather._target_gather(rois, sampled_indices)
         # [batch_size, num_sampled_rois, 4]
-        sampled_gt_boxes = target_gather._target_gather(matched_gt_boxes, sampled_indices)
+        sampled_gt_boxes = target_gather._target_gather(
+            matched_gt_boxes, sampled_indices
+        )
         # [batch_size, num_sampled_rois, 1]
-        sampled_gt_classes = target_gather._target_gather(matched_gt_classes, sampled_indices)
+        sampled_gt_classes = target_gather._target_gather(
+            matched_gt_classes, sampled_indices
+        )
         return sampled_rois, sampled_gt_boxes, sampled_gt_classes

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -212,3 +212,16 @@ class ROISamplerTest(tf.test.TestCase):
         gt_classes = gt_classes[..., tf.newaxis]
         with self.assertRaisesRegex(ValueError, "must be less than"):
             _, _, _ = roi_sampler(rois, gt_boxes, gt_classes)
+
+    def test_serialization(self):
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
+        roi_sampler = _ROISampler(
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=200,
+            append_gt_boxes=True,
+        )
+        sampler_config = roi_sampler.get_config()
+        new_sampler = _ROISampler.from_config(sampler_config)
+        self.assertAllEqual(new_sampler.roi_matcher.match_values, [-1, 1])

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -1,0 +1,214 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers.object_detection.roi_sampler import _ROISampler
+from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
+
+
+class ROISamplerTest(tf.test.TestCase):
+    def test_roi_sampler(self):
+        box_matcher = ArgmaxBoxMatcher([0.3], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=2,
+            append_labels=False,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.5, 2.5, 7.5, 7.5], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        a, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        # given we only choose 1 positive sample, and `append_labesl` is False,
+        # only the 2nd ROI is chosen.
+        expected_gt_boxes = tf.constant([[2.5, 2.5, 7.5, 7.5], [0.0, 0.0, 0, 0.0]])
+        expected_gt_boxes = expected_gt_boxes[tf.newaxis, ...]
+        # only the 2nd ROI is chosen, and the negative ROI is mapped to 0.
+        expected_gt_classes = tf.constant([[10], [0]], dtype=tf.int32)
+        expected_gt_classes = expected_gt_classes[tf.newaxis, ...]
+        self.assertAllClose(expected_gt_boxes, sampled_gt_boxes)
+        self.assertAllClose(expected_gt_classes, sampled_gt_classes)
+
+    def test_roi_sampler_small_threshold(self):
+        box_matcher = ArgmaxBoxMatcher([0.1], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=2,
+            append_labels=False,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.6, 2.6, 7.6, 7.6], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        sampled_rois, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        # given we only choose 1 positive sample, and `append_labesl` is False,
+        # only the 2nd ROI is chosen. No negative samples exist given we
+        # select positive_threshold to be 0.1. (the minimum IOU is 1/7)
+        # given num_sampled_rois=2, it selects the 1st ROI as well.
+        expected_rois = tf.constant([[2.5, 2.5, 7.5, 7.5], [0.0, 0.0, 5.0, 5.0]])
+        expected_rois = expected_rois[tf.newaxis, ...]
+        # all ROIs are matched to the 2nd gt box.
+        expected_gt_boxes = tf.constant([[2.6, 2.6, 7.6, 7.6], [2.6, 2.6, 7.6, 7.6]])
+        expected_gt_boxes = expected_gt_boxes[tf.newaxis, ...]
+        # only the 2nd ROI is chosen, and the negative ROI is mapped to 0.
+        expected_gt_classes = tf.constant([[10], [10]], dtype=tf.int32)
+        expected_gt_classes = expected_gt_classes[tf.newaxis, ...]
+        self.assertAllClose(expected_rois, sampled_rois)
+        self.assertAllClose(expected_gt_boxes, sampled_gt_boxes)
+        self.assertAllClose(expected_gt_classes, sampled_gt_classes)
+
+    def test_roi_sampler_large_threshold(self):
+        # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
+        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=2,
+            append_labels=False,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.6, 2.6, 7.6, 7.6], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        _, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        # all ROIs are negative matches, so they are mapped to 0.
+        expected_gt_boxes = tf.zeros([1, 2, 4], dtype=tf.float32)
+        # only the 2nd ROI is chosen, and the negative ROI is mapped to 0.
+        expected_gt_classes = tf.constant([[0], [0]], dtype=tf.int32)
+        expected_gt_classes = expected_gt_classes[tf.newaxis, ...]
+        # self.assertAllClose(expected_rois, sampled_rois)
+        self.assertAllClose(expected_gt_boxes, sampled_gt_boxes)
+        self.assertAllClose(expected_gt_classes, sampled_gt_classes)
+
+    def test_roi_sampler_large_threshold_custom_bg_class(self):
+        # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
+        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            background_class=-1,
+            num_sampled_rois=2,
+            append_labels=False,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.6, 2.6, 7.6, 7.6], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        _, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        # all ROIs are negative matches, so they are mapped to 0.
+        expected_gt_boxes = tf.zeros([1, 2, 4], dtype=tf.float32)
+        # only the 2nd ROI is chosen, and the negative ROI is mapped to -1 from customization.
+        expected_gt_classes = tf.constant([[-1], [-1]], dtype=tf.int32)
+        expected_gt_classes = expected_gt_classes[tf.newaxis, ...]
+        # self.assertAllClose(expected_rois, sampled_rois)
+        self.assertAllClose(expected_gt_boxes, sampled_gt_boxes)
+        self.assertAllClose(expected_gt_classes, sampled_gt_classes)
+
+    def test_roi_sampler_large_threshold_append_gt_boxes(self):
+        # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
+        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=2,
+            append_labels=True,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.6, 2.6, 7.6, 7.6], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        _, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        # the selected gt boxes should be [0, 0, 0, 0], and [2.6, 2.6, 7.6, 7.6]
+        # ordering is random, so we assert for max and min values
+        self.assertAllClose(tf.reduce_min(sampled_gt_boxes), 0)
+        self.assertAllClose(tf.reduce_max(sampled_gt_boxes), 7.6)
+        # the selected gt classes should be [0, 10]
+        self.assertAllClose(tf.reduce_min(sampled_gt_classes), 0)
+        self.assertAllClose(tf.reduce_max(sampled_gt_classes), 10)
+
+    def test_roi_sampler_large_num_sampled_rois(self):
+        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        roi_sampler = _ROISampler(
+            "xyxy",
+            box_matcher,
+            positive_fraction=0.5,
+            num_sampled_rois=200,
+            append_labels=True,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        rois = rois[tf.newaxis, ...]
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant(
+            [[10, 10, 15, 15], [2.6, 2.6, 7.6, 7.6], [-1, -1, -1, -1]]
+        )
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        with self.assertRaisesRegex(ValueError, "must be less than"):
+            _, _, _ = roi_sampler(rois, gt_boxes, gt_classes)

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -22,8 +22,8 @@ class ROISamplerTest(tf.test.TestCase):
     def test_roi_sampler(self):
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.3], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
             append_gt_boxes=False,
@@ -55,8 +55,8 @@ class ROISamplerTest(tf.test.TestCase):
     def test_roi_sampler_small_threshold(self):
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.1], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
             append_gt_boxes=False,
@@ -95,8 +95,8 @@ class ROISamplerTest(tf.test.TestCase):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
             append_gt_boxes=False,
@@ -128,8 +128,8 @@ class ROISamplerTest(tf.test.TestCase):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             background_class=-1,
             num_sampled_rois=2,
@@ -162,8 +162,8 @@ class ROISamplerTest(tf.test.TestCase):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
             append_gt_boxes=True,
@@ -193,8 +193,8 @@ class ROISamplerTest(tf.test.TestCase):
     def test_roi_sampler_large_num_sampled_rois(self):
         box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
-            "xyxy",
-            box_matcher,
+            bounding_box_format="xyxy",
+            roi_matcher=box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=200,
             append_gt_boxes=True,

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -20,13 +20,13 @@ from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 
 class ROISamplerTest(tf.test.TestCase):
     def test_roi_sampler(self):
-        box_matcher = ArgmaxBoxMatcher([0.3], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.3], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
-            append_labels=False,
+            append_gt_boxes=False,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
@@ -39,7 +39,7 @@ class ROISamplerTest(tf.test.TestCase):
         gt_boxes = gt_boxes[tf.newaxis, ...]
         gt_classes = tf.constant([[2, 10, -1]], dtype=tf.int32)
         gt_classes = gt_classes[..., tf.newaxis]
-        a, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
+        _, sampled_gt_boxes, sampled_gt_classes = roi_sampler(
             rois, gt_boxes, gt_classes
         )
         # given we only choose 1 positive sample, and `append_labesl` is False,
@@ -53,13 +53,13 @@ class ROISamplerTest(tf.test.TestCase):
         self.assertAllClose(expected_gt_classes, sampled_gt_classes)
 
     def test_roi_sampler_small_threshold(self):
-        box_matcher = ArgmaxBoxMatcher([0.1], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.1], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
-            append_labels=False,
+            append_gt_boxes=False,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
@@ -93,13 +93,13 @@ class ROISamplerTest(tf.test.TestCase):
 
     def test_roi_sampler_large_threshold(self):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
-        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
-            append_labels=False,
+            append_gt_boxes=False,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
@@ -126,14 +126,14 @@ class ROISamplerTest(tf.test.TestCase):
 
     def test_roi_sampler_large_threshold_custom_bg_class(self):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
-        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             background_class=-1,
             num_sampled_rois=2,
-            append_labels=False,
+            append_gt_boxes=False,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
@@ -160,13 +160,13 @@ class ROISamplerTest(tf.test.TestCase):
 
     def test_roi_sampler_large_threshold_append_gt_boxes(self):
         # the 2nd roi and 2nd gt box has IOU of 0.923, setting positive_threshold to 0.95 to ignore it
-        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=2,
-            append_labels=True,
+            append_gt_boxes=True,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
@@ -191,13 +191,13 @@ class ROISamplerTest(tf.test.TestCase):
         self.assertAllClose(tf.reduce_max(sampled_gt_classes), 10)
 
     def test_roi_sampler_large_num_sampled_rois(self):
-        box_matcher = ArgmaxBoxMatcher([0.95], [-1, 1])
+        box_matcher = ArgmaxBoxMatcher(thresholds=[0.95], match_values=[-1, 1])
         roi_sampler = _ROISampler(
             "xyxy",
             box_matcher,
             positive_fraction=0.5,
             num_sampled_rois=200,
-            append_labels=True,
+            append_gt_boxes=True,
         )
         rois = tf.constant(
             [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]

--- a/keras_cv/ops/box_matcher.py
+++ b/keras_cv/ops/box_matcher.py
@@ -30,24 +30,22 @@ class ArgmaxBoxMatcher:
     The settings include `thresholds` and `match_values`, for example if:
     1) thresholds=[negative_threshold, positive_threshold], and
        match_values=[negative_value=0, ignore_value=-1, positive_value=1]: the rows will
-       be assigned to positive_value if its argmax result is above
+       be assigned to positive_value if its argmax result >=
        positive_threshold; the rows will be assigned to negative_value if its
-       argmax result is below negative_threshold, and the rows will be assigned
-       to ignore_value if its argmax result is between negative_threshold and
-       positive_threshold.
+       argmax result < negative_threshold, and the rows will be assigned
+       to ignore_value if its argmax result is between [negative_threshold, positive_threshold).
     2) thresholds=[negative_threshold, positive_threshold], and
        match_values=[ignore_value=-1, negative_value=0, positive_value=1]: the rows will
-       be assigned to positive_value if its argmax result is above
+       be assigned to positive_value if its argmax result >=
        positive_threshold; the rows will be assigned to ignore_value if its
-       argmax result is below negative_threshold, and the rows will be assigned
-       to negative_value if its argmax result is between negative_threshold and
-       positive_threshold. This is different from case 1) by swapping first two
+       argmax result < negative_threshold, and the rows will be assigned
+       to negative_value if its argmax result is between [negative_threshold ,positive_threshold).
+       This is different from case 1) by swapping first two
        values.
     3) thresholds=[positive_threshold], and
        match_values=[negative_values, positive_value]: the rows will be assigned to
-       positive value if its argmax result is above positive_threshold; the rows
-       will be assigned to negative_value if its argmax result is below
-       negative_threshold.
+       positive value if its argmax result >= positive_threshold; the rows
+       will be assigned to negative_value if its argmax result < negative_threshold.
 
     Args:
         thresholds: A sorted list of floats to classify the matches into

--- a/keras_cv/ops/box_matcher.py
+++ b/keras_cv/ops/box_matcher.py
@@ -95,7 +95,7 @@ class ArgmaxBoxMatcher:
         thresholds.insert(0, -float("inf"))
         thresholds.append(float("inf"))
         self.thresholds = thresholds
-        self._force_match_for_each_col = force_match_for_each_col
+        self.force_match_for_each_col = force_match_for_each_col
 
     def __call__(self, similarity_matrix: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
         """Matches each row to a column based on argmax
@@ -168,7 +168,7 @@ class ArgmaxBoxMatcher:
                         matched_values, mask, ind
                     )
 
-                if self._force_match_for_each_col:
+                if self.force_match_for_each_col:
                     # [batch_size, num_cols], for each column (groundtruth_box), find the
                     # best matching row (anchor).
                     matching_rows = tf.argmax(
@@ -230,3 +230,11 @@ class ArgmaxBoxMatcher:
         """
         indicator = tf.cast(indicator, x.dtype)
         return tf.add(tf.multiply(x, 1 - indicator), val * indicator)
+
+    def get_config(self):
+        config = {
+            "thresholds": self.thresholds[1:-1],
+            "match_values": self.match_values,
+            "force_match_for_each_col": self.force_match_for_each_col,
+        }
+        return config

--- a/keras_cv/ops/sampling.py
+++ b/keras_cv/ops/sampling.py
@@ -1,0 +1,85 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+
+def balanced_sample(
+    positive_matches: tf.Tensor,
+    negative_matches: tf.Tensor,
+    num_samples: int,
+    positive_fraction: float,
+):
+    """
+    Sampling ops to balance positive and negative samples, deals with both
+    batched and unbatched inputs.
+
+    Args:
+      positive_matches: [N] or [batch_size, N] boolean Tensor, True for
+        indicating the index is a positive sample
+      negative_matches: [N] or [batch_size, N] boolean Tensor, True for
+        indicating the index is a negative sample
+      num_samples: int, representing the number of samples to collect
+      positive_fraction: float. 0.5 means positive samples should be half
+        of all collected samples.
+
+    Returns:
+      selected_indicators: [`num_samples`] or [batch_size, `num_samples`]
+        integer Tensor, 1 for indicating the index is sampled, 0 for
+        indicating the index is not sampled.
+    """
+
+    def balanced_single_sample(positive_match, negative_match):
+        num_pos_matches = tf.reduce_sum(tf.cast(positive_match, tf.int32))
+        num_neg_matches = tf.reduce_sum(tf.cast(negative_match, tf.int32))
+        num_pos = tf.cast(num_samples * positive_fraction, tf.int32)
+        # if there are not enough positive samples, obtain all
+        num_pos = tf.minimum(num_pos, num_pos_matches)
+        num_neg = num_samples - num_pos
+        # if there are not enough negative samples, obtain all
+        num_neg = tf.minimum(num_neg, num_neg_matches)
+
+        # we choose to use random generator instead of random shuffle since the latter
+        # does not work on GPU.
+
+        # randomly generate positive values for positive match, and 0 for negative match
+        random_pos = tf.random.uniform(tf.shape(positive_match), minval=0.0, maxval=1.0)
+        zeros = tf.zeros_like(random_pos)
+        random_pos = tf.where(positive_match, random_pos, zeros)
+        # pick the top k values as random positive indices
+        _, positive_indices = tf.math.top_k(random_pos, k=num_pos)
+
+        # randomly generate positive values for negative match, and 0 for positive match
+        random_neg = tf.random.uniform(tf.shape(negative_match), minval=0.0, maxval=1.0)
+        random_neg = tf.where(negative_match, random_neg, zeros)
+        # pick the top k values as random negative indices
+        _, negative_indices = tf.math.top_k(random_neg, k=num_neg)
+
+        selected_indices = tf.concat([positive_indices, negative_indices], axis=0)
+        selected_indicators = tf.scatter_nd(
+            tf.expand_dims(selected_indices, axis=-1),
+            tf.ones_like(selected_indices, dtype=tf.int32),
+            tf.shape(positive_match),
+        )
+        return selected_indicators
+
+    if len(positive_matches.get_shape().as_list()) == 1:
+        return balanced_single_sample(positive_matches, negative_matches)
+    else:
+
+        def balance_fn(args):
+            pos, neg = args
+            return balanced_single_sample(pos, neg)
+
+        return tf.vectorized_map(balance_fn, (positive_matches, negative_matches))

--- a/keras_cv/ops/sampling_test.py
+++ b/keras_cv/ops/sampling_test.py
@@ -14,7 +14,7 @@
 
 import tensorflow as tf
 
-from keras_cv.ops.sampling import *
+from keras_cv.ops.sampling import balanced_sample
 
 
 class BalancedSamplingTest(tf.test.TestCase):

--- a/keras_cv/ops/sampling_test.py
+++ b/keras_cv/ops/sampling_test.py
@@ -1,0 +1,135 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.ops.sampling import *
+
+
+class BalancedSamplingTest(tf.test.TestCase):
+    def test_balanced_sampling(self):
+        positive_matches = tf.constant(
+            [True, False, False, False, False, False, False, False, False, False]
+        )
+        negative_matches = tf.constant(
+            [False, True, True, True, True, True, True, True, True, True]
+        )
+        num_samples = 5
+        positive_fraction = 0.2
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # The 1st element must be selected, given it's the only one.
+        self.assertAllClose(res[0], 1)
+
+    def test_balanced_batched_sampling(self):
+        positive_matches = tf.constant(
+            [
+                [True, False, False, False, False, False, False, False, False, False],
+                [False, False, False, False, False, False, True, False, False, False],
+            ]
+        )
+        negative_matches = tf.constant(
+            [
+                [False, True, True, True, True, True, True, True, True, True],
+                [True, True, True, True, True, True, False, True, True, True],
+            ]
+        )
+        num_samples = 5
+        positive_fraction = 0.2
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # the 1st element from the 1st batch must be selected, given it's the only one
+        self.assertAllClose(res[0][0], 1)
+        # the 7th element from the 2nd batch must be selected, given it's the only one
+        self.assertAllClose(res[1][6], 1)
+
+    def test_balanced_sampling_over_positive_fraction(self):
+        positive_matches = tf.constant(
+            [True, False, False, False, False, False, False, False, False, False]
+        )
+        negative_matches = tf.constant(
+            [False, True, True, True, True, True, True, True, True, True]
+        )
+        num_samples = 5
+        positive_fraction = 0.4
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # only 1 positive sample exists, thus it is chosen
+        self.assertAllClose(res[0], 1)
+
+    def test_balanced_sampling_under_positive_fraction(self):
+        positive_matches = tf.constant(
+            [True, False, False, False, False, False, False, False, False, False]
+        )
+        negative_matches = tf.constant(
+            [False, True, True, True, True, True, True, True, True, True]
+        )
+        num_samples = 5
+        positive_fraction = 0.1
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # no positive is chosen
+        self.assertAllClose(res[0], 0)
+        self.assertAllClose(tf.reduce_sum(res), 5)
+
+    def test_balanced_sampling_over_num_samples(self):
+        positive_matches = tf.constant(
+            [True, False, False, False, False, False, False, False, False, False]
+        )
+        negative_matches = tf.constant(
+            [False, True, True, True, True, True, True, True, True, True]
+        )
+        # users want to get 20 samples, but only 10 are available
+        num_samples = 20
+        positive_fraction = 0.1
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # only 1 positive sample exists, thus it is chosen
+        self.assertAllClose(res[0], 1)
+        self.assertAllClose(res.shape, [10])
+
+    def test_balanced_sampling_no_positive(self):
+        positive_matches = tf.constant(
+            [False, False, False, False, False, False, False, False, False, False]
+        )
+        # the rest are neither positive nor negative, but ignord matches
+        negative_matches = tf.constant(
+            [False, False, True, False, False, True, False, False, False, False]
+        )
+        num_samples = 5
+        positive_fraction = 0.5
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # given only 2 negative and 0 positive, select all of them
+        self.assertAllClose(res, [0, 0, 1, 0, 0, 1, 0, 0, 0, 0])
+
+    def test_balanced_sampling_no_negative(self):
+        positive_matches = tf.constant(
+            [True, True, False, False, False, False, False, False, False, False]
+        )
+        # 2-9 indices are neither positive nor negative, they're ignored matches
+        negative_matches = tf.constant([False] * 10)
+        num_samples = 5
+        positive_fraction = 0.5
+        res = balanced_sample(
+            positive_matches, negative_matches, num_samples, positive_fraction
+        )
+        # given only 2 positive and 0 negative, select all of them.
+        self.assertAllClose(res, [1, 1, 0, 0, 0, 0, 0, 0, 0, 0])


### PR DESCRIPTION
# What does this PR do?
This PR adds ROISampler as a private API.
This shows why we should have `target_gather` and `box_matcher`
Some slight API changes according to the design doc:
https://github.com/keras-team/governance/blob/master/rfcs/20220804-keras-cv-two-stage-2d-object-detection.md
The ProposalSampler is renamed to ROISampler.