### PR TITLE
Add bounding box support to resizing

### DIFF
--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -63,7 +63,7 @@ def visualize_data(data, bounding_box_format):
 
 def visualize_bounding_boxes(image, bounding_boxes, bounding_box_format):
     color = np.array([[255.0, 0.0, 0.0]])
-    bounding_boxes = bounding_boxes[..., :4].to_tensor(-1)
+    bounding_boxes = bounding_boxes[..., :4]
     bounding_boxes = bounding_box.convert_format(
         bounding_boxes,
         source=bounding_box_format,

--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -16,7 +16,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
-tf.debugging.disable_traceback_filtering()
 
 from keras_cv import bounding_box
 

--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
+tf.debugging.disable_traceback_filtering()
 
 from keras_cv import bounding_box
 
@@ -63,13 +64,15 @@ def visualize_data(data, bounding_box_format):
 
 def visualize_bounding_boxes(image, bounding_boxes, bounding_box_format):
     color = np.array([[255.0, 0.0, 0.0]])
-    bounding_boxes = bounding_boxes[..., :4]
+    bounding_boxes = bounding_boxes[..., :4].to_tensor(-1)
     bounding_boxes = bounding_box.convert_format(
         bounding_boxes,
         source=bounding_box_format,
         target="rel_yxyx",
         images=image,
     )
+    if isinstance(bounding_boxes, tf.RaggedTensor):
+        bounding_boxes = bounding_boxes[..., :4].to_tensor(-1)
     return tf.image.draw_bounding_boxes(image, bounding_boxes, color, name=None)
 
 

--- a/examples/layers/preprocessing/bounding_box/resizing_demo.py
+++ b/examples/layers/preprocessing/bounding_box/resizing_demo.py
@@ -1,0 +1,40 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+mosaic_demo.py shows how to use the Mosaic preprocessing layer for
+object detection.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv import layers
+import keras_cv
+
+def main():
+    dataset, _ = keras_cv.datasets.pascal_voc.load(
+        split='train',
+        bounding_box_format="xyxy",
+        batch_size=9,
+        img_size=(512, 512)
+    )
+    # ragged tensor of images
+    # sample = next(iter(dataset))
+    # resizing = layers.Resizing(height=512, width=512, bounding_box_format='xyxy')
+    # outputs = resizing(sample)
+    # result = dataset.map(resizing, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_data(dataset, bounding_box_format="xyxy")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/layers/preprocessing/bounding_box/resizing_demo.py
+++ b/examples/layers/preprocessing/bounding_box/resizing_demo.py
@@ -22,10 +22,6 @@ import tensorflow_datasets as tfds
 import keras_cv
 from keras_cv import layers
 
-train_ds = tfds.load(
-    "voc/2007", split="train+test", with_info=False, shuffle_files=True
-)
-
 
 def preproc(inputs):
     image = inputs["image"]
@@ -46,15 +42,42 @@ def preproc(inputs):
     return {"images": image, "bounding_boxes": bounding_boxes}
 
 
+# pad to aspect ratio height > width
+train_ds = tfds.load(
+    "voc/2007", split="train+test", with_info=False, shuffle_files=True
+)
 train_ds = train_ds.map(preproc)
 train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(16, drop_remainder=True)
 )
-print(train_ds)
 resizing = layers.Resizing(
     height=600, width=400, pad_to_aspect_ratio=True, bounding_box_format="xywh"
 )
-
 train_ds = train_ds.map(resizing)
-next(iter(train_ds))
+demo_utils.visualize_data(train_ds, bounding_box_format="xywh")
+
+# pad to aspect ratio width > height
+train_ds = tfds.load(
+    "voc/2007", split="train+test", with_info=False, shuffle_files=True
+)
+train_ds = train_ds.map(preproc)
+train_ds = train_ds.apply(
+    tf.data.experimental.dense_to_ragged_batch(16, drop_remainder=True)
+)
+resizing = layers.Resizing(
+    height=400, width=600, pad_to_aspect_ratio=True, bounding_box_format="xywh"
+)
+train_ds = train_ds.map(resizing)
+demo_utils.visualize_data(train_ds, bounding_box_format="xywh")
+
+# resize with distortion
+train_ds = tfds.load(
+    "voc/2007", split="train+test", with_info=False, shuffle_files=True
+)
+train_ds = train_ds.map(preproc)
+train_ds = train_ds.apply(
+    tf.data.experimental.dense_to_ragged_batch(16, drop_remainder=True)
+)
+resizing = layers.Resizing(height=400, width=600, bounding_box_format="xywh")
+train_ds = train_ds.map(resizing)
 demo_utils.visualize_data(train_ds, bounding_box_format="xywh")

--- a/examples/layers/preprocessing/bounding_box/resizing_demo.py
+++ b/examples/layers/preprocessing/bounding_box/resizing_demo.py
@@ -18,12 +18,14 @@ object detection.
 import demo_utils
 import tensorflow as tf
 import tensorflow_datasets as tfds
+
 import keras_cv
 from keras_cv import layers
 
 train_ds = tfds.load(
     "voc/2007", split="train+test", with_info=False, shuffle_files=True
 )
+
 
 def preproc(inputs):
     image = inputs["image"]
@@ -39,9 +41,10 @@ def preproc(inputs):
     gt_classes = tf.expand_dims(gt_classes, axis=-1)
     bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
     bounding_boxes = keras_cv.bounding_box.convert_format(
-        bounding_boxes, images=image, source="yxyx", target='xywh'
+        bounding_boxes, images=image, source="yxyx", target="xywh"
     )
     return {"images": image, "bounding_boxes": bounding_boxes}
+
 
 train_ds = train_ds.map(preproc)
 train_ds = train_ds.apply(
@@ -49,8 +52,7 @@ train_ds = train_ds.apply(
 )
 print(train_ds)
 resizing = layers.Resizing(
-    height=600, width=400,
-    pad_to_aspect_ratio=True, bounding_box_format='xywh'
+    height=600, width=400, pad_to_aspect_ratio=True, bounding_box_format="xywh"
 )
 
 train_ds = train_ds.map(resizing)

--- a/examples/layers/preprocessing/bounding_box/resizing_demo.py
+++ b/examples/layers/preprocessing/bounding_box/resizing_demo.py
@@ -69,15 +69,3 @@ resizing = layers.Resizing(
 )
 train_ds = train_ds.map(resizing)
 demo_utils.visualize_data(train_ds, bounding_box_format="xywh")
-
-# resize with distortion
-train_ds = tfds.load(
-    "voc/2007", split="train+test", with_info=False, shuffle_files=True
-)
-train_ds = train_ds.map(preproc)
-train_ds = train_ds.apply(
-    tf.data.experimental.dense_to_ragged_batch(16, drop_remainder=True)
-)
-resizing = layers.Resizing(height=400, width=600, bounding_box_format="xywh")
-train_ds = train_ds.map(resizing)
-demo_utils.visualize_data(train_ds, bounding_box_format="xywh")

--- a/examples/layers/preprocessing/bounding_box/resizing_demo.py
+++ b/examples/layers/preprocessing/bounding_box/resizing_demo.py
@@ -18,15 +18,13 @@ object detection.
 import demo_utils
 import tensorflow as tf
 
-from keras_cv import layers
 import keras_cv
+from keras_cv import layers
+
 
 def main():
     dataset, _ = keras_cv.datasets.pascal_voc.load(
-        split='train',
-        bounding_box_format="xyxy",
-        batch_size=9,
-        img_size=(512, 512)
+        split="train", bounding_box_format="xyxy", batch_size=9, img_size=(512, 512)
     )
     # ragged tensor of images
     # sample = next(iter(dataset))

--- a/examples/models/object_detection/retina_net/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/pascal_voc/train.py
@@ -415,6 +415,12 @@ def proc_eval_fn(bounding_box_format, target_size):
 
     def apply(inputs):
         image = tf.cast(inputs["image"], tf.float32)
+        gt_boxes = keras_cv.bounding_box.convert_format(
+            inputs["objects"]["bbox"],
+            images=image,
+            source="rel_yxyx",
+            target=bounding_box_format,
+        )
         gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
         gt_classes = tf.expand_dims(gt_classes, axis=-1)
         bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)

--- a/examples/models/object_detection/retina_net/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/pascal_voc/train.py
@@ -406,48 +406,21 @@ model.load_weights(CHECKPOINT_PATH)
 
 
 def proc_eval_fn(bounding_box_format, target_size):
+    resizer = keras_cv.layers.Resizing(
+        target_size[0],
+        target_size[1],
+        pad_to_aspect_ratio=True,
+        bounding_box_format=bounding_box_format,
+    )
+
     def apply(inputs):
-        raw_image = inputs["image"]
-        raw_image = tf.cast(raw_image, tf.float32)
-
-        img_size = tf.shape(raw_image)
-        height = img_size[0]
-        width = img_size[1]
-
-        target_height = tf.cond(
-            height > width,
-            lambda: 640.0,
-            lambda: tf.cast(height / width * 640.0, tf.float32),
-        )
-        target_width = tf.cond(
-            width > height,
-            lambda: 640.0,
-            lambda: tf.cast(width / height * 640.0, tf.float32),
-        )
-        image = tf.image.resize(
-            raw_image, (target_height, target_width), antialias=False
-        )
-
-        gt_boxes = keras_cv.bounding_box.convert_format(
-            inputs["objects"]["bbox"],
-            images=image,
-            source="rel_yxyx",
-            target="xyxy",
-        )
-        image = tf.image.pad_to_bounding_box(
-            image, 0, 0, target_size[0], target_size[1]
-        )
-        gt_boxes = keras_cv.bounding_box.convert_format(
-            gt_boxes,
-            images=image,
-            source="xyxy",
-            target=bounding_box_format,
-        )
-
+        image = tf.cast(inputs["image"], tf.float32)
         gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
         gt_classes = tf.expand_dims(gt_classes, axis=-1)
         bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
-        return image, bounding_boxes
+        inputs = {"images": image, "bounding_boxes": bounding_boxes}
+        o = resizer(inputs)
+        return o["images"], o["bounding_boxes"]
 
     return apply
 

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -78,6 +78,7 @@ def load(
         batch_size: how many instances to include in batches after loading
         shuffle: whether or not to shuffle the dataset.  Defaults to True.
         shuffle_buffer: the size of the buffer to use in shuffling.
+        shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
         img_size: (Optional) size to resize the images to, if not provided image batches
             will be of type `tf.RaggedTensor`.
 

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -24,7 +24,10 @@ def curry_map_function(bounding_box_format, img_size):
 
     if img_size is not None:
         resizing = keras.layers.Resizing(
-            height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
+            height=img_size[0],
+            width=img_size[1],
+            bounding_box_format=bounding_box_format,
+            crop_to_aspect_ratio=False,
         )
 
     # TODO(lukewood): update `keras.layers.Resizing` to support bounding boxes.

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -27,7 +27,7 @@ def curry_map_function(bounding_box_format, img_size):
             height=img_size[0],
             width=img_size[1],
             bounding_box_format=bounding_box_format,
-            pad_to_aspect_ratio=False,
+            pad_to_aspect_ratio=True,
         )
 
     def apply(inputs):
@@ -54,10 +54,10 @@ def curry_map_function(bounding_box_format, img_size):
 def load(
     split,
     bounding_box_format,
-    img_size=None,
     batch_size=None,
     shuffle_files=True,
     shuffle_buffer=None,
+    img_size=None,
 ):
     """Loads the PascalVOC 2007 dataset.
 

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -14,7 +14,6 @@
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv import layers as cv_layers

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -19,6 +19,7 @@ from tensorflow import keras
 from keras_cv import bounding_box
 from keras_cv import layers as cv_layers
 
+
 def curry_map_function(bounding_box_format, img_size):
     """Mapping function to create batched image and bbox coordinates"""
 
@@ -27,7 +28,7 @@ def curry_map_function(bounding_box_format, img_size):
             height=img_size[0],
             width=img_size[1],
             bounding_box_format=bounding_box_format,
-            crop_to_aspect_ratio=False,
+            pad_to_aspect_ratio=False,
         )
 
     def apply(inputs):
@@ -56,6 +57,7 @@ def load(
     bounding_box_format,
     img_size=None,
     batch_size=None,
+    shuffle_files=True,
     shuffle_buffer=None,
 ):
     """Loads the PascalVOC 2007 dataset.

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -17,37 +17,36 @@ import tensorflow_datasets as tfds
 from tensorflow import keras
 
 from keras_cv import bounding_box
-
+from keras_cv import layers as cv_layers
 
 def curry_map_function(bounding_box_format, img_size):
     """Mapping function to create batched image and bbox coordinates"""
 
     if img_size is not None:
-        resizing = keras.layers.Resizing(
+        resizing = cv_layers.Resizing(
             height=img_size[0],
             width=img_size[1],
             bounding_box_format=bounding_box_format,
             crop_to_aspect_ratio=False,
         )
 
-    # TODO(lukewood): update `keras.layers.Resizing` to support bounding boxes.
     def apply(inputs):
-        # Support image size none.
-        if img_size is not None:
-            inputs["image"] = resizing(inputs["image"])
-
-        inputs["objects"]["bbox"] = bounding_box.convert_format(
-            inputs["objects"]["bbox"],
-            images=inputs["image"],
-            source="rel_yxyx",
-            target=bounding_box_format,
-        )
-
+        images = inputs["image"]
         bounding_boxes = inputs["objects"]["bbox"]
         labels = tf.cast(inputs["objects"]["label"], tf.float32)
         labels = tf.expand_dims(labels, axis=-1)
         bounding_boxes = tf.concat([bounding_boxes, labels], axis=-1)
-        return {"images": inputs["image"], "bounding_boxes": bounding_boxes}
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            images=images,
+            source="rel_yxyx",
+            target=bounding_box_format,
+        )
+
+        outputs = {"images": images, "bounding_boxes": bounding_boxes}
+        if img_size is not None:
+            outputs = resizing(outputs)
+        return outputs
 
     return apply
 
@@ -55,10 +54,9 @@ def curry_map_function(bounding_box_format, img_size):
 def load(
     split,
     bounding_box_format,
+    img_size=None,
     batch_size=None,
     shuffle_buffer=None,
-    shuffle_files=True,
-    img_size=None,
 ):
     """Loads the PascalVOC 2007 dataset.
 
@@ -76,12 +74,11 @@ def load(
             For a list of supported formats, please  Refer
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
-        batch_size: (Optional) how many instances to include in batches after loading. If
-            not provided, no batching will occur.
-        shuffle_buffer: (Optional) the size of the buffer to use in shuffling.
-        shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
-        img_size: (Optional) size to resize the images to.  By default, images are not
-            resized `tf.RaggedTensor` batches are produced if batching occurs.
+        batch_size: how many instances to include in batches after loading
+        shuffle: whether or not to shuffle the dataset.  Defaults to True.
+        shuffle_buffer: the size of the buffer to use in shuffling.
+        img_size: (Optional) size to resize the images to, if not provided image batches
+            will be of type `tf.RaggedTensor`.
 
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -55,7 +55,6 @@ from keras_cv.layers.preprocessing.random_choice import RandomChoice
 from keras_cv.layers.preprocessing.random_color_degeneration import (
     RandomColorDegeneration,
 )
-from keras_cv.layers.preprocessing.resizing import Resizing
 from keras_cv.layers.preprocessing.random_color_jitter import RandomColorJitter
 from keras_cv.layers.preprocessing.random_crop_and_resize import RandomCropAndResize
 from keras_cv.layers.preprocessing.random_cutout import RandomCutout
@@ -67,6 +66,7 @@ from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.randomly_zoomed_crop import RandomlyZoomedCrop
+from keras_cv.layers.preprocessing.resizing import Resizing
 from keras_cv.layers.preprocessing.solarization import Solarization
 from keras_cv.layers.regularization.drop_path import DropPath
 from keras_cv.layers.regularization.dropblock_2d import DropBlock2D

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -22,7 +22,6 @@ from tensorflow.keras.layers import RandomTranslation
 from tensorflow.keras.layers import RandomWidth
 from tensorflow.keras.layers import RandomZoom
 from tensorflow.keras.layers import Rescaling
-from tensorflow.keras.layers import Resizing
 
 from keras_cv.layers.feature_pyramid import FeaturePyramid
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
@@ -56,6 +55,7 @@ from keras_cv.layers.preprocessing.random_choice import RandomChoice
 from keras_cv.layers.preprocessing.random_color_degeneration import (
     RandomColorDegeneration,
 )
+from keras_cv.layers.preprocessing.resizing import Resizing
 from keras_cv.layers.preprocessing.random_color_jitter import RandomColorJitter
 from keras_cv.layers.preprocessing.random_crop_and_resize import RandomCropAndResize
 from keras_cv.layers.preprocessing.random_cutout import RandomCutout

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -62,5 +62,5 @@ from keras_cv.layers.preprocessing.random_saturation import RandomSaturation
 from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.randomly_zoomed_crop import RandomlyZoomedCrop
-from keras_cv.layers.preprocessing.solarization import Solarization
 from keras_cv.layers.preprocessing.resizing import Resizing
+from keras_cv.layers.preprocessing.solarization import Solarization

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -24,7 +24,6 @@ from tensorflow.keras.layers import RandomTranslation
 from tensorflow.keras.layers import RandomWidth
 from tensorflow.keras.layers import RandomZoom
 from tensorflow.keras.layers import Rescaling
-from tensorflow.keras.layers import Resizing
 
 from keras_cv.layers.preprocessing.aug_mix import AugMix
 from keras_cv.layers.preprocessing.augmenter import Augmenter
@@ -64,3 +63,4 @@ from keras_cv.layers.preprocessing.random_sharpness import RandomSharpness
 from keras_cv.layers.preprocessing.random_shear import RandomShear
 from keras_cv.layers.preprocessing.randomly_zoomed_crop import RandomlyZoomedCrop
 from keras_cv.layers.preprocessing.solarization import Solarization
+from keras_cv.layers.preprocessing.resizing import Resizing

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -361,11 +361,15 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
 
     def _format_bounding_boxes(self, bounding_boxes):
         metadata = {RAGGED_BOUNDING_BOXES: False}
+        shape = None
         if isinstance(bounding_boxes, tf.RaggedTensor):
             metadata = {RAGGED_BOUNDING_BOXES: True}
+            shape = bounding_boxes.bounding_shape()
             bounding_boxes = bounding_box.pad_with_sentinels(bounding_boxes)
+        else:
+            shape = bounding_boxes.shape
 
-        if bounding_boxes.shape[-1] < 5:
+        if shape[-1] < 5:
             raise ValueError(
                 "Bounding boxes are missing class_id. If you would like to pad the "
                 "bounding boxes with class_id, use `keras_cv.bounding_box.add_class_id`"

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -363,9 +363,10 @@ class BaseImageAugmentationLayer(tf.keras.__internal__.layers.BaseRandomLayer):
         metadata = {RAGGED_BOUNDING_BOXES: False}
         shape = None
         if isinstance(bounding_boxes, tf.RaggedTensor):
-            metadata = {RAGGED_BOUNDING_BOXES: True}
-            shape = bounding_boxes.bounding_shape()
+            metadata.update({RAGGED_BOUNDING_BOXES: True})
             bounding_boxes = bounding_box.pad_with_sentinels(bounding_boxes)
+            # hard code after pad_with_sentinels()
+            shape = [5]
         else:
             shape = bounding_boxes.shape
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -245,7 +245,7 @@ class Resizing(BaseImageAugmentationLayer):
         return inputs
 
     def call(self, inputs, training=True):
-        # inputs = self._ensure_inputs_are_compute_dtype(inputs)
+        inputs = self._ensure_inputs_are_compute_dtype(inputs)
         inputs, metadata = self._format_inputs(inputs)
         self._check_inputs(inputs)
         images = inputs["images"]

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -20,8 +20,8 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
-H_AXIS=-3
-W_AXIS=-2
+H_AXIS = -3
+W_AXIS = -2
 
 
 class Resizing(BaseImageAugmentationLayer):
@@ -110,8 +110,8 @@ class Resizing(BaseImageAugmentationLayer):
         return inputs
 
     def _resize_with_distortion(self, inputs):
-        images = inputs.get('images', None)
-        bounding_boxes = inputs.get('bounding_boxes', None)
+        images = inputs.get("images", None)
+        bounding_boxes = inputs.get("bounding_boxes", None)
         if bounding_boxes is not None:
             bounding_boxes = bounding_box.convert_format(
                 bounding_boxes,
@@ -166,18 +166,18 @@ class Resizing(BaseImageAugmentationLayer):
             target_width = img_width * resize_scale
 
             image = tf.image.resize(
-                image, size=(target_height, target_width), method=self._interpolation_method
+                image,
+                size=(target_height, target_width),
+                method=self._interpolation_method,
             )
             if boxes is not None:
                 boxes = keras_cv.bounding_box.convert_format(
                     boxes,
                     images=image,
                     source="rel_xyxy",
-                    target='xyxy',
+                    target="xyxy",
                 )
-            image = tf.image.pad_to_bounding_box(
-                image, 0, 0, self.height, self.width
-            )
+            image = tf.image.pad_to_bounding_box(image, 0, 0, self.height, self.width)
             if boxes is not None:
                 boxes = keras_cv.bounding_box.convert_format(
                     boxes,
@@ -185,20 +185,23 @@ class Resizing(BaseImageAugmentationLayer):
                     source="xyxy",
                     target=self.bounding_box_format,
                 )
-            inputs['images'] = image
+            inputs["images"] = image
             if boxes is not None:
-                inputs['bounding_boxes'] = tf.RaggedTensor.from_tensor(boxes)
+                inputs["bounding_boxes"] = tf.RaggedTensor.from_tensor(boxes)
             return inputs
+
         size_as_shape = tf.TensorShape((self.height, self.width))
-        shape = size_as_shape + inputs['images'].shape[-1:]
+        shape = size_as_shape + inputs["images"].shape[-1:]
         img_spec = tf.TensorSpec(shape, self.compute_dtype)
         boxes_spec = tf.RaggedTensorSpec(
-            shape=[None, inputs['bounding_boxes'].shape[2]],
-            dtype=inputs['bounding_boxes'].dtype
+            shape=[None, inputs["bounding_boxes"].shape[2]],
+            dtype=inputs["bounding_boxes"].dtype,
         )
-        return tf.map_fn(resize_with_pad_to_aspect, inputs, fn_output_signature={
-            'images': img_spec, 'bounding_boxes':boxes_spec
-            })
+        return tf.map_fn(
+            resize_with_pad_to_aspect,
+            inputs,
+            fn_output_signature={"images": img_spec, "bounding_boxes": boxes_spec},
+        )
 
     def _resize_with_crop(self, inputs):
         images = inputs.get("images", None)
@@ -224,7 +227,9 @@ class Resizing(BaseImageAugmentationLayer):
             size_as_shape = tf.TensorShape(size)
             shape = size_as_shape + images.shape[-1:]
             spec = tf.TensorSpec(shape, input_dtype)
-            images = tf.map_fn(resize_with_crop_to_aspect, images, fn_output_signature=spec)
+            images = tf.map_fn(
+                resize_with_crop_to_aspect, images, fn_output_signature=spec
+            )
         else:
             images = resize_with_crop_to_aspect(inputs)
 
@@ -234,7 +239,7 @@ class Resizing(BaseImageAugmentationLayer):
     def call(self, inputs, training=True):
         # inputs = self._ensure_inputs_are_compute_dtype(inputs)
         inputs, metadata = self._format_inputs(inputs)
-        images = inputs['images']
+        images = inputs["images"]
         if images.shape.rank == 3:
             return self._format_output(self._augment(inputs), metadata)
         elif images.shape.rank == 4:
@@ -245,6 +250,7 @@ class Resizing(BaseImageAugmentationLayer):
                 "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
                 f"{images.shape}"
             )
+
     def _batch_augment(self, inputs):
         if (
             inputs.get("bounding_boxes", None) is None

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -1,0 +1,155 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+import keras_cv.utils
+import tensorflow as tf
+from keras_cv import bounding_box
+
+
+class Resizing(BaseImageAugmentationLayer):
+    """A preprocessing layer which resizes images.
+
+    This layer resizes an image input to a target height and width. The input
+    should be a 4D (batched) or 3D (unbatched) tensor in `"channels_last"`
+    format.  Input pixel values can be of any range (e.g. `[0., 1.)` or `[0,
+    255]`) and of interger or floating point dtype. By default, the layer will
+    output floats.
+
+    This layer can be called on tf.RaggedTensor batches of input images of
+    distinct sizes, and will resize the outputs to dense tensors of uniform
+    size.
+
+    For an overview and full list of preprocessing layers, see the preprocessing
+    [guide](https://www.tensorflow.org/guide/keras/preprocessing_layers).
+
+    Args:
+      height: Integer, the height of the output shape.
+      width: Integer, the width of the output shape.
+      interpolation: String, the interpolation method. Defaults to `"bilinear"`.
+        Supports `"bilinear"`, `"nearest"`, `"bicubic"`, `"area"`, `"lanczos3"`,
+        `"lanczos5"`, `"gaussian"`, `"mitchellcubic"`.
+      crop_to_aspect_ratio: If True, resize the images without aspect
+        ratio distortion. When the original aspect ratio differs from the target
+        aspect ratio, the output image will be cropped so as to return the
+        largest possible window in the image (of size `(height, width)`) that
+        matches the target aspect ratio. By default
+        (`crop_to_aspect_ratio=False`), aspect ratio may not be preserved.
+    """
+
+    def __init__(
+        self,
+        height,
+        width,
+        interpolation="bilinear",
+        crop_to_aspect_ratio=False,
+        bounding_box_format=None,
+        **kwargs,
+    ):
+        self.height = height
+        self.width = width
+        self.interpolation = interpolation
+        self.crop_to_aspect_ratio = crop_to_aspect_ratio
+        self._interpolation_method = utils.get_interpolation(interpolation)
+        self.bounding_box_format = bounding_box_format
+        if crop_to_aspect_ratio and bounding_box_format:
+            # TODO(lukewood): support `bounding_box.smart_resize()`
+            raise ValueError(
+                "Resizing() does not support `crop_to_aspect_ratio=True` "
+                "and `bounding_box_format` at the same time.  In order to resize with "
+                "bounding boxes, please pass `crop_to_aspect_ratio=False`."
+            )
+        super().__init__(**kwargs)
+
+    def _batch_augment(self, inputs):
+        self._validate_inputs(inputs)
+        images = inputs.get("images", None)
+        bounding_boxes = inputs.get("bounding_boxes", None)
+
+        if images is None:
+            raise ValueError(
+                "Resizing expects images as an input, weight as a raw input Tensor or "
+                "as a dictionary: "
+                '{"images": images, {"bounding_boxes": bounding_boxes}}.'
+                f"Got: inputs = {inputs}"
+            )
+        if self.interpolation == "nearest":
+            input_dtype = self.compute_dtype
+        else:
+            input_dtype = tf.float32
+
+        if bounding_boxes is not None:
+            if self.bounding_box_format is None:
+                raise ValueError(
+                    "Resizing requires `bounding_box_format` to be set "
+                    "when augmenting bounding boxes, but `self.bounding_box_format=None`."
+                )
+            bounding_boxes = bounding_box.convert_format(
+                bounding_boxes,
+                source=self.bounding_box_format,
+                target="rel_xyxy",
+                images=images,
+            )
+
+        size = [self.height, self.width]
+        if self.crop_to_aspect_ratio:
+
+            def resize_to_aspect(x):
+                if isinstance(x, tf.RaggedTensor):
+                    x = x.to_tensor()
+                return tf.keras.utils.smart_resize(
+                    x, size=size, interpolation=self._interpolation_method
+                )
+
+            if isinstance(images, tf.RaggedTensor):
+                size_as_shape = tf.TensorShape(size)
+                shape = size_as_shape + images.shape[-1:]
+                spec = tf.TensorSpec(shape, input_dtype)
+                images = tf.map_fn(resize_to_aspect, images, fn_output_signature=spec)
+            else:
+                images = resize_to_aspect(inputs)
+        else:
+            images = tf.image.resize(
+                images, size=size, method=self._interpolation_method
+            )
+
+        images = tf.cast(outputs, self.compute_dtype)
+        inputs["images"] = images
+        if bounding_boxes is not None:
+            inputs["bounding_boxes"] = bounding_box.convert_format(
+                bounding_boxes,
+                target="rel_xyxy",
+                source=self.bounding_box_format,
+                images=images,
+            )
+        return inputs
+
+    def compute_output_shape(self, input_shape):
+        input_shape = tf.TensorShape(input_shape).as_list()
+        input_shape[H_AXIS] = self.height
+        input_shape[W_AXIS] = self.width
+        return tf.TensorShape(input_shape)
+
+    def get_config(self):
+        config = {
+            "height": self.height,
+            "width": self.width,
+            "interpolation": self.interpolation,
+            "crop_to_aspect_ratio": self.crop_to_aspect_ratio,
+            "bounding_box_format": self.bounding_box_format,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -197,9 +197,8 @@ class Resizing(BaseImageAugmentationLayer):
         if bounding_boxes is not None:
             raise ValueError(
                 "Resizing(crop_to_aspect_ratio=True) does not support "
-                "bounding box inputs.  Please use `pad_to_aspect_ratio=True`, or "
-                "`crop_to_aspect_ratio=False` and `pad_to_aspect_ratio=False` when "
-                "passing bounding boxes to Resizing()."
+                "bounding box inputs.  Please use `pad_to_aspect_ratio=True` when "
+                "processing bounding boxes with Resizing()."
             )
         inputs["images"] = images
         size = [self.height, self.width]

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -239,9 +239,7 @@ class Resizing(BaseImageAugmentationLayer):
 
     def call(self, inputs, training=True):
         # inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        print("INPUTS", inputs)
         inputs, metadata = self._format_inputs(inputs)
-        print("INPUTS after", inputs)
         images = inputs["images"]
         if images.shape.rank == 3:
             return self._format_output(self._augment(inputs), metadata)

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -216,6 +216,9 @@ class Resizing(BaseImageAugmentationLayer):
         inputs["images"] = images
         size = [self.height, self.width]
 
+        # tf.image.resize will always output float32 and operate more
+        # efficiently on float32 unless interpolation is nearest, in which case
+        # ouput type matches input type.
         if self.interpolation == "nearest":
             input_dtype = self.compute_dtype
         else:

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -219,7 +219,7 @@ class Resizing(BaseImageAugmentationLayer):
                 resize_with_crop_to_aspect, images, fn_output_signature=spec
             )
         else:
-            images = resize_with_crop_to_aspect(inputs)
+            images = resize_with_crop_to_aspect(images)
 
         inputs["images"] = images
         return inputs

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -265,7 +265,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         layer = cv_layers.Resizing(
             16, 16, pad_to_aspect_ratio=True, bounding_box_format="xyxy"
         )
-        unit_test = self
         inputs = {"images": images, "bounding_boxes": boxes}
         outputs = layer(inputs)
         self.assertListEqual(
@@ -273,6 +272,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
-        self.assertAllEqual(outputs['images'][1][:, :8, :], tf.ones((16, 8, 3)))
-        self.assertAllEqual(outputs['images'][1][:, -8:, :], tf.zeros((16, 8, 3)))
-        self.assertAllEqual(outputs['bounding_boxes'][1][0], [2, 2, 2, 2, 1])
+        self.assertAllEqual(outputs["images"][1][:, :8, :], tf.ones((16, 8, 3)))
+        self.assertAllEqual(outputs["images"][1][:, -8:, :], tf.zeros((16, 8, 3)))
+        self.assertAllEqual(outputs["bounding_boxes"][1][0], [2, 2, 2, 2, 1])

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -203,40 +203,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
-    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
-        images = tf.ragged.constant(
-            [
-                np.ones((8, 8, 3)),
-                np.ones((8, 4, 3)),
-                np.ones((4, 8, 3)),
-                np.ones((2, 2, 3)),
-            ],
-            dtype="float32",
-        )
-        boxes = tf.ragged.stack(
-            [
-                tf.ones((3, 5), dtype=tf.float32),
-                tf.ones((5, 5), dtype=tf.float32),
-                tf.ones((3, 5), dtype=tf.float32),
-                tf.ones((2, 5), dtype=tf.float32),
-            ],
-        )
-        layer = cv_layers.Resizing(
-            4, 4, pad_to_aspect_ratio=True, bounding_box_format="xywh"
-        )
-        unit_test = self
-        inputs = {"images": images, "bounding_boxes": boxes}
-
-        @tf.function
-        def tf_function(inputs):
-            outputs = layer(inputs)
-            unit_test.assertListEqual(
-                [4, 4, 3],
-                outputs["images"].shape.as_list()[-3:],
-            )
-
-        tf_function(inputs)
-
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -257,17 +223,12 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         )
         channels = 3
         layer = cv_layers.Resizing(
-            4, 4, pad_to_aspect_ratio=True, bounding_box_format="xywh"
+            4, 4, pad_to_aspect_ratio=True, bounding_box_format="xyxy"
         )
         unit_test = self
         inputs = {"images": images, "bounding_boxes": boxes}
-
-        # Test without tf.function
-        def non_tf_function(inputs):
-            outputs = layer(inputs)
-            unit_test.assertListEqual(
-                [4, 4, 3],
-                outputs["images"].shape.as_list()[-3:],
-            )
-
-        non_tf_function(inputs)
+        outputs = layer(inputs)
+        unit_test.assertListEqual(
+            [4, 4, 3],
+            outputs["images"].shape.as_list()[-3:],
+        )

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -4,4 +4,12 @@ from absl.testing import parameterized
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
     # TODO(lukewood): figure out the set of cases we need to port from core Keras.
-    pass
+
+    def test_resize_with_distortion_with_boxes(self):
+        pass
+
+    def test_resize_with_pad_with_boxes(self):
+        pass
+
+    def test_resize_with_crop_rejects_boxes(self):
+        pass

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -275,3 +275,4 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllEqual(outputs['images'][1][:, :8, :], tf.ones((16, 8, 3)))
         self.assertAllEqual(outputs['images'][1][:, -8:, :], tf.zeros((16, 8, 3)))
+        self.assertAllEqual(outputs['bounding_boxes'][1][0], [2, 2, 2, 2, 1])

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -202,3 +202,73 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             input_shape = (input_height, input_width, channels)
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
+
+    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
+        images = tf.ragged.constant(
+            [
+                np.ones((8, 8, 3)),
+                np.ones((8, 4, 3)),
+                np.ones((4, 8, 3)),
+                np.ones((2, 2, 3)),
+            ],
+            dtype="float32",
+        )
+        boxes = tf.ragged.stack(
+            [
+                tf.ones((3, 5), dtype=tf.float32),
+                tf.ones((5, 5), dtype=tf.float32),
+                tf.ones((3, 5), dtype=tf.float32),
+                tf.ones((2, 5), dtype=tf.float32),
+            ],
+        )
+        channels = 3
+        layer = cv_layers.Resizing(
+            4, 4, pad_to_aspect_ratio=True, bounding_box_format="xywh"
+        )
+        unit_test = self
+        inputs = {"images": images, "bounding_boxes": boxes}
+
+        @tf.function
+        def tf_function(inputs):
+            outputs = layer(inputs)
+            unit_test.assertListEqual(
+                [4, 4, 3],
+                outputs["images"].shape.as_list()[-3:],
+            )
+
+        tf_function(inputs)
+
+    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
+        images = tf.ragged.constant(
+            [
+                np.ones((8, 8, 3)),
+                np.ones((8, 4, 3)),
+                np.ones((4, 8, 3)),
+                np.ones((2, 2, 3)),
+            ],
+            dtype="float32",
+        )
+        boxes = tf.ragged.stack(
+            [
+                tf.ones((3, 5), dtype=tf.float32),
+                tf.ones((5, 5), dtype=tf.float32),
+                tf.ones((3, 5), dtype=tf.float32),
+                tf.ones((2, 5), dtype=tf.float32),
+            ],
+        )
+        channels = 3
+        layer = cv_layers.Resizing(
+            4, 4, pad_to_aspect_ratio=True, bounding_box_format="xywh"
+        )
+        unit_test = self
+        inputs = {"images": images, "bounding_boxes": boxes}
+
+        # Test without tf.function
+        def non_tf_function(inputs):
+            outputs = layer(inputs)
+            unit_test.assertListEqual(
+                [4, 4, 3],
+                outputs["images"].shape.as_list()[-3:],
+            )
+
+        non_tf_function(inputs)

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -203,7 +203,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
-    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
+    def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
                 np.ones((8, 8, 3)),
@@ -221,7 +221,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
                 tf.ones((2, 5), dtype=tf.float32),
             ],
         )
-        channels = 3
         layer = cv_layers.Resizing(
             4, 4, pad_to_aspect_ratio=True, bounding_box_format="xywh"
         )

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -203,7 +203,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
-    def test_pad_to_size_with_bounding_boxes_ragged_images(self):
+    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
         images = tf.ragged.constant(
             [
                 np.ones((8, 8, 3)),
@@ -237,7 +237,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
 
         tf_function(inputs)
 
-    def test_pad_to_size_with_bounding_boxes_ragged_images_tf_function(self):
+    def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
                 np.ones((8, 8, 3)),

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+from absl.testing import parameterized
+
+
+class ResizingTest(tf.test.TestCase, parameterized.TestCase):
+    # TODO(lukewood): figure out the set of cases we need to port from core Keras.
+    pass

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -1,14 +1,204 @@
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import layers as cv_layers
+
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
-    # TODO(lukewood): figure out the set of cases we need to port from core Keras.
-    def test_resize_with_distortion_with_boxes(self):
-        pass
+    def _run_test(self, kwargs, height, width):
+        kwargs.update({"height": height, "width": width})
+        layer = cv_layers.Resizing(**kwargs)
 
-    def test_resize_with_pad_with_boxes(self):
-        pass
+        inputs = tf.random.uniform((2, 5, 8, 3))
+        outputs = layer(inputs)
+        self.assertEqual(outputs.shape, (2, height, width, 3))
 
-    def test_resize_with_crop_rejects_boxes(self):
-        pass
+    @parameterized.named_parameters(
+        ("down_sample_bilinear_2_by_2", {"interpolation": "bilinear"}, 2, 2),
+        ("down_sample_bilinear_3_by_2", {"interpolation": "bilinear"}, 3, 2),
+        ("down_sample_nearest_2_by_2", {"interpolation": "nearest"}, 2, 2),
+        ("down_sample_nearest_3_by_2", {"interpolation": "nearest"}, 3, 2),
+        ("down_sample_area_2_by_2", {"interpolation": "area"}, 2, 2),
+        ("down_sample_area_3_by_2", {"interpolation": "area"}, 3, 2),
+        (
+            "down_sample_crop_to_aspect_ratio_3_by_2",
+            {
+                "interpolation": "bilinear",
+                "crop_to_aspect_ratio": True,
+            },
+            3,
+            2,
+        ),
+    )
+    def test_down_sampling(self, kwargs, height, width):
+        self._run_test(kwargs, height, width)
+
+    @parameterized.named_parameters(
+        ("up_sample_bilinear_10_by_12", {"interpolation": "bilinear"}, 10, 12),
+        ("up_sample_bilinear_12_by_12", {"interpolation": "bilinear"}, 12, 12),
+        ("up_sample_nearest_10_by_12", {"interpolation": "nearest"}, 10, 12),
+        ("up_sample_nearest_12_by_12", {"interpolation": "nearest"}, 12, 12),
+        ("up_sample_area_10_by_12", {"interpolation": "area"}, 10, 12),
+        ("up_sample_area_12_by_12", {"interpolation": "area"}, 12, 12),
+        (
+            "up_sample_crop_to_aspect_ratio_12_by_14",
+            {
+                "interpolation": "bilinear",
+                "crop_to_aspect_ratio": True,
+            },
+            12,
+            14,
+        ),
+    )
+    def test_up_sampling(self, kwargs, expected_height, expected_width):
+        self._run_test(kwargs, expected_height, expected_width)
+
+    def test_down_sampling_numeric(self):
+        for dtype in (np.int64, np.float32):
+            input_image = np.reshape(np.arange(0, 16), (1, 4, 4, 1)).astype(dtype)
+            layer = cv_layers.Resizing(height=2, width=2, interpolation="nearest")
+            output_image = layer(input_image)
+            # pyformat: disable
+            expected_output = np.asarray([[5, 7], [13, 15]]).astype(dtype)
+            # pyformat: enable
+            expected_output = np.reshape(expected_output, (1, 2, 2, 1))
+            self.assertAllEqual(expected_output, output_image)
+
+    def test_up_sampling_numeric(self):
+        for dtype in (np.int64, np.float32):
+            input_image = np.reshape(np.arange(0, 4), (1, 2, 2, 1)).astype(dtype)
+            layer = cv_layers.Resizing(height=4, width=4, interpolation="nearest")
+            output_image = layer(input_image)
+            # pyformat: disable
+            expected_output = np.asarray(
+                [[0, 0, 1, 1], [0, 0, 1, 1], [2, 2, 3, 3], [2, 2, 3, 3]]
+            ).astype(dtype)
+            # pyformat: enable
+            expected_output = np.reshape(expected_output, (1, 4, 4, 1))
+            self.assertAllEqual(expected_output, output_image)
+
+    @parameterized.named_parameters(
+        ("reshape_bilinear_10_by_4", {"interpolation": "bilinear"}, 10, 4)
+    )
+    def test_reshaping(self, kwargs, expected_height, expected_width):
+        self._run_test(kwargs, expected_height, expected_width)
+
+    def test_invalid_interpolation(self):
+        with self.assertRaises(NotImplementedError):
+            cv_layers.Resizing(5, 5, interpolation="invalid_interpolation")
+
+    def test_config_with_custom_name(self):
+        layer = cv_layers.Resizing(5, 5, name="image_preproc")
+        config = layer.get_config()
+        layer_1 = cv_layers.Resizing.from_config(config)
+        self.assertEqual(layer_1.name, layer.name)
+
+    def test_crop_to_aspect_ratio(self):
+        input_image = np.reshape(np.arange(0, 16), (1, 4, 4, 1)).astype("float32")
+        layer = cv_layers.Resizing(4, 2, crop_to_aspect_ratio=True)
+        output_image = layer(input_image)
+        expected_output = np.asarray(
+            [
+                [1, 2],
+                [5, 6],
+                [9, 10],
+                [13, 14],
+            ]
+        ).astype("float32")
+        expected_output = np.reshape(expected_output, (1, 4, 2, 1))
+        self.assertAllEqual(expected_output, output_image)
+
+    def test_unbatched_image(self):
+        input_image = np.reshape(np.arange(0, 16), (4, 4, 1)).astype("float32")
+        layer = cv_layers.Resizing(2, 2, interpolation="nearest")
+        output_image = layer(input_image)
+        expected_output = np.asarray(
+            [
+                [5, 7],
+                [13, 15],
+            ]
+        ).astype("float32")
+        expected_output = np.reshape(expected_output, (2, 2, 1))
+        self.assertAllEqual(expected_output, output_image)
+
+    @parameterized.named_parameters(
+        ("crop_to_aspect_ratio_false", False),
+        ("crop_to_aspect_ratio_true", True),
+    )
+    def test_ragged_image(self, crop_to_aspect_ratio):
+        inputs = tf.ragged.constant(
+            [
+                np.ones((8, 8, 1)),
+                np.ones((8, 4, 1)),
+                np.ones((4, 8, 1)),
+                np.ones((2, 2, 1)),
+            ],
+            dtype="float32",
+        )
+        layer = cv_layers.Resizing(
+            2,
+            2,
+            interpolation="nearest",
+            crop_to_aspect_ratio=crop_to_aspect_ratio,
+        )
+        outputs = layer(inputs)
+        expected_output = [
+            [[[1.0], [1.0]], [[1.0], [1.0]]],
+            [[[1.0], [1.0]], [[1.0], [1.0]]],
+            [[[1.0], [1.0]], [[1.0], [1.0]]],
+            [[[1.0], [1.0]], [[1.0], [1.0]]],
+        ]
+        self.assertIsInstance(outputs, tf.Tensor)
+        self.assertNotIsInstance(outputs, tf.RaggedTensor)
+        self.assertAllEqual(expected_output, outputs)
+
+    def test_output_dtypes(self):
+        inputs = np.array([[[1], [2]], [[3], [4]]], dtype="float64")
+        layer = cv_layers.Resizing(2, 2)
+        self.assertAllEqual(layer(inputs).dtype, "float32")
+        layer = cv_layers.Resizing(2, 2, dtype="uint8")
+        self.assertAllEqual(layer(inputs).dtype, "uint8")
+
+    @parameterized.named_parameters(
+        ("batch_crop_to_aspect_ratio", True, False, True),
+        ("batch_dont_crop_to_aspect_ratio", False, False, True),
+        ("single_sample_crop_to_aspect_ratio", True, False, False),
+        ("single_sample_dont_crop_to_aspect_ratio", False, False, False),
+        ("batch_pad_to_aspect_ratio", False, True, True),
+        ("single_sample_pad_to_aspect_ratio", False, True, False),
+    )
+    def test_static_shape_inference(
+        self, crop_to_aspect_ratio, pad_to_aspect_ratio, batch
+    ):
+        channels = 3
+        input_height = 8
+        input_width = 8
+        target_height = 4
+        target_width = 6
+        layer = cv_layers.Resizing(
+            target_height,
+            target_width,
+            crop_to_aspect_ratio=crop_to_aspect_ratio,
+            pad_to_aspect_ratio=pad_to_aspect_ratio,
+        )
+        unit_test = self
+
+        @tf.function
+        def tf_function(img):
+            unit_test.assertListEqual(
+                [input_height, input_width, channels], img.shape.as_list()[-3:]
+            )
+            img = layer(img)
+            unit_test.assertListEqual(
+                [target_height, target_width, channels],
+                img.shape.as_list()[-3:],
+            )
+            return img
+
+        if batch:
+            input_shape = (2, input_height, input_width, channels)
+        else:
+            input_shape = (input_height, input_width, channels)
+        img_data = np.random.random(size=input_shape).astype("float32")
+        tf_function(img_data)

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -166,6 +166,15 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         self.assertNotIsInstance(outputs, tf.RaggedTensor)
         self.assertAllEqual(expected_output, outputs)
 
+    def test_raises_with_segmap(self):
+        inputs = {
+            "images": np.array([[[1], [2]], [[3], [4]]], dtype="float64"),
+            "segmentation_map": np.array([[[1], [2]], [[3], [4]]], dtype="float64"),
+        }
+        layer = cv_layers.Resizing(2, 2)
+        with self.assertRaises(ValueError):
+            layer(inputs)
+
     def test_output_dtypes(self):
         inputs = np.array([[[1], [2]], [[3], [4]]], dtype="float64")
         layer = cv_layers.Resizing(2, 2)

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -221,7 +221,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
                 tf.ones((2, 5), dtype=tf.float32),
             ],
         )
-        channels = 3
         layer = cv_layers.Resizing(
             4, 4, pad_to_aspect_ratio=True, bounding_box_format="xyxy"
         )

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -4,7 +4,6 @@ from absl.testing import parameterized
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
     # TODO(lukewood): figure out the set of cases we need to port from core Keras.
-
     def test_resize_with_distortion_with_boxes(self):
         pass
 

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -14,15 +14,15 @@
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv.layers import preprocessing
+from keras_cv import layers
 
 TEST_CONFIGURATIONS = [
-    ("AutoContrast", preprocessing.AutoContrast, {"value_range": (0, 255)}),
-    ("ChannelShuffle", preprocessing.ChannelShuffle, {}),
-    ("Equalization", preprocessing.Equalization, {"value_range": (0, 255)}),
+    ("AutoContrast", layers.AutoContrast, {"value_range": (0, 255)}),
+    ("ChannelShuffle", layers.ChannelShuffle, {}),
+    ("Equalization", layers.Equalization, {"value_range": (0, 255)}),
     (
         "RandomCropAndResize",
-        preprocessing.RandomCropAndResize,
+        layers.RandomCropAndResize,
         {
             "target_size": (224, 224),
             "crop_area_factor": (0.8, 1.0),
@@ -30,8 +30,16 @@ TEST_CONFIGURATIONS = [
         },
     ),
     (
+        "Resizing",
+        layers.Resizing,
+        {
+            "height": 224,
+            "width": 224,
+        },
+    ),
+    (
         "RandomlyZoomedCrop",
-        preprocessing.RandomlyZoomedCrop,
+        layers.RandomlyZoomedCrop,
         {
             "height": 224,
             "width": 224,
@@ -39,36 +47,36 @@ TEST_CONFIGURATIONS = [
             "aspect_ratio_factor": (3 / 4, 4 / 3),
         },
     ),
-    ("Grayscale", preprocessing.Grayscale, {}),
-    ("GridMask", preprocessing.GridMask, {}),
+    ("Grayscale", layers.Grayscale, {}),
+    ("GridMask", layers.GridMask, {}),
     (
         "Posterization",
-        preprocessing.Posterization,
+        layers.Posterization,
         {"bits": 3, "value_range": (0, 255)},
     ),
     (
         "RandomColorDegeneration",
-        preprocessing.RandomColorDegeneration,
+        layers.RandomColorDegeneration,
         {"factor": 0.5},
     ),
     (
         "RandomCutout",
-        preprocessing.RandomCutout,
+        layers.RandomCutout,
         {"height_factor": 0.2, "width_factor": 0.2},
     ),
     (
         "RandomHue",
-        preprocessing.RandomHue,
+        layers.RandomHue,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
     (
         "RandomChannelShift",
-        preprocessing.RandomChannelShift,
+        layers.RandomChannelShift,
         {"value_range": (0, 255), "factor": 0.5},
     ),
     (
         "RandomColorJitter",
-        preprocessing.RandomColorJitter,
+        layers.RandomColorJitter,
         {
             "value_range": (0, 255),
             "brightness_factor": (-0.2, 0.5),
@@ -80,26 +88,26 @@ TEST_CONFIGURATIONS = [
     ),
     (
         "RandomGaussianBlur",
-        preprocessing.RandomGaussianBlur,
+        layers.RandomGaussianBlur,
         {"kernel_size": 3, "factor": (0.0, 3.0)},
     ),
-    ("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)}),
-    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
+    ("RandomJpegQuality", layers.RandomJpegQuality, {"factor": (75, 100)}),
+    ("RandomSaturation", layers.RandomSaturation, {"factor": 0.5}),
     (
         "RandomSharpness",
-        preprocessing.RandomSharpness,
+        layers.RandomSharpness,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
-    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
-    ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
+    ("RandomShear", layers.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
+    ("Solarization", layers.Solarization, {"value_range": (0, 255)}),
 ]
 
 
 class WithLabelsTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(
         *TEST_CONFIGURATIONS,
-        ("CutMix", preprocessing.CutMix, {}),
-        ("Mosaic", preprocessing.Mosaic, {}),
+        ("CutMix", layers.CutMix, {}),
+        ("Mosaic", layers.Mosaic, {}),
     )
     def test_can_run_with_labels(self, layer_cls, init_args):
         layer = layer_cls(**init_args)

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -14,15 +14,15 @@
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv.layers import preprocessing
+from keras_cv import layers
 
 TEST_CONFIGURATIONS = [
-    ("AutoContrast", preprocessing.AutoContrast, {"value_range": (0, 255)}),
-    ("ChannelShuffle", preprocessing.ChannelShuffle, {}),
-    ("Equalization", preprocessing.Equalization, {"value_range": (0, 255)}),
+    ("AutoContrast", layers.AutoContrast, {"value_range": (0, 255)}),
+    ("ChannelShuffle", layers.ChannelShuffle, {}),
+    ("Equalization", layers.Equalization, {"value_range": (0, 255)}),
     (
         "RandomCropAndResize",
-        preprocessing.RandomCropAndResize,
+        layers.RandomCropAndResize,
         {
             "target_size": (224, 224),
             "crop_area_factor": (0.8, 1.0),
@@ -31,7 +31,7 @@ TEST_CONFIGURATIONS = [
     ),
     (
         "RandomlyZoomedCrop",
-        preprocessing.RandomlyZoomedCrop,
+        layers.RandomlyZoomedCrop,
         {
             "height": 224,
             "width": 224,
@@ -39,36 +39,36 @@ TEST_CONFIGURATIONS = [
             "aspect_ratio_factor": (3 / 4, 4 / 3),
         },
     ),
-    ("Grayscale", preprocessing.Grayscale, {}),
-    ("GridMask", preprocessing.GridMask, {}),
+    ("Grayscale", layers.Grayscale, {}),
+    ("GridMask", layers.GridMask, {}),
     (
         "Posterization",
-        preprocessing.Posterization,
+        layers.Posterization,
         {"bits": 3, "value_range": (0, 255)},
     ),
     (
         "RandomColorDegeneration",
-        preprocessing.RandomColorDegeneration,
+        layers.RandomColorDegeneration,
         {"factor": 0.5},
     ),
     (
         "RandomCutout",
-        preprocessing.RandomCutout,
+        layers.RandomCutout,
         {"height_factor": 0.2, "width_factor": 0.2},
     ),
     (
         "RandomHue",
-        preprocessing.RandomHue,
+        layers.RandomHue,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
     (
         "RandomChannelShift",
-        preprocessing.RandomChannelShift,
+        layers.RandomChannelShift,
         {"value_range": (0, 255), "factor": 0.5},
     ),
     (
         "RandomColorJitter",
-        preprocessing.RandomColorJitter,
+        layers.RandomColorJitter,
         {
             "value_range": (0, 255),
             "brightness_factor": (-0.2, 0.5),
@@ -80,26 +80,34 @@ TEST_CONFIGURATIONS = [
     ),
     (
         "RandomGaussianBlur",
-        preprocessing.RandomGaussianBlur,
+        layers.RandomGaussianBlur,
         {"kernel_size": 3, "factor": (0.0, 3.0)},
     ),
-    ("RandomJpegQuality", preprocessing.RandomJpegQuality, {"factor": (75, 100)}),
-    ("RandomSaturation", preprocessing.RandomSaturation, {"factor": 0.5}),
+    ("RandomJpegQuality", layers.RandomJpegQuality, {"factor": (75, 100)}),
+    ("RandomSaturation", layers.RandomSaturation, {"factor": 0.5}),
     (
         "RandomSharpness",
-        preprocessing.RandomSharpness,
+        layers.RandomSharpness,
         {"factor": 0.5, "value_range": (0, 255)},
     ),
-    ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
-    ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
-    ("Mosaic", preprocessing.Mosaic, {}),
-    ("CutMix", preprocessing.CutMix, {}),
+    ("RandomShear", layers.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
+    ("Solarization", layers.Solarization, {"value_range": (0, 255)}),
+    ("Mosaic", layers.Mosaic, {}),
+    ("CutMix", layers.CutMix, {}),
+    (
+        "Resizing",
+        layers.Resizing,
+        {
+            "height": 224,
+            "width": 224,
+        },
+    ),
 ]
 
 NO_CPU_FP16_KERNEL_LAYERS = [
-    preprocessing.RandomSaturation,
-    preprocessing.RandomColorJitter,
-    preprocessing.RandomHue,
+    layers.RandomSaturation,
+    layers.RandomColorJitter,
+    layers.RandomHue,
 ]
 
 

--- a/keras_cv/utils/__init__.py
+++ b/keras_cv/utils/__init__.py
@@ -14,10 +14,10 @@
 
 from keras_cv.utils.fill_utils import fill_rectangle
 from keras_cv.utils.preprocessing import blend
+from keras_cv.utils.preprocessing import ensure_tensor
+from keras_cv.utils.preprocessing import get_interpolation
 from keras_cv.utils.preprocessing import parse_factor
 from keras_cv.utils.preprocessing import transform
 from keras_cv.utils.preprocessing import transform_value_range
-from keras_cv.utils.preprocessing import get_interpolation
 from keras_cv.utils.train import convert_inputs_to_tf_dataset
 from keras_cv.utils.train import scale_loss_for_distribution
-from keras_cv.utils.preprocessing import ensure_tensor

--- a/keras_cv/utils/__init__.py
+++ b/keras_cv/utils/__init__.py
@@ -17,5 +17,7 @@ from keras_cv.utils.preprocessing import blend
 from keras_cv.utils.preprocessing import parse_factor
 from keras_cv.utils.preprocessing import transform
 from keras_cv.utils.preprocessing import transform_value_range
+from keras_cv.utils.preprocessing import get_interpolation
 from keras_cv.utils.train import convert_inputs_to_tf_dataset
 from keras_cv.utils.train import scale_loss_for_distribution
+from keras_cv.utils.preprocessing import ensure_tensor

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -16,6 +16,38 @@ from tensorflow.keras import backend
 
 from keras_cv import core
 
+ResizeMethod = tf.image.ResizeMethod
+_TF_INTERPOLATION_METHODS = {
+    "bilinear": ResizeMethod.BILINEAR,
+    "nearest": ResizeMethod.NEAREST_NEIGHBOR,
+    "bicubic": ResizeMethod.BICUBIC,
+    "area": ResizeMethod.AREA,
+    "lanczos3": ResizeMethod.LANCZOS3,
+    "lanczos5": ResizeMethod.LANCZOS5,
+    "gaussian": ResizeMethod.GAUSSIAN,
+    "mitchellcubic": ResizeMethod.MITCHELLCUBIC,
+}
+
+
+def get_interpolation(interpolation):
+    """fetches a valid interpolation method from `tf.image.ResizeMethod`.
+
+    Args:
+        interpolation: string representing an interpolation method.
+    Raises:
+        NotImplementedError: if the method passed is not recognized
+    Returns:
+        An interpolation method from `tf.image.ResizeMethod`
+
+    """
+    interpolation = interpolation.lower()
+    if interpolation not in _TF_INTERPOLATION_METHODS:
+        raise NotImplementedError(
+            "Value not recognized for `interpolation`: {}. Supported values "
+            "are: {}".format(interpolation, _TF_INTERPOLATION_METHODS.keys())
+        )
+    return _TF_INTERPOLATION_METHODS[interpolation]
+
 
 def transform_value_range(images, original_range, target_range, dtype=tf.float32):
     """transforms values in input tensor from original_range to target_range.

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -16,16 +16,15 @@ from tensorflow.keras import backend
 
 from keras_cv import core
 
-ResizeMethod = tf.image.ResizeMethod
 _TF_INTERPOLATION_METHODS = {
-    "bilinear": ResizeMethod.BILINEAR,
-    "nearest": ResizeMethod.NEAREST_NEIGHBOR,
-    "bicubic": ResizeMethod.BICUBIC,
-    "area": ResizeMethod.AREA,
-    "lanczos3": ResizeMethod.LANCZOS3,
-    "lanczos5": ResizeMethod.LANCZOS5,
-    "gaussian": ResizeMethod.GAUSSIAN,
-    "mitchellcubic": ResizeMethod.MITCHELLCUBIC,
+    "bilinear": tf.image.ResizeMethod.BILINEAR,
+    "nearest": tf.image.ResizeMethod.NEAREST_NEIGHBOR,
+    "bicubic": tf.image.ResizeMethod.BICUBIC,
+    "area": tf.image.ResizeMethod.AREA,
+    "lanczos3": tf.image.ResizeMethod.LANCZOS3,
+    "lanczos5": tf.image.ResizeMethod.LANCZOS5,
+    "gaussian": tf.image.ResizeMethod.GAUSSIAN,
+    "mitchellcubic": tf.image.ResizeMethod.MITCHELLCUBIC,
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras-cv/issues/936, https://github.com/keras-team/keras-cv/issues/702

This allows us to resize with a pad which is the optimal resize mode for object detection.

Sample out from examples:
<img width="501" alt="Screen Shot 2022-11-03 at 2 24 06 PM" src="https://user-images.githubusercontent.com/12191303/199837085-6ff9883f-e2a5-44ab-9bf2-72c9c60bf00a.png">

---