### PR TITLE
[Draft] Add bounding box support to RandomCropAndResize

### DIFF
--- a/examples/layers/preprocessing/bounding_box/random_crop_and_resize.py
+++ b/examples/layers/preprocessing/bounding_box/random_crop_and_resize.py
@@ -1,0 +1,76 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import demo_utils
+import tensorflow as tf
+
+import keras_cv
+from keras_cv import layers
+from luketils import visualization
+
+IMG_SIZE = (256, 256)
+BATCH_SIZE = 9
+
+class_ids = [
+    "Aeroplane",
+    "Bicycle",
+    "Bird",
+    "Boat",
+    "Bottle",
+    "Bus",
+    "Car",
+    "Cat",
+    "Chair",
+    "Cow",
+    "Dining Table",
+    "Dog",
+    "Horse",
+    "Motorbike",
+    "Person",
+    "Potted Plant",
+    "Sheep",
+    "Sofa",
+    "Train",
+    "Tvmonitor",
+    "Total",
+]
+class_mapping = dict(zip(range(len(class_ids)), class_ids))
+
+
+def main():
+    dataset, ds_info = keras_cv.datasets.pascal_voc.load(
+        split="train", bounding_box_format="rel_xyxy", batch_size=1, shuffle=True
+    )
+    random_shear = layers.RandomCropAndResize(
+        target_size=(512, 512),
+        crop_area_factor=(1.0, 1.0),
+        aspect_ratio_factor=(1.0, 1.0),
+        bounding_box_format="rel_xyxy",
+    )
+    dataset = dataset.map(lambda x: random_shear(x, training=True), num_parallel_calls=tf.data.AUTOTUNE)
+    dataset = dataset.map(lambda inputs: (inputs["images"], inputs["bounding_boxes"]))
+    images, boxes = next(iter(dataset.take(1)))
+    visualization.plot_bounding_box_gallery(
+        images,
+        value_range=(0, 255),
+        y_true=boxes,
+        bounding_box_format="rel_xyxy",
+        class_mapping=class_mapping,
+        rows=1,
+        cols=1,
+        show=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/bounding_box/smart_resize.py
+++ b/keras_cv/bounding_box/smart_resize.py
@@ -1,0 +1,2 @@
+def smart_resize_bounding_boxes():
+    pass


### PR DESCRIPTION
# What does this PR do?

This PR (eventually...) will add bounding box support to RandomCropAndResize.

This is unfortunately quite complex and there are a lot of edge cases to consider:

- is the crop outside of the original image?
- are we cropping to preserve aspect ratio
- at inference time are we preserving crop ratio?

Right now I have a basic skeleton working, but it is not complete


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Lets not have a review yet.
