### PR TITLE
Support no image size in PascalVOC loader

### DIFF
--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -22,13 +22,17 @@ from keras_cv import bounding_box
 def curry_map_function(bounding_box_format, img_size):
     """Mapping function to create batched image and bbox coordinates"""
 
-    resizing = keras.layers.Resizing(
-        height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
-    )
+    if img_size is not None:
+        resizing = keras.layers.Resizing(
+            height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
+        )
 
     # TODO(lukewood): update `keras.layers.Resizing` to support bounding boxes.
     def apply(inputs):
-        inputs["image"] = resizing(inputs["image"])
+        # Support image size none.
+        if img_size is not None:
+            inputs["image"] = resizing(inputs["image"])
+
         inputs["objects"]["bbox"] = bounding_box.convert_format(
             inputs["objects"]["bbox"],
             images=inputs["image"],

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -55,7 +55,7 @@ def load(
     batch_size=None,
     shuffle=True,
     shuffle_buffer=None,
-    img_size=(512, 512),
+    img_size=None,
 ):
     """Loads the PascalVOC 2007 dataset.
 

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -53,7 +53,6 @@ def load(
     split,
     bounding_box_format,
     batch_size=None,
-    shuffle=None,
     shuffle_buffer=None,
     img_size=None,
 ):
@@ -75,11 +74,9 @@ def load(
             for more details on supported bounding box formats.
         batch_size: (Optional) how many instances to include in batches after loading. If
             not provided, no batching will occur.
-        shuffle: whether or not to shuffle the dataset.  Defaults to None, which indicates
-            shuffling will only occur if a `shuffle_buffer` is provided.
         shuffle_buffer: the size of the buffer to use in shuffling.
         img_size: (Optional) size to resize the images to.  By default, images are not
-            resized and ragged batches are produced if batching occurs.
+            resized `tf.RaggedTensor` batches are produced if batching occurs.
 
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing
@@ -95,15 +92,7 @@ def load(
         num_parallel_calls=tf.data.AUTOTUNE,
     )
 
-    if shuffle is None and shuffle_buffer is not None:
-        shuffle = True
-
-    if shuffle:
-        if not shuffle_buffer:
-            raise ValueError(
-                "If `shuffle=True`, either a `batch_size` or `shuffle_buffer` must be "
-                "provided to `keras_cv.datasets.pascal_voc.load().`"
-            )
+    if shuffle_buffer:
         dataset = dataset.shuffle(shuffle_buffer, reshuffle_each_iteration=True)
 
     if batch_size is not None:

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -54,6 +54,7 @@ def load(
     bounding_box_format,
     batch_size=None,
     shuffle_buffer=None,
+    shuffle_files=True,
     img_size=None,
 ):
     """Loads the PascalVOC 2007 dataset.
@@ -74,7 +75,8 @@ def load(
             for more details on supported bounding box formats.
         batch_size: (Optional) how many instances to include in batches after loading. If
             not provided, no batching will occur.
-        shuffle_buffer: the size of the buffer to use in shuffling.
+        shuffle_buffer: (Optional) the size of the buffer to use in shuffling.
+        shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
         img_size: (Optional) size to resize the images to.  By default, images are not
             resized `tf.RaggedTensor` batches are produced if batching occurs.
 
@@ -85,7 +87,7 @@ def load(
         shape [batch, None, 5].
     """
     dataset, dataset_info = tfds.load(
-        "voc/2007", split=split, shuffle_files=shuffle, with_info=True
+        "voc/2007", split=split, shuffle_files=shuffle_files, with_info=True
     )
     dataset = dataset.map(
         curry_map_function(bounding_box_format=bounding_box_format, img_size=img_size),


### PR DESCRIPTION
This will allow us to support Ragged pipelines where the batch sizes are randomly set each batch.