### PR TITLE
Respect `box_head` in constructor

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -170,12 +170,10 @@ class RetinaNet(ObjectDetectionBaseModel):
         self.classification_head = classification_head or layers_lib.PredictionHead(
             output_filters=9 * classes, bias_initializer=prior_probability
         )
-        # self.classification_head.trainable = False
 
-        self.box_head = layers_lib.PredictionHead(
+        self.box_head = box_head or layers_lib.PredictionHead(
             output_filters=9 * 4, bias_initializer="zeros"
         )
-        # self.box_head.trainable = False
 
         self._metrics_bounding_box_format = None
         self.loss_metric = tf.keras.metrics.Mean(name="loss")


### PR DESCRIPTION
Fixes a bug where I wasn't respecting box head in the constructor for RetinaNet.