### PR TITLE
Small performance optimization for StableDiffusion

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -127,21 +127,21 @@ class StableDiffusion:
             )
         phrase = inputs + [49407] * (MAX_PROMPT_LENGTH - len(inputs))
         phrase = tf.convert_to_tensor([phrase], dtype=tf.int32)
-        phrase = tf.repeat(phrase, batch_size, axis=0)
 
         # Encode prompt tokens + positions into a "context" vector
         pos_ids = tf.convert_to_tensor([list(range(MAX_PROMPT_LENGTH))], dtype=tf.int32)
-        pos_ids = tf.repeat(pos_ids, batch_size, axis=0)
+
         context = self.text_encoder.predict_on_batch([phrase, pos_ids])
+        context = tf.repeat(context, batch_size, axis=0)
 
         # Encode unconditional tokens + positions as "unconditional context"
         unconditional_tokens = tf.convert_to_tensor(
             [_UNCONDITIONAL_TOKENS], dtype=tf.int32
         )
-        self.unconditional_tokens = tf.repeat(unconditional_tokens, batch_size, axis=0)
         unconditional_context = self.text_encoder.predict_on_batch(
-            [self.unconditional_tokens, pos_ids]
+            [unconditional_tokens, pos_ids]
         )
+        unconditional_context = tf.repeat(unconditional_context, batch_size, axis=0)
 
         # Iterative reverse diffusion stage
         timesteps = tf.range(1, 1000, 1000 // num_steps)


### PR DESCRIPTION
Maybe this is totally pointless, in which case feel free to close the PR.

But I noticed while working with the code yesterday that we're unnecessarily passing many copies of the input phrase (and the unconditional phrase) into the text encoder. With this change, we pass just one copy into the encoder and repeat it to match the batch dimension _after_ encoding.

(This also guarantees that the output of the encoder is _exactly_ equal for each image in the batch, whereas before there was some minor variation due to fuzzy GPU math. I don't think that actually matters but I figured I'd note it)

Edit: I also manually ran the tests for stable diffusion and used the code in this state for my experiments with latent space walks