### PR TITLE
Add encode_text and generate_image to StableDiffusion API

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -164,7 +164,7 @@ class StableDiffusion:
             self._get_unconditional_context(), batch_size, axis=0
         )
 
-        if diffusion_noise:
+        if diffusion_noise is not None:
             latent = diffusion_noise
         else:
             latent = self._get_initial_diffusion_noise(batch_size, seed)

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -231,7 +231,7 @@ class StableDiffusion:
 
         if diffusion_noise is not None:
             diffusion_noise = tf.squeeze(diffusion_noise)
-            if diffusion_noise.shape.rank == 2:
+            if diffusion_noise.shape.rank == 3:
                 diffusion_noise = tf.tile(diffusion_noise, batch_size)
             latent = diffusion_noise
         else:

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -152,6 +152,13 @@ class StableDiffusion:
         diffusion_noise=None,
         seed=None,
     ):
+        if diffusion_noise is not None and seed is not None:
+            raise ValueError(
+                "`diffusion_noise` and `seed` should not both be passed to "
+                "`generate_image`. `seed` is only used to generate diffusion "
+                "noise when it's not already user-specified."
+            )
+
         context = tf.repeat(encoded_text, batch_size, axis=0)
         unconditional_context = tf.repeat(
             self._get_unconditional_context(), batch_size, axis=0

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -192,7 +192,7 @@ class StableDiffusion:
         alphas = [_ALPHAS_CUMPROD[t] for t in timesteps]
         alphas_prev = [1.0] + alphas[:-1]
 
-        noise = diffusion_noise or tf.random.normal(
+        noise = diffusion_noise if diffusion_noise is not None else or tf.random.normal(
             (batch_size, self.img_height // 8, self.img_width // 8, 4), seed=seed
         )
 

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -147,19 +147,13 @@ class StableDiffusion:
         )
         unconditional_context = tf.repeat(unconditional_context, batch_size, axis=0)
 
-
         if walk_breadth:
-            #print(context.shape)
-            #print(context)
-
-            walk_noise = tf.zeros(context.shape[1:], dtype=tf.float64)
+            walk_noise = tf.random.uniform(context.shape[1:], maxval=walk_breadth, dtype=tf.float64)
             walk_scale = tf.cos(tf.linspace(0, batch_size-1, batch_size) * 2 * math.pi / batch_size)
             walk_adjustments = tf.tensordot(walk_scale, walk_noise, axes=0)
 
             walk_adjustments = tf.cast(walk_adjustments, context.dtype)
             context = tf.add(context, walk_adjustments)
-
-            #print(context)
 
             return self._generate_image(unconditional_context, context, num_steps, unconditional_guidance_scale, batch_size, seed, walking=True)
         else:
@@ -216,8 +210,5 @@ class StableDiffusion:
             noise = tf.random.normal(
                 (batch_size, self.img_height // 8, self.img_width // 8, 4), seed=seed
             )
-
-        print(noise)
-        print(noise.shape)
 
         return noise, alphas, alphas_prev

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -221,7 +221,9 @@ class StableDiffusion:
 
         encoded_text = tf.squeeze(encoded_text)
         if encoded_text.shape.rank == 2:
-            encoded_text = tf.tile(encoded_text, batch_size)
+            encoded_text = tf.repeat(
+                tf.expand_dims(encoded_text, axis=0), batch_size, axis=0
+            )
 
         context = encoded_text
         unconditional_context = tf.repeat(
@@ -232,7 +234,9 @@ class StableDiffusion:
         if diffusion_noise is not None:
             diffusion_noise = tf.squeeze(diffusion_noise)
             if diffusion_noise.shape.rank == 3:
-                diffusion_noise = tf.tile(diffusion_noise, batch_size)
+                diffusion_noise = tf.repeat(
+                    tf.expand_dims(diffusion_noise, axis=0), batch_size, axis=0
+                )
             latent = diffusion_noise
         else:
             latent = self._get_initial_diffusion_noise(batch_size, seed)

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -192,7 +192,7 @@ class StableDiffusion:
         alphas = [_ALPHAS_CUMPROD[t] for t in timesteps]
         alphas_prev = [1.0] + alphas[:-1]
 
-        noise = diffusion_noise if diffusion_noise is not None else or tf.random.normal(
+        noise = diffusion_noise if diffusion_noise is not None else tf.random.normal(
             (batch_size, self.img_height // 8, self.img_width // 8, 4), seed=seed
         )
 

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -214,6 +214,7 @@ class StableDiffusion:
             walk_noise = tf.random.uniform(noise.shape[1:], maxval=walk_breadth, dtype=tf.float64)
             walk_scale = tf.cos(tf.linspace(0, batch_size-1, batch_size) * 2 * math.pi / batch_size)
             walk_adjustments = tf.tensordot(walk_scale, walk_noise, axes=0)
+            walk_adjustments = tf.cast(walk_adjustments, noise.dtype)
 
             noise = tf.add(noise, walk_adjustments)
 

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -211,10 +211,13 @@ class StableDiffusion:
         if walking:
             noise = tf.repeat(tf.random.normal(
                 (1, self.img_height // 8, self.img_width // 8, 4), seed=seed
-            ), batch_size)
+            ), batch_size, axis=0)
         else:
             noise = tf.random.normal(
                 (batch_size, self.img_height // 8, self.img_width // 8, 4), seed=seed
             )
+
+        print(noise)
+        print(noise.shape)
 
         return noise, alphas, alphas_prev

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -229,7 +229,6 @@ class StableDiffusion:
         unconditional_context = tf.repeat(
             self._get_unconditional_context(), batch_size, axis=0
         )
-        unconditional_context = tf.repeat(unconditional_context, batch_size, axis=0)
 
         if diffusion_noise is not None:
             diffusion_noise = tf.squeeze(diffusion_noise)

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -210,8 +210,8 @@ class StableDiffusion:
 
         if walking:
             noise = tf.repeat(tf.random.normal(
-                (1, self.img_height // 8, self.img_width // 8, 4), batch_size, seed=seed
-            ))
+                (1, self.img_height // 8, self.img_width // 8, 4), seed=seed
+            ), batch_size)
         else:
             noise = tf.random.normal(
                 (batch_size, self.img_height // 8, self.img_width // 8, 4), seed=seed

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -119,6 +119,7 @@ class StableDiffusion:
         unconditional_guidance_scale=7.5,
         seed=None,
         walk_size=None,
+        walk_breadth=1e-3
     ):
         # Tokenize prompt (i.e. starting context)
         inputs = self.tokenizer.encode(prompt)
@@ -147,7 +148,7 @@ class StableDiffusion:
 
         if walk_size:
             images = []
-            walk_noise = tf.random.uniform(tf.shape(context))
+            walk_noise = tf.random.uniform(tf.shape(context), maxval=walk_breadth)
             for walk_step in range(walk_size):
                 step_noise = walk_noise * math.cos(2*math.pi / walk_size)
                 images.append(self._generate_image(unconditional_context, context+step_noise, num_steps, unconditional_guidance_scale, batch_size=1, seed=seed))

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -139,7 +139,7 @@ class StableDiffusion:
         between two prompts.
 
         Args:
-            prompt: a string to encode, must be 77 characters or shorter.
+            prompt: a string to encode, must be 77 tokens or shorter.
 
         Example:
 

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -39,6 +39,18 @@ class StableDiffusionTest(tf.test.TestCase):
         stablediff = StableDiffusion(128, 128)
         _ = stablediff.text_to_image("Testing123 haha!")
 
+    def DISABLED_test_generate_image_rejects_noise_and_seed(self):
+        stablediff = StableDiffusion(128, 128)
+
+        with self.assertRaisesRegex(
+            ValueError, r"`diffusion_noise` and `seed` should not both be passed"
+        ):
+            _ = stablediff.generate_image(
+                stablediff.encode_text("thou shall not render"),
+                diffusion_noise=tf.random.normal((1, 16, 16, 4)),
+                seed=1337,
+            )
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -18,13 +18,21 @@ from tensorflow.keras import mixed_precision
 from keras_cv.models import StableDiffusion
 
 
-class StableDiffusioNTest(tf.test.TestCase):
+class StableDiffusionTest(tf.test.TestCase):
     def DISABLED_test_end_to_end_golden_value(self):
+        prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
-        img = stablediff.text_to_image(
-            "a caterpillar smoking a hookah while sitting on a mushroom", seed=123
-        )
-        self.assertAllClose(img[0][64:65, 64:65, :][0][0], [255, 232, 18], atol=1e-4)
+
+        # Using TF global random seed to guarantee that subsequent text-to-image
+        # runs are seeded identically.
+        tf.random.set_seed(8675309)
+        img = stablediff.text_to_image(prompt)
+        self.assertAllClose(img[0][64:65, 64:65, :][0][0], [124, 188, 114], atol=1e-4)
+
+        # Verify that the step-by-step creation flow creates an identical output
+        tf.random.set_seed(8675309)
+        text_encoding = stablediff.encode_text(prompt)
+        self.assertAllClose(img, stablediff.generate_image(text_encoding), atol=1e-4)
 
     def DISABLED_test_mixed_precision(self):
         mixed_precision.set_global_policy("mixed_float16")


### PR DESCRIPTION
This provides an API surface for tinkering with / walking through the text encoding space as well as the initial noise space for diffusion, both of which are popular use cases.

Let me know what your thoughts are on this API change. If we think this is a reasonable approach, I'll add docstrings and examples for the new methods.

The thing that I dislike the most about this PR in its current form is the way that diffusion noise is provided to the `generate_image` method. I haven't thought of a cleaner way to do this in a way that makes it easy to arbitrarily (and sequentially) mutate the noise for a sequence of images. Critically, we can't perform single-batch inference for large walks, because even large accelerators will OOM, so users need to be able to run consecutive batches and control a walk themselves.
