### PR TITLE
Add FasterRCNN model.

### DIFF
--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -12,12 +12,31 @@ import tensorflow_datasets as tfds
 
 import keras_cv
 
+physical_devices = tf.config.list_physical_devices("GPU")
+tf.config.set_visible_devices(physical_devices[:1], "GPU")
+
+# parameters from FasterRCNN [paper](https://arxiv.org/pdf/1506.01497.pdf)
+
 global_batch = 4
+image_size = [256, 256, 3]
 train_ds = tfds.load(
     "voc/2007", split="train+test", with_info=False, shuffle_files=True
+).concatenate(
+    tfds.load("voc/2012", split="train+test", with_info=False, shuffle_files=True)
+)
+eval_ds = tfds.load("voc/2007", split="validation", with_info=False).concatenate(
+    tfds.load("voc/2012", split="validation", with_info=False)
 )
 
 model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
+
+
+def flip_fn(image, boxes):
+    if tf.random.uniform([], minval=0, maxval=1, dtype=tf.float32) > 0.5:
+        image = tf.image.flip_left_right(image)
+        y1, x1, y2, x2 = tf.split(boxes, num_or_size_splits=4, axis=-1)
+        boxes = tf.concat([y1, 1.0 - x2, y2, 1.0 - x1], axis=-1)
+    return image, boxes
 
 
 def proc_train_fn(bounding_box_format, img_size):
@@ -32,8 +51,10 @@ def proc_train_fn(bounding_box_format, img_size):
         image = tf.cast(image, tf.float32)
         image = tf.keras.applications.resnet50.preprocess_input(image)
         image = resizing(image)
+        gt_boxes = inputs["objects"]["bbox"]
+        # image, gt_boxes = flip_fn(image, gt_boxes)
         gt_boxes = keras_cv.bounding_box.convert_format(
-            inputs["objects"]["bbox"],
+            gt_boxes,
             images=image,
             source="rel_yxyx",
             target=bounding_box_format,
@@ -74,13 +95,26 @@ def filter_fn(examples):
 
 train_ds = train_ds.filter(filter_fn)
 train_ds = train_ds.map(
-    proc_train_fn("yxyx", [256, 256, 3]), num_parallel_calls=tf.data.AUTOTUNE
+    proc_train_fn(bounding_box_format="yxyx", img_size=image_size),
+    num_parallel_calls=tf.data.AUTOTUNE,
 )
 train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(global_batch, drop_remainder=True)
 )
 train_ds = train_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
 train_ds = train_ds.prefetch(2)
+
+eval_ds = eval_ds.filter(filter_fn)
+eval_ds = eval_ds.map(
+    proc_train_fn(bounding_box_format="yxyx", img_size=image_size),
+    num_parallel_calls=tf.data.AUTOTUNE,
+)
+eval_ds = eval_ds.apply(
+    tf.data.experimental.dense_to_ragged_batch(global_batch, drop_remainder=True)
+)
+eval_ds = eval_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
+eval_ds = eval_ds.prefetch(2)
+
 
 # The keras huber loss will sum all losses and divide by BS * N * 4, instead we want divide by BS
 # using NONE reduction as also summing creates issues
@@ -93,6 +127,11 @@ rcnn_cls_loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
     from_logits=True, reduction=tf.keras.losses.Reduction.NONE
 )
 
+rpn_reg_metric = tf.keras.metrics.Mean()
+rpn_cls_metric = tf.keras.metrics.Mean()
+rcnn_reg_metric = tf.keras.metrics.Mean()
+rcnn_cls_metric = tf.keras.metrics.Mean()
+
 lr_decay = tf.keras.optimizers.schedules.PiecewiseConstantDecay(
     boundaries=[80000], values=[0.001, 0.0001]
 )
@@ -101,12 +140,11 @@ optimizer = tf.keras.optimizers.SGD(
     learning_rate=lr_decay, momentum=0.9, global_clipnorm=10.0
 )
 
-weight_decay = 0.001
+weight_decay = 0.00001
 step = 0
 
 
-@tf.function
-def train_step(examples):
+def compute_loss(examples, training):
     image, gt_boxes, gt_classes, box_targets, box_weights, cls_targets, cls_weights = (
         examples["images"],
         examples["gt_boxes"],
@@ -116,80 +154,126 @@ def train_step(examples):
         examples["rpn_cls_targets"],
         examples["rpn_cls_weights"],
     )
+    outputs = model(image, gt_boxes=gt_boxes, gt_classes=gt_classes, training=training)
+    rpn_box_pred, rpn_cls_pred = outputs["rpn_box_pred"], outputs["rpn_cls_pred"]
+    rpn_reg_loss = tf.reduce_sum(
+        rpn_reg_loss_fn(box_targets, rpn_box_pred, box_weights)
+    )
+    # avoid divide by zero
+    positive_boxes = tf.reduce_sum(box_weights) + 0.01
+    # x4 given huber loss reduce_mean on the box dimension
+    rpn_reg_loss /= positive_boxes * 0.25
+    rpn_cls_loss = tf.reduce_sum(
+        rpn_cls_loss_fn(cls_targets, rpn_cls_pred, cls_weights)
+    )
+    rpn_cls_loss /= model.rpn_labeler.samples_per_image * global_batch
+    rcnn_reg_loss = tf.reduce_sum(
+        rcnn_reg_loss_fn(
+            outputs["rcnn_box_targets"],
+            outputs["rcnn_box_pred"],
+            outputs["rcnn_box_weights"],
+        )
+    )
+    # avoid divide by zero
+    positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
+    rcnn_reg_loss /= positive_rois * 0.25
+    rcnn_cls_loss = tf.reduce_sum(
+        rcnn_cls_loss_fn(
+            outputs["rcnn_cls_targets"],
+            outputs["rcnn_cls_pred"],
+            outputs["rcnn_cls_weights"],
+        )
+    )
+    # 512 is for num_sampled_rois
+    rcnn_cls_loss /= model.roi_sampler.num_sampled_rois * global_batch
+    l2_loss = weight_decay * tf.add_n(
+        [tf.nn.l2_loss(var) for var in model.trainable_variables]
+    )
+    total_loss = rpn_reg_loss + rpn_cls_loss + rcnn_reg_loss + rcnn_cls_loss + l2_loss
+    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, l2_loss, total_loss
+
+
+@tf.function
+def train_step(examples):
     with tf.GradientTape() as tape:
-        outputs = model(image, gt_boxes, gt_classes, training=True)
-        rpn_box_pred, rpn_cls_pred = outputs["rpn_box_pred"], outputs["rpn_cls_pred"]
-        rpn_reg_loss = tf.reduce_sum(
-            rpn_reg_loss_fn(box_targets, rpn_box_pred, box_weights)
-        )
-        positive_boxes = tf.reduce_sum(box_weights) + 0.01
-        # x4 given huber loss reduce_mean on the box dimension
-        rpn_reg_loss /= positive_boxes * global_batch * 0.25
-        rpn_cls_loss = tf.reduce_sum(
-            rpn_cls_loss_fn(cls_targets, rpn_cls_pred, cls_weights)
-        )
-        rpn_cls_loss /= 256 * global_batch
-        rcnn_reg_loss = tf.reduce_sum(
-            rcnn_reg_loss_fn(
-                outputs["rcnn_box_targets"],
-                outputs["rcnn_box_pred"],
-                outputs["rcnn_box_weights"],
-            )
-        )
-        positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
-        rcnn_reg_loss /= positive_rois * global_batch * 0.25
-        rcnn_cls_loss = tf.reduce_sum(
-            rcnn_cls_loss_fn(
-                outputs["rcnn_cls_targets"],
-                outputs["rcnn_cls_pred"],
-                outputs["rcnn_cls_weights"],
-            )
-        )
-        # 512 is for num_sampled_rois
-        rcnn_cls_loss /= 512 * global_batch
-        l2_loss = weight_decay * tf.add_n(
-            [tf.nn.l2_loss(var) for var in model.trainable_variables]
-        )
-        total_loss = (
-            rpn_reg_loss + rpn_cls_loss + rcnn_reg_loss + rcnn_cls_loss + l2_loss
-        )
+        (
+            rpn_reg_loss,
+            rpn_cls_loss,
+            rcnn_reg_loss,
+            rcnn_cls_loss,
+            l2_loss,
+            total_loss,
+        ) = compute_loss(examples, training=True)
     gradients = tape.gradient(total_loss, model.trainable_variables)
     optimizer.apply_gradients(zip(gradients, model.trainable_variables))
-    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, total_loss
+    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, l2_loss, total_loss
+
+
+@tf.function
+def eval_step(examples):
+    rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, _, _ = compute_loss(
+        examples, training=True
+    )
+    rpn_reg_metric.update_state(rpn_reg_loss)
+    rpn_cls_metric.update_state(rpn_cls_loss)
+    rcnn_reg_metric.update_state(rcnn_reg_loss)
+    rcnn_cls_metric.update_state(rcnn_cls_loss)
 
 
 rpn_reg_loss = 0.0
 rpn_cls_loss = 0.0
 rcnn_reg_loss = 0.0
 rcnn_cls_loss = 0.0
+l2_loss = 0.0
 step_size = 500
 
-for epoch in range(50):
+for epoch in range(40):
     for examples in train_ds:
         (
             step_rpn_reg_loss,
             step_rpn_cls_loss,
             step_rcnn_reg_loss,
             step_rcnn_cls_loss,
+            step_l2_loss,
             total_loss,
         ) = train_step(examples)
         rpn_reg_loss += step_rpn_reg_loss
         rpn_cls_loss += step_rpn_cls_loss
         rcnn_reg_loss += step_rcnn_reg_loss
         rcnn_cls_loss += step_rcnn_cls_loss
+        l2_loss += step_l2_loss
         step += 1
         if step % step_size == 0:
             print(
-                "step {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}".format(
+                "step {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}, l2 loss {}".format(
                     step,
                     rpn_reg_loss / step_size,
                     rpn_cls_loss / step_size,
                     rcnn_reg_loss / step_size,
                     rcnn_cls_loss / step_size,
+                    l2_loss / step_size,
                 )
             )
             rpn_reg_loss = 0.0
             rpn_cls_loss = 0.0
             rcnn_reg_loss = 0.0
             rcnn_cls_loss = 0.0
+            l2_loss = 0.0
+    for examples in eval_ds:
+        eval_step(examples)
+    print(
+        "epoch {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}".format(
+            epoch,
+            rpn_reg_metric.result(),
+            rpn_cls_metric.result(),
+            rcnn_reg_metric.result(),
+            rcnn_cls_metric.result(),
+        )
+    )
+    rpn_reg_metric.reset_state()
+    rpn_cls_metric.reset_state()
+    rcnn_reg_metric.reset_state()
+    rcnn_cls_metric.reset_state()
     print("{} finished epoch {}".format(datetime.now(), epoch))
+
+    model.save_weights(f"./weights_{epoch}.h5")

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Title: Train an Object Detection Model on Pascal VOC 2007 using KerasCV
 Author: [tanzhenyu](https://github.com/tanzhenyu)

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -1,0 +1,195 @@
+"""
+Title: Train an Object Detection Model on Pascal VOC 2007 using KerasCV
+Author: [tanzhenyu](https://github.com/tanzhenyu)
+Date created: 2022/09/27
+Last modified: 2022/09/27
+Description: Use KerasCV to train a RetinaNet on Pascal VOC 2007.
+"""
+from datetime import datetime
+
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+import keras_cv
+
+global_batch = 4
+train_ds = tfds.load(
+    "voc/2007", split="train+test", with_info=False, shuffle_files=True
+)
+
+model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="xyxy")
+
+
+def proc_train_fn(bounding_box_format, img_size):
+    anchors = model.anchor_generator(image_shape=img_size)
+    anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
+    resizing = tf.keras.layers.Resizing(
+        height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
+    )
+
+    def apply(inputs):
+        image = inputs["image"]
+        image = tf.cast(image, tf.float32)
+        image = tf.keras.applications.resnet50.preprocess_input(image)
+        image = resizing(image)
+        gt_boxes = keras_cv.bounding_box.convert_format(
+            inputs["objects"]["bbox"],
+            images=image,
+            source="rel_yxyx",
+            target=bounding_box_format,
+        )
+        gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
+        gt_classes = tf.expand_dims(gt_classes, axis=-1)
+        box_targets, box_weights, cls_targets, cls_weights = model.rpn_labeler(
+            anchors, gt_boxes, gt_classes
+        )
+        return {
+            "images": image,
+            "rpn_box_targets": box_targets,
+            "rpn_box_weights": box_weights,
+            "rpn_cls_targets": cls_targets,
+            "rpn_cls_weights": cls_weights,
+            "gt_boxes": gt_boxes,
+            "gt_classes": gt_classes,
+        }
+
+    return apply
+
+
+def pad_fn(examples):
+    gt_boxes = examples.pop("gt_boxes")
+    gt_classes = examples.pop("gt_classes")
+    examples["gt_boxes"] = gt_boxes.to_tensor(default_value=-1.0)
+    examples["gt_classes"] = gt_classes.to_tensor(default_value=-1.0)
+    return examples
+
+
+def filter_fn(examples):
+    gt_boxes = examples["objects"]["bbox"]
+    if tf.shape(gt_boxes)[0] <= 0 or tf.reduce_sum(gt_boxes) < 0:
+        return False
+    else:
+        return True
+
+
+train_ds = train_ds.filter(filter_fn)
+train_ds = train_ds.map(
+    proc_train_fn("xyxy", [256, 256, 3]), num_parallel_calls=tf.data.AUTOTUNE
+)
+train_ds = train_ds.apply(
+    tf.data.experimental.dense_to_ragged_batch(global_batch, drop_remainder=True)
+)
+train_ds = train_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
+train_ds = train_ds.prefetch(2)
+
+# The keras huber loss will sum all losses and divide by BS * N * 4, instead we want divide by BS
+# using NONE reduction as also summing creates issues
+rpn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.NONE)
+rpn_cls_loss_fn = tf.keras.losses.BinaryCrossentropy(
+    from_logits=True, reduction=tf.keras.losses.Reduction.NONE
+)
+rcnn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.NONE)
+rcnn_cls_loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
+    from_logits=True, reduction=tf.keras.losses.Reduction.NONE
+)
+
+lr_decay = tf.keras.optimizers.schedules.PiecewiseConstantDecay(
+    boundaries=[80000], values=[0.001, 0.0001]
+)
+
+optimizer = tf.keras.optimizers.SGD(
+    learning_rate=lr_decay, momentum=0.9, global_clipnorm=10.0
+)
+
+weight_decay = 0.001
+step = 0
+
+
+@tf.function
+def train_step(examples):
+    image, gt_boxes, gt_classes, box_targets, box_weights, cls_targets, cls_weights = (
+        examples["images"],
+        examples["gt_boxes"],
+        examples["gt_classes"],
+        examples["rpn_box_targets"],
+        examples["rpn_box_weights"],
+        examples["rpn_cls_targets"],
+        examples["rpn_cls_weights"],
+    )
+    with tf.GradientTape() as tape:
+        outputs = model(image, gt_boxes, gt_classes, training=True)
+        rpn_box_pred, rpn_cls_pred = outputs["rpn_box_pred"], outputs["rpn_cls_pred"]
+        rpn_reg_loss = tf.reduce_sum(
+            rpn_reg_loss_fn(box_targets, rpn_box_pred, box_weights)
+        )
+        positive_boxes = tf.reduce_sum(box_weights) + 0.01
+        # x4 given huber loss reduce_mean on the box dimension
+        rpn_reg_loss /= positive_boxes * global_batch * 0.25
+        rpn_cls_loss = tf.reduce_sum(
+            rpn_cls_loss_fn(cls_targets, rpn_cls_pred, cls_weights)
+        )
+        rpn_cls_loss /= 256 * global_batch
+        rcnn_reg_loss = tf.reduce_sum(
+            rcnn_reg_loss_fn(
+                outputs["rcnn_box_targets"],
+                outputs["rcnn_box_pred"],
+                outputs["rcnn_box_weights"],
+            )
+        )
+        positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
+        rcnn_reg_loss /= positive_rois * global_batch * 0.25
+        rcnn_cls_loss = tf.reduce_sum(
+            rcnn_cls_loss_fn(
+                outputs["rcnn_cls_targets"],
+                outputs["rcnn_cls_pred"],
+                outputs["rcnn_cls_weights"],
+            )
+        )
+        # 512 is for num_sampled_rois
+        rcnn_cls_loss /= 512 * global_batch
+        l2_loss = weight_decay * tf.add_n(
+            [tf.nn.l2_loss(var) for var in model.trainable_variables]
+        )
+        total_loss = (
+            rpn_reg_loss + rpn_cls_loss + rcnn_reg_loss + rcnn_cls_loss + l2_loss
+        )
+    gradients = tape.gradient(total_loss, model.trainable_variables)
+    optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, total_loss
+
+
+rpn_reg_loss = 0.0
+rpn_cls_loss = 0.0
+rcnn_reg_loss = 0.0
+rcnn_cls_loss = 0.0
+step_size = 500
+
+for epoch in range(50):
+    for examples in train_ds:
+        (
+            step_rpn_reg_loss,
+            step_rpn_cls_loss,
+            step_rcnn_reg_loss,
+            step_rcnn_cls_loss,
+            total_loss,
+        ) = train_step(examples)
+        rpn_reg_loss += step_rpn_reg_loss
+        rpn_cls_loss += step_rpn_cls_loss
+        rcnn_reg_loss += step_rcnn_reg_loss
+        rcnn_cls_loss += step_rcnn_cls_loss
+        step += 1
+        if step % step_size == 0:
+            print(
+                "step {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}".format(
+                    step,
+                    rpn_reg_loss / step_size,
+                    rpn_cls_loss / step_size,
+                    rcnn_reg_loss / step_size,
+                    rcnn_cls_loss / step_size,
+                )
+            )
+            rpn_reg_loss = 0.0
+            rpn_cls_loss = 0.0
+            rcnn_reg_loss = 0.0
+            rcnn_cls_loss = 0.0
+    print("{} finished epoch {}".format(datetime.now(), epoch))

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -17,7 +17,7 @@ train_ds = tfds.load(
     "voc/2007", split="train+test", with_info=False, shuffle_files=True
 )
 
-model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="xyxy")
+model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
 
 
 def proc_train_fn(bounding_box_format, img_size):
@@ -74,7 +74,7 @@ def filter_fn(examples):
 
 train_ds = train_ds.filter(filter_fn)
 train_ds = train_ds.map(
-    proc_train_fn("xyxy", [256, 256, 3]), num_parallel_calls=tf.data.AUTOTUNE
+    proc_train_fn("yxyx", [256, 256, 3]), num_parallel_calls=tf.data.AUTOTUNE
 )
 train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(global_batch, drop_remainder=True)

--- a/keras_cv/bounding_box/__init__.py
+++ b/keras_cv/bounding_box/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_cv.bounding_box.converters import _decode
-from keras_cv.bounding_box.converters import _encode
+from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
+from keras_cv.bounding_box.converters import _encode_box_to_deltas
 from keras_cv.bounding_box.converters import convert_format
 from keras_cv.bounding_box.formats import CENTER_XYWH
 from keras_cv.bounding_box.formats import REL_XYXY

--- a/keras_cv/bounding_box/__init__.py
+++ b/keras_cv/bounding_box/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.bounding_box.converters import _decode
+from keras_cv.bounding_box.converters import _encode
 from keras_cv.bounding_box.converters import convert_format
 from keras_cv.bounding_box.formats import CENTER_XYWH
 from keras_cv.bounding_box.formats import REL_XYXY

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -32,6 +32,7 @@ def _encode_box_to_deltas(
     box_format: str,
     variance: Optional[List[float]] = None,
 ):
+    """Converts bounding_boxes from `center_yxhw` to delta format."""
     if variance and len(variance) != 4:
         raise ValueError(f"`variance` must be length 4, got {variance}")
     anchors = convert_format(
@@ -65,6 +66,7 @@ def _decode_deltas_to_boxes(
     anchor_format: str,
     variance: Optional[List[float]] = None,
 ):
+    """Converts bounding_boxes from delta format to `center_yxhw`."""
     if variance and len(variance) != 4:
         raise ValueError(f"`variance` must be length 4, got {variance}")
     anchors = convert_format(

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -38,6 +38,9 @@ def compute_iou(
         `"rel_xyxy"`, `"xyWH"`, `"center_xyWH"`, `"yxyx"`, `"rel_yxyx"`.
         For detailed information on the supported format, see the
         [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
+    use_masking: whether masking will be applied. This will mask all `boxes1` or `boxes2` that
+        have values less then 0 in all its 4 dimensions. Default to `False`.
+    mask_val: int to mask those returned IOUs if the masking is True. Default to -1.
 
     Returns:
       iou_lookup_table: a vector containing the pairwise ious of boxes1 and

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -17,7 +17,13 @@ import tensorflow as tf
 from keras_cv import bounding_box
 
 
-def compute_iou(boxes1, boxes2, bounding_box_format):
+def compute_iou(
+    boxes1,
+    boxes2,
+    bounding_box_format,
+    use_masking=False,
+    mask_val=-1,
+):
     """Computes a lookup table vector containing the ious for a given set boxes.
 
     The lookup vector is to be indexed by [`boxes1_index`,`boxes2_index`] if boxes
@@ -93,8 +99,20 @@ def compute_iou(boxes1, boxes2, bounding_box_format):
         return tf.math.divide_no_nan(intersect_area, union_area)
 
     if boxes1_rank == 2:
-        return compute_iou_for_batch((boxes1, boxes2))
+        res = compute_iou_for_batch((boxes1, boxes2))
+        perm = [1, 0]
     else:
-        return tf.map_fn(
+        res = tf.map_fn(
             compute_iou_for_batch, elems=(boxes1, boxes2), dtype=boxes1.dtype
         )
+        perm = [0, 2, 1]
+
+    if not use_masking:
+        return res
+
+    mask_val_t = tf.cast(mask_val, res.dtype) * tf.ones_like(res)
+    boxes1_mask = tf.less(tf.reduce_max(boxes1, axis=-1, keepdims=True), 0.0)
+    boxes2_mask = tf.less(tf.reduce_max(boxes2, axis=-1, keepdims=True), 0.0)
+    background_mask = tf.logical_or(boxes1_mask, tf.transpose(boxes2_mask, perm))
+    iou_lookup_table = tf.where(background_mask, mask_val_t, res)
+    return iou_lookup_table

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -249,9 +249,9 @@ class _SingleAnchorGenerator:
 
         stride = tf.cast(self.stride, tf.float32)
         # [W]
-        cx = tf.range(0.5 * stride, image_width, stride)
+        cx = tf.range(0.5 * stride, image_width + 1, stride)
         # [H]
-        cy = tf.range(0.5 * stride, image_height, stride)
+        cy = tf.range(0.5 * stride, image_height + 1, stride)
         # [H, W]
         cx_grid, cy_grid = tf.meshgrid(cx, cy)
         # [H, W, 1]

--- a/keras_cv/layers/object_detection/roi_align.py
+++ b/keras_cv/layers/object_detection/roi_align.py
@@ -327,6 +327,7 @@ def multilevel_crop_and_resize(
         return features_per_box
 
 
+# TODO(tanzheny): Remove this implementation once roi_pool has better performance.
 class _ROIAligner(tf.keras.layers.Layer):
     """Performs ROIAlign for the second stage processing."""
 

--- a/keras_cv/layers/object_detection/roi_align.py
+++ b/keras_cv/layers/object_detection/roi_align.py
@@ -14,6 +14,7 @@
 
 from typing import Dict
 from typing import Mapping
+from typing import Optional
 from typing import Tuple
 
 import tensorflow as tf
@@ -24,7 +25,9 @@ from keras_cv import bounding_box
 def _feature_bilinear_interpolation(
     features: tf.Tensor, kernel_y: tf.Tensor, kernel_x: tf.Tensor
 ) -> tf.Tensor:
-    """Feature bilinear interpolation.
+    """
+    Feature bilinear interpolation.
+
     The RoIAlign feature f can be computed by bilinear interpolation
     of four neighboring feature points f0, f1, f2, and f3.
     f(y, x) = [hy, ly] * [[f00, f01], * [hx, lx]^T
@@ -33,11 +36,13 @@ def _feature_bilinear_interpolation(
     f(y, x) = w00*f00 + w01*f01 + w10*f10 + w11*f11
     kernel_y = [hy, ly]
     kernel_x = [hx, lx]
+
     Args:
       features: The features are in shape of [batch_size, num_boxes, output_size *
         2, output_size * 2, num_filters].
       kernel_y: Tensor of size [batch_size, boxes, output_size, 2, 1].
       kernel_x: Tensor of size [batch_size, boxes, output_size, 2, 1].
+
     Returns:
       A 5-D tensor representing feature crop of shape
       [batch_size, num_boxes, output_size, output_size, num_filters].
@@ -75,8 +80,9 @@ def _feature_bilinear_interpolation(
 def _compute_grid_positions(
     boxes: tf.Tensor, boundaries: tf.Tensor, output_size: int, sample_offset: float
 ) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
-    """Computes the grid position w.r.t.
-    the corresponding feature map.
+    """
+    Computes the grid position w.r.t. the corresponding feature map.
+
     Args:
       boxes: a 3-D tensor of shape [batch_size, num_boxes, 4] encoding the
         information of each box w.r.t. the corresponding feature map.
@@ -89,6 +95,7 @@ def _compute_grid_positions(
       output_size: a scalar indicating the output crop size.
       sample_offset: a float number in [0, 1] indicates the subpixel sample offset
         from grid point.
+
     Returns:
       kernel_y: Tensor of size [batch_size, boxes, output_size, 2, 1].
       kernel_x: Tensor of size [batch_size, boxes, output_size, 2, 1].
@@ -149,10 +156,13 @@ def multilevel_crop_and_resize(
     output_size: int = 7,
     sample_offset: float = 0.5,
 ) -> tf.Tensor:
-    """Crop and resize on multilevel feature pyramid.
+    """
+    Crop and resize on multilevel feature pyramid.
+
     Generate the (output_size, output_size) set of pixels for each input box
     by first locating the box into the correct feature level, and then cropping
     and resizing it using the correspoding feature map of that level.
+
     Args:
       features: A dictionary with key as pyramid level and value as features. The
         features are in shape of [batch_size, height_l, width_l, num_filters].
@@ -161,6 +171,7 @@ def multilevel_crop_and_resize(
       output_size: A scalar to indicate the output crop size.
       sample_offset: a float number in [0, 1] indicates the subpixel sample offset
         from grid point.
+
     Returns:
       A 5-D tensor representing feature crop of shape
       [batch_size, num_boxes, output_size, output_size, num_filters].
@@ -322,7 +333,9 @@ class _ROIAligner(tf.keras.layers.Layer):
     def __init__(
         self, bounding_box_format, target_size=7, sample_offset: float = 0.5, **kwargs
     ):
-        """Initializes a ROI aligner.
+        """
+        Generates ROI Aligner.
+
         Args:
           bounding_box_format: the input format for boxes.
           crop_size: An `int` of the output size of the cropped features.
@@ -334,12 +347,16 @@ class _ROIAligner(tf.keras.layers.Layer):
             "crop_size": target_size,
             "sample_offset": sample_offset,
         }
-        super(_ROIAligner, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def call(
-        self, features: Mapping[str, tf.Tensor], boxes: tf.Tensor, training: bool = None
+        self,
+        features: Mapping[str, tf.Tensor],
+        boxes: tf.Tensor,
+        training: Optional[bool] = None,
     ):
-        """Generates ROIs.
+        """
+
         Args:
           features: A dictionary with key as pyramid level and value as features.
             The features are in shape of

--- a/keras_cv/layers/object_detection/roi_align.py
+++ b/keras_cv/layers/object_detection/roi_align.py
@@ -1,0 +1,367 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+from typing import Mapping
+from typing import Tuple
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+
+
+def _feature_bilinear_interpolation(
+    features: tf.Tensor, kernel_y: tf.Tensor, kernel_x: tf.Tensor
+) -> tf.Tensor:
+    """Feature bilinear interpolation.
+    The RoIAlign feature f can be computed by bilinear interpolation
+    of four neighboring feature points f0, f1, f2, and f3.
+    f(y, x) = [hy, ly] * [[f00, f01], * [hx, lx]^T
+                          [f10, f11]]
+    f(y, x) = (hy*hx)f00 + (hy*lx)f01 + (ly*hx)f10 + (lx*ly)f11
+    f(y, x) = w00*f00 + w01*f01 + w10*f10 + w11*f11
+    kernel_y = [hy, ly]
+    kernel_x = [hx, lx]
+    Args:
+      features: The features are in shape of [batch_size, num_boxes, output_size *
+        2, output_size * 2, num_filters].
+      kernel_y: Tensor of size [batch_size, boxes, output_size, 2, 1].
+      kernel_x: Tensor of size [batch_size, boxes, output_size, 2, 1].
+    Returns:
+      A 5-D tensor representing feature crop of shape
+      [batch_size, num_boxes, output_size, output_size, num_filters].
+    """
+    features_shape = tf.shape(features)
+    batch_size, num_boxes, output_size, num_filters = (
+        features_shape[0],
+        features_shape[1],
+        features_shape[2],
+        features_shape[4],
+    )
+
+    output_size = output_size // 2
+    kernel_y = tf.reshape(kernel_y, [batch_size, num_boxes, output_size * 2, 1])
+    kernel_x = tf.reshape(kernel_x, [batch_size, num_boxes, 1, output_size * 2])
+    # Use implicit broadcast to generate the interpolation kernel. The
+    # multiplier `4` is for avg pooling.
+    interpolation_kernel = kernel_y * kernel_x * 4
+
+    # Interpolate the gathered features with computed interpolation kernels.
+    features *= tf.cast(
+        tf.expand_dims(interpolation_kernel, axis=-1), dtype=features.dtype
+    )
+    features = tf.reshape(
+        features,
+        [batch_size * num_boxes, output_size * 2, output_size * 2, num_filters],
+    )
+    features = tf.nn.avg_pool(features, [1, 2, 2, 1], [1, 2, 2, 1], "VALID")
+    features = tf.reshape(
+        features, [batch_size, num_boxes, output_size, output_size, num_filters]
+    )
+    return features
+
+
+def _compute_grid_positions(
+    boxes: tf.Tensor, boundaries: tf.Tensor, output_size: int, sample_offset: float
+) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor]:
+    """Computes the grid position w.r.t.
+    the corresponding feature map.
+    Args:
+      boxes: a 3-D tensor of shape [batch_size, num_boxes, 4] encoding the
+        information of each box w.r.t. the corresponding feature map.
+        boxes[:, :, 0:2] are the grid position in (y, x) (float) of the top-left
+        corner of each box. boxes[:, :, 2:4] are the box sizes in (h, w) (float)
+          in terms of the number of pixels of the corresponding feature map size.
+      boundaries: a 3-D tensor of shape [batch_size, num_boxes, 2] representing
+        the boundary (in (y, x)) of the corresponding feature map for each box.
+        Any resampled grid points that go beyond the bounary will be clipped.
+      output_size: a scalar indicating the output crop size.
+      sample_offset: a float number in [0, 1] indicates the subpixel sample offset
+        from grid point.
+    Returns:
+      kernel_y: Tensor of size [batch_size, boxes, output_size, 2, 1].
+      kernel_x: Tensor of size [batch_size, boxes, output_size, 2, 1].
+      box_grid_y0y1: Tensor of size [batch_size, boxes, output_size, 2]
+      box_grid_x0x1: Tensor of size [batch_size, boxes, output_size, 2]
+    """
+    boxes_shape = tf.shape(boxes)
+    batch_size, num_boxes = boxes_shape[0], boxes_shape[1]
+    if batch_size is None:
+        batch_size = tf.shape(boxes)[0]
+    box_grid_x = []
+    box_grid_y = []
+    for i in range(output_size):
+        box_grid_x.append(
+            boxes[:, :, 1] + (i + sample_offset) * boxes[:, :, 3] / output_size
+        )
+        box_grid_y.append(
+            boxes[:, :, 0] + (i + sample_offset) * boxes[:, :, 2] / output_size
+        )
+    box_grid_x = tf.stack(box_grid_x, axis=2)
+    box_grid_y = tf.stack(box_grid_y, axis=2)
+
+    box_grid_y0 = tf.floor(box_grid_y)
+    box_grid_x0 = tf.floor(box_grid_x)
+    box_grid_x0 = tf.maximum(tf.cast(0.0, dtype=box_grid_x0.dtype), box_grid_x0)
+    box_grid_y0 = tf.maximum(tf.cast(0.0, dtype=box_grid_y0.dtype), box_grid_y0)
+
+    box_grid_x0 = tf.minimum(box_grid_x0, tf.expand_dims(boundaries[:, :, 1], -1))
+    box_grid_x1 = tf.minimum(box_grid_x0 + 1, tf.expand_dims(boundaries[:, :, 1], -1))
+    box_grid_y0 = tf.minimum(box_grid_y0, tf.expand_dims(boundaries[:, :, 0], -1))
+    box_grid_y1 = tf.minimum(box_grid_y0 + 1, tf.expand_dims(boundaries[:, :, 0], -1))
+
+    box_gridx0x1 = tf.stack([box_grid_x0, box_grid_x1], axis=-1)
+    box_gridy0y1 = tf.stack([box_grid_y0, box_grid_y1], axis=-1)
+
+    # The RoIAlign feature f can be computed by bilinear interpolation of four
+    # neighboring feature points f0, f1, f2, and f3.
+    # f(y, x) = [hy, ly] * [[f00, f01], * [hx, lx]^T
+    #                       [f10, f11]]
+    # f(y, x) = (hy*hx)f00 + (hy*lx)f01 + (ly*hx)f10 + (lx*ly)f11
+    # f(y, x) = w00*f00 + w01*f01 + w10*f10 + w11*f11
+    ly = box_grid_y - box_grid_y0
+    lx = box_grid_x - box_grid_x0
+    hy = 1.0 - ly
+    hx = 1.0 - lx
+    kernel_y = tf.reshape(
+        tf.stack([hy, ly], axis=3), [batch_size, num_boxes, output_size, 2, 1]
+    )
+    kernel_x = tf.reshape(
+        tf.stack([hx, lx], axis=3), [batch_size, num_boxes, output_size, 2, 1]
+    )
+    return kernel_y, kernel_x, box_gridy0y1, box_gridx0x1
+
+
+def multilevel_crop_and_resize(
+    features: Dict[str, tf.Tensor],
+    boxes: tf.Tensor,
+    output_size: int = 7,
+    sample_offset: float = 0.5,
+) -> tf.Tensor:
+    """Crop and resize on multilevel feature pyramid.
+    Generate the (output_size, output_size) set of pixels for each input box
+    by first locating the box into the correct feature level, and then cropping
+    and resizing it using the correspoding feature map of that level.
+    Args:
+      features: A dictionary with key as pyramid level and value as features. The
+        features are in shape of [batch_size, height_l, width_l, num_filters].
+      boxes: A 3-D Tensor of shape [batch_size, num_boxes, 4]. Each row represents
+        a box with [y1, x1, y2, x2] in un-normalized coordinates.
+      output_size: A scalar to indicate the output crop size.
+      sample_offset: a float number in [0, 1] indicates the subpixel sample offset
+        from grid point.
+    Returns:
+      A 5-D tensor representing feature crop of shape
+      [batch_size, num_boxes, output_size, output_size, num_filters].
+    """
+
+    with tf.name_scope("multilevel_crop_and_resize"):
+        levels = list(features.keys())
+        min_level = int(min(levels))
+        max_level = int(max(levels))
+        features_shape = tf.shape(features[min_level])
+        batch_size, max_feature_height, max_feature_width, num_filters = (
+            features_shape[0],
+            features_shape[1],
+            features_shape[2],
+            features_shape[3],
+        )
+
+        num_boxes = tf.shape(boxes)[1]
+
+        # Stack feature pyramid into a features_all of shape
+        # [batch_size, levels, height, width, num_filters].
+        features_all = []
+        feature_heights = []
+        feature_widths = []
+        for level in range(min_level, max_level + 1):
+            shape = features[level].get_shape().as_list()
+            feature_heights.append(shape[1])
+            feature_widths.append(shape[2])
+            # Concat tensor of [batch_size, height_l * width_l, num_filters] for each
+            # levels.
+            features_all.append(
+                tf.reshape(features[level], [batch_size, -1, num_filters])
+            )
+        features_r2 = tf.reshape(tf.concat(features_all, 1), [-1, num_filters])
+
+        # Calculate height_l * width_l for each level.
+        level_dim_sizes = [
+            feature_widths[i] * feature_heights[i] for i in range(len(feature_widths))
+        ]
+        # level_dim_offsets is accumulated sum of level_dim_size.
+        level_dim_offsets = [0]
+        for i in range(len(feature_widths) - 1):
+            level_dim_offsets.append(level_dim_offsets[i] + level_dim_sizes[i])
+        batch_dim_size = level_dim_offsets[-1] + level_dim_sizes[-1]
+        level_dim_offsets = tf.constant(level_dim_offsets, tf.int32)
+        height_dim_sizes = tf.constant(feature_widths, tf.int32)
+
+        # Assigns boxes to the right level.
+        box_width = boxes[:, :, 3] - boxes[:, :, 1]
+        box_height = boxes[:, :, 2] - boxes[:, :, 0]
+        areas_sqrt = tf.sqrt(
+            tf.cast(box_height, tf.float32) * tf.cast(box_width, tf.float32)
+        )
+
+        levels = tf.cast(
+            tf.math.floordiv(
+                tf.math.log(tf.math.divide_no_nan(areas_sqrt, 256.0)), tf.math.log(2.0)
+            )
+            + 4.0,
+            dtype=tf.int32,
+        )
+        # Maps levels between [min_level, max_level].
+        levels = tf.minimum(max_level, tf.maximum(levels, min_level))
+
+        # Projects box location and sizes to corresponding feature levels.
+        scale_to_level = tf.cast(
+            tf.pow(tf.constant(2.0), tf.cast(levels, tf.float32)), dtype=boxes.dtype
+        )
+        boxes /= tf.expand_dims(scale_to_level, axis=2)
+        box_width /= scale_to_level
+        box_height /= scale_to_level
+        boxes = tf.concat(
+            [
+                boxes[:, :, 0:2],
+                tf.expand_dims(box_height, -1),
+                tf.expand_dims(box_width, -1),
+            ],
+            axis=-1,
+        )
+
+        # Maps levels to [0, max_level-min_level].
+        levels -= min_level
+        level_strides = tf.pow([[2.0]], tf.cast(levels, tf.float32))
+        boundary = tf.cast(
+            tf.concat(
+                [
+                    tf.expand_dims(
+                        [[tf.cast(max_feature_height, tf.float32)]] / level_strides - 1,
+                        axis=-1,
+                    ),
+                    tf.expand_dims(
+                        [[tf.cast(max_feature_width, tf.float32)]] / level_strides - 1,
+                        axis=-1,
+                    ),
+                ],
+                axis=-1,
+            ),
+            boxes.dtype,
+        )
+
+        # Compute grid positions.
+        kernel_y, kernel_x, box_gridy0y1, box_gridx0x1 = _compute_grid_positions(
+            boxes, boundary, output_size, sample_offset
+        )
+
+        x_indices = tf.cast(
+            tf.reshape(box_gridx0x1, [batch_size, num_boxes, output_size * 2]),
+            dtype=tf.int32,
+        )
+        y_indices = tf.cast(
+            tf.reshape(box_gridy0y1, [batch_size, num_boxes, output_size * 2]),
+            dtype=tf.int32,
+        )
+
+        batch_size_offset = tf.tile(
+            tf.reshape(tf.range(batch_size) * batch_dim_size, [batch_size, 1, 1, 1]),
+            [1, num_boxes, output_size * 2, output_size * 2],
+        )
+        # Get level offset for each box. Each box belongs to one level.
+        levels_offset = tf.tile(
+            tf.reshape(
+                tf.gather(level_dim_offsets, levels), [batch_size, num_boxes, 1, 1]
+            ),
+            [1, 1, output_size * 2, output_size * 2],
+        )
+        y_indices_offset = tf.tile(
+            tf.reshape(
+                y_indices * tf.expand_dims(tf.gather(height_dim_sizes, levels), -1),
+                [batch_size, num_boxes, output_size * 2, 1],
+            ),
+            [1, 1, 1, output_size * 2],
+        )
+        x_indices_offset = tf.tile(
+            tf.reshape(x_indices, [batch_size, num_boxes, 1, output_size * 2]),
+            [1, 1, output_size * 2, 1],
+        )
+        indices = tf.reshape(
+            batch_size_offset + levels_offset + y_indices_offset + x_indices_offset,
+            [-1],
+        )
+
+        # TODO(tanzhenyu): replace tf.gather with tf.gather_nd and try to get similar
+        # performance.
+        features_per_box = tf.reshape(
+            tf.gather(features_r2, indices),
+            [batch_size, num_boxes, output_size * 2, output_size * 2, num_filters],
+        )
+
+        # Bilinear interpolation.
+        features_per_box = _feature_bilinear_interpolation(
+            features_per_box, kernel_y, kernel_x
+        )
+        return features_per_box
+
+
+class _ROIAligner(tf.keras.layers.Layer):
+    """Performs ROIAlign for the second stage processing."""
+
+    def __init__(
+        self, bounding_box_format, target_size=7, sample_offset: float = 0.5, **kwargs
+    ):
+        """Initializes a ROI aligner.
+        Args:
+          bounding_box_format: the input format for boxes.
+          crop_size: An `int` of the output size of the cropped features.
+          sample_offset: A `float` in [0, 1] of the subpixel sample offset.
+          **kwargs: Additional keyword arguments passed to Layer.
+        """
+        self._config_dict = {
+            "bounding_box_format": bounding_box_format,
+            "crop_size": target_size,
+            "sample_offset": sample_offset,
+        }
+        super(_ROIAligner, self).__init__(**kwargs)
+
+    def call(
+        self, features: Mapping[str, tf.Tensor], boxes: tf.Tensor, training: bool = None
+    ):
+        """Generates ROIs.
+        Args:
+          features: A dictionary with key as pyramid level and value as features.
+            The features are in shape of
+            [batch_size, height_l, width_l, num_filters].
+          boxes: A 3-D `tf.Tensor` of shape [batch_size, num_boxes, 4]. Each row
+            represents a box with [y1, x1, y2, x2] in un-normalized coordinates.
+            from grid point.
+          training: A `bool` of whether it is in training mode.
+        Returns:
+          A 5-D `tf.Tensor` representing feature crop of shape
+          [batch_size, num_boxes, crop_size, crop_size, num_filters].
+        """
+        boxes = bounding_box.convert_format(
+            boxes, source=self._config_dict["bounding_box_format"], target="yxyx"
+        )
+        roi_features = multilevel_crop_and_resize(
+            features,
+            boxes,
+            output_size=self._config_dict["crop_size"],
+            sample_offset=self._config_dict["sample_offset"],
+        )
+        return roi_features
+
+    def get_config(self):
+        return self._config_dict

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -73,7 +73,8 @@ class _ROISampler(tf.keras.layers.Layer):
         self.num_sampled_rois = num_sampled_rois
         self.append_gt_boxes = append_gt_boxes
         self.built = True
-        self.positives = self.add_weight(
+        # for debugging.
+        self._positives = self.add_weight(
             shape=[],
             initializer="zeros",
             dtype=tf.float32,
@@ -123,7 +124,7 @@ class _ROISampler(tf.keras.layers.Layer):
         matched_gt_cols, matched_vals = self.roi_matcher(similarity_mat)
         # [batch_size, num_rois]
         positive_matches = tf.math.equal(matched_vals, 1)
-        self.positives.assign_add(tf.reduce_sum(tf.cast(positive_matches, tf.float32)))
+        self._positives.assign_add(tf.reduce_sum(tf.cast(positive_matches, tf.float32)))
         negative_matches = tf.math.equal(matched_vals, -1)
         # [batch_size, num_rois, 1]
         background_mask = tf.expand_dims(tf.logical_not(positive_matches), axis=-1)

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -110,14 +110,14 @@ class _ROISampler(tf.keras.layers.Layer):
                 f"num_rois must be less than `num_sampled_rois` ({self.num_sampled_rois}), got {num_rois}"
             )
         rois = bounding_box.convert_format(
-            rois, source=self.bounding_box_format, target="xyxy"
+            rois, source=self.bounding_box_format, target="yxyx"
         )
         gt_boxes = bounding_box.convert_format(
-            gt_boxes, source=self.bounding_box_format, target="xyxy"
+            gt_boxes, source=self.bounding_box_format, target="yxyx"
         )
         # [batch_size, num_rois, num_gt]
         similarity_mat = iou.compute_iou(
-            rois, gt_boxes, bounding_box_format="xyxy", use_masking=True
+            rois, gt_boxes, bounding_box_format="yxyx", use_masking=True
         )
         # [batch_size, num_rois] | [batch_size, num_rois]
         matched_gt_cols, matched_vals = self.roi_matcher(similarity_mat)
@@ -140,7 +140,7 @@ class _ROISampler(tf.keras.layers.Layer):
         )
         # [batch_size, num_rois, 4]
         matched_gt_boxes = target_gather._target_gather(gt_boxes, matched_gt_cols)
-        encoded_matched_gt_boxes = bounding_box._encode(
+        encoded_matched_gt_boxes = bounding_box._encode_box_to_deltas(
             rois, matched_gt_boxes, "xyxy", "xyxy"
         )
         # also set all background matches to 0 coordinates

--- a/keras_cv/layers/object_detection/rpn_label_encoder.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder.py
@@ -102,13 +102,13 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
             pack = True
             anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
         anchors = bounding_box.convert_format(
-            anchors, source=self.anchor_format, target="xyxy"
+            anchors, source=self.anchor_format, target="yxyx"
         )
         gt_boxes = bounding_box.convert_format(
-            gt_boxes, source=self.gt_box_format, target="xyxy"
+            gt_boxes, source=self.gt_box_format, target="yxyx"
         )
         # [num_anchors, num_gt]
-        similarity_mat = iou.compute_iou(anchors, gt_boxes, bounding_box_format="xyxy")
+        similarity_mat = iou.compute_iou(anchors, gt_boxes, bounding_box_format="yxyx")
         # [num_anchors]
         matched_gt_indices, matched_vals = self.box_matcher(similarity_mat)
         # [num_anchors]
@@ -117,8 +117,8 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
         # [num_anchors, 4]
         matched_gt_boxes = target_gather._target_gather(gt_boxes, matched_gt_indices)
         # [num_anchors, 4], used as `y_true` for regression loss
-        encoded_box_targets = bounding_box._encode(
-            anchors, matched_gt_boxes, anchor_format="xyxy", box_format="xyxy"
+        encoded_box_targets = bounding_box._encode_box_to_deltas(
+            anchors, matched_gt_boxes, anchor_format="yxyx", box_format="yxyx"
         )
         # [num_anchors, 1]
         box_sample_weights = tf.cast(positive_matches[..., tf.newaxis], gt_boxes.dtype)

--- a/keras_cv/layers/object_detection/rpn_label_encoder.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder.py
@@ -29,8 +29,8 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
     # TODO(tanzhenyu): consider unifying with _ROISampler.
     This is different from _ROISampler for a couple of reasons:
     1) This deals with unbatched input, dict of anchors and potentially ragged labels
-    2) This deals with gt boxes, while _ROISampler deals with padded gt
-       boxes with value -1 and padded gt classes with value -1
+    2) This deals with ground truth boxes, while _ROISampler deals with padded ground truth
+       boxes with value -1 and padded ground truth classes with value -1
     3) this returns positive class target as 1, while _ROISampler returns
        positive class target as-is. (All negative class target are 0)
        The final classification loss will use one hot and #num_fg_classes + 1
@@ -44,10 +44,10 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
       anchor_format: The format of bounding boxes for anchors to generate. Refer
         [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
         for more details on supported bounding box formats.
-      gt_box_format: The format of bounding boxes for ground truth boxes to generate.
-      positive_threshold: the threshold to set an anchor to positive match to gt box.
+      ground_truth_box_format: The format of bounding boxes for ground truth boxes to generate.
+      positive_threshold: the float threshold to set an anchor to positive match to gt box.
         values above it are positive matches.
-      negative_threshold: the threshold to set an anchor to negative match to gt box.
+      negative_threshold: the float threshold to set an anchor to negative match to gt box.
         values below it are negative matches.
       samples_per_image: for each image, the number of positive and negative samples
         to generate.
@@ -58,7 +58,7 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
     def __init__(
         self,
         anchor_format,
-        gt_box_format,
+        ground_truth_box_format,
         positive_threshold,
         negative_threshold,
         samples_per_image,
@@ -67,7 +67,7 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
     ):
         super().__init__(**kwargs)
         self.anchor_format = anchor_format
-        self.gt_box_format = gt_box_format
+        self.ground_truth_box_format = ground_truth_box_format
         self.positive_threshold = positive_threshold
         self.negative_threshold = negative_threshold
         self.samples_per_image = samples_per_image
@@ -105,7 +105,7 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
             anchors, source=self.anchor_format, target="yxyx"
         )
         gt_boxes = bounding_box.convert_format(
-            gt_boxes, source=self.gt_box_format, target="yxyx"
+            gt_boxes, source=self.ground_truth_box_format, target="yxyx"
         )
         # [num_anchors, num_gt]
         similarity_mat = iou.compute_iou(anchors, gt_boxes, bounding_box_format="yxyx")
@@ -167,7 +167,7 @@ class _RpnLabelEncoder(tf.keras.layers.Layer):
     def get_config(self):
         config = {
             "anchor_format": self.anchor_format,
-            "gt_box_format": self.gt_box_format,
+            "ground_truth_box_format": self.ground_truth_box_format,
             "positive_threshold": self.positive_threshold,
             "negative_threshold": self.negative_threshold,
             "samples_per_image": self.samples_per_image,

--- a/keras_cv/layers/object_detection/rpn_label_encoder.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder.py
@@ -1,0 +1,176 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Mapping
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+from keras_cv.bounding_box import iou
+from keras_cv.ops import box_matcher
+from keras_cv.ops import sampling
+from keras_cv.ops import target_gather
+
+
+class _RpnLabelEncoder(tf.keras.layers.Layer):
+    """Transforms the raw labels into training targets for region proposal network (RPN).
+
+    # TODO(tanzhenyu): consider unifying with _ROISampler.
+    This is different from _ROISampler for a couple of reasons:
+    1) This deals with unbatched input, dict of anchors and potentially ragged labels
+    2) This deals with gt boxes, while _ROISampler deals with padded gt
+       boxes with value -1 and padded gt classes with value -1
+    3) this returns positive class target as 1, while _ROISampler returns
+       positive class target as-is. (All negative class target are 0)
+       The final classification loss will use one hot and #num_fg_classes + 1
+    4) this returns #num_anchors dense targets, while _ROISampler returns
+       #num_sampled_rois dense targets.
+    5) this returns all positive box targets, while _ROISampler still samples
+       positive box targets, while all negative box targets are also ignored
+       in regression loss.
+
+    Args:
+      anchor_format: The format of bounding boxes for anchors to generate. Refer
+        [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
+        for more details on supported bounding box formats.
+      gt_box_format: The format of bounding boxes for ground truth boxes to generate.
+      positive_threshold: the threshold to set an anchor to positive match to gt box.
+        values above it are positive matches.
+      negative_threshold: the threshold to set an anchor to negative match to gt box.
+        values below it are negative matches.
+      samples_per_image: for each image, the number of positive and negative samples
+        to generate.
+      positive_fraction: the fraction of positive samples to the total samples.
+
+    """
+
+    def __init__(
+        self,
+        anchor_format,
+        gt_box_format,
+        positive_threshold,
+        negative_threshold,
+        samples_per_image,
+        positive_fraction,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.anchor_format = anchor_format
+        self.gt_box_format = gt_box_format
+        self.positive_threshold = positive_threshold
+        self.negative_threshold = negative_threshold
+        self.samples_per_image = samples_per_image
+        self.positive_fraction = positive_fraction
+        self.box_matcher = box_matcher.ArgmaxBoxMatcher(
+            thresholds=[negative_threshold, positive_threshold],
+            match_values=[-1, -2, 1],
+            force_match_for_each_col=True,
+        )
+        self.built = True
+
+    def call(
+        self,
+        anchors_dict: Mapping[str, tf.Tensor],
+        gt_boxes: tf.Tensor,
+        gt_classes: tf.Tensor,
+    ):
+        """
+        Args:
+          anchors: dict of [num_anchors, 4] for each level.
+          gt_boxes: [num_gt, 4]
+          gt_classes: [num_gt, 1]
+        Returns:
+          box_targets: dict of [num_anchors, 4] for each level.
+          box_weights: dict of [num_anchors, 1] for each level.
+          class_targets: dict of [num_anchors, 1] for each level.
+          class_weights: dict of [num_anchors, 1] for each level.
+        """
+        pack = False
+        anchors = anchors_dict
+        if isinstance(anchors, dict):
+            pack = True
+            anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
+        anchors = bounding_box.convert_format(
+            anchors, source=self.anchor_format, target="xyxy"
+        )
+        gt_boxes = bounding_box.convert_format(
+            gt_boxes, source=self.gt_box_format, target="xyxy"
+        )
+        # [num_anchors, num_gt]
+        similarity_mat = iou.compute_iou(anchors, gt_boxes, bounding_box_format="xyxy")
+        # [num_anchors]
+        matched_gt_indices, matched_vals = self.box_matcher(similarity_mat)
+        # [num_anchors]
+        positive_matches = tf.math.equal(matched_vals, 1)
+        negative_matches = tf.math.equal(matched_vals, -1)
+        # [num_anchors, 4]
+        matched_gt_boxes = target_gather._target_gather(gt_boxes, matched_gt_indices)
+        # [num_anchors, 4], used as `y_true` for regression loss
+        encoded_box_targets = bounding_box._encode(
+            anchors, matched_gt_boxes, anchor_format="xyxy", box_format="xyxy"
+        )
+        # [num_anchors, 1]
+        box_sample_weights = tf.cast(positive_matches[..., tf.newaxis], gt_boxes.dtype)
+
+        # [num_anchors, 1]
+        positive_mask = tf.expand_dims(positive_matches, axis=-1)
+        # set all negative and ignored matches to 0, and all positive matches to 1
+        positive_classes = tf.ones_like(positive_mask, dtype=gt_classes.dtype)
+        negative_classes = tf.zeros_like(positive_mask, dtype=gt_classes.dtype)
+        # [num_anchors, 1]
+        class_targets = tf.where(positive_mask, positive_classes, negative_classes)
+        # [num_anchors]
+        sampled_indicators = sampling.balanced_sample(
+            positive_matches,
+            negative_matches,
+            self.samples_per_image,
+            self.positive_fraction,
+        )
+        # [num_anchors, 1]
+        class_sample_weights = tf.cast(
+            sampled_indicators[..., tf.newaxis], gt_classes.dtype
+        )
+        if pack:
+            encoded_box_targets = self.unpack_targets(encoded_box_targets, anchors_dict)
+            box_sample_weights = self.unpack_targets(box_sample_weights, anchors_dict)
+            class_targets = self.unpack_targets(class_targets, anchors_dict)
+            class_sample_weights = self.unpack_targets(
+                class_sample_weights, anchors_dict
+            )
+        return (
+            encoded_box_targets,
+            box_sample_weights,
+            class_targets,
+            class_sample_weights,
+        )
+
+    def unpack_targets(self, targets, anchors_dict):
+        unpacked_targets = {}
+        count = 0
+        for level, anchors in anchors_dict.items():
+            num_anchors_lvl = anchors.get_shape().as_list()[0]
+            unpacked_targets[level] = targets[count : count + num_anchors_lvl, ...]
+            count += num_anchors_lvl
+        return unpacked_targets
+
+    def get_config(self):
+        config = {
+            "anchor_format": self.anchor_format,
+            "gt_box_format": self.gt_box_format,
+            "positive_threshold": self.positive_threshold,
+            "negative_threshold": self.negative_threshold,
+            "samples_per_image": self.samples_per_image,
+            "positive_fraction": self.positive_fraction,
+        }
+        return config

--- a/keras_cv/layers/object_detection/rpn_label_encoder_test.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder_test.py
@@ -21,7 +21,7 @@ class RpnLabelEncoderTest(tf.test.TestCase):
     def test_rpn_label_encoder(self):
         rpn_encoder = _RpnLabelEncoder(
             anchor_format="xyxy",
-            gt_box_format="xyxy",
+            ground_truth_box_format="xyxy",
             positive_threshold=0.7,
             negative_threshold=0.3,
             positive_fraction=0.5,
@@ -59,7 +59,7 @@ class RpnLabelEncoderTest(tf.test.TestCase):
     def test_rpn_label_encoder_multi_level(self):
         rpn_encoder = _RpnLabelEncoder(
             anchor_format="xyxy",
-            gt_box_format="xyxy",
+            ground_truth_box_format="xyxy",
             positive_threshold=0.7,
             negative_threshold=0.3,
             positive_fraction=0.5,

--- a/keras_cv/layers/object_detection/rpn_label_encoder_test.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder_test.py
@@ -1,0 +1,83 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
+
+
+class RpnLabelEncoderTest(tf.test.TestCase):
+    def test_rpn_label_encoder(self):
+        rpn_encoder = _RpnLabelEncoder(
+            anchor_format="xyxy",
+            gt_box_format="xyxy",
+            positive_threshold=0.7,
+            negative_threshold=0.3,
+            positive_fraction=0.5,
+            samples_per_image=2,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant([[10, 10, 15, 15], [2.5, 2.5, 7.5, 7.5]])
+        gt_classes = tf.constant([2, 10, -1], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        box_targets, box_weights, cls_targets, cls_weights = rpn_encoder(
+            rois, gt_boxes, gt_classes
+        )
+        # all rois will be matched to the 2nd gt boxes, and encoded
+        expected_box_targets = tf.constant(
+            [
+                [0.5, 0.5, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [-0.5, -0.5, 0.0, 0.0],
+                [0.5, 0.5, 0.0, 0.0],
+            ]
+        )
+        self.assertAllClose(expected_box_targets, box_targets)
+        # only foreground and background classes
+        self.assertAllClose(tf.reduce_max(cls_targets), 1.0)
+        self.assertAllClose(tf.reduce_min(cls_targets), 0.0)
+        # all weights between 0 and 1
+        self.assertAllClose(tf.reduce_max(cls_weights), 1.0)
+        self.assertAllClose(tf.reduce_min(cls_weights), 0.0)
+        self.assertAllClose(tf.reduce_max(box_weights), 1.0)
+        self.assertAllClose(tf.reduce_min(box_weights), 0.0)
+
+    def test_rpn_label_encoder_multi_level(self):
+        rpn_encoder = _RpnLabelEncoder(
+            anchor_format="xyxy",
+            gt_box_format="xyxy",
+            positive_threshold=0.7,
+            negative_threshold=0.3,
+            positive_fraction=0.5,
+            samples_per_image=2,
+        )
+        rois = {
+            2: tf.constant([[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5]]),
+            3: tf.constant([[5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]),
+        }
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant([[10, 10, 15, 15], [2.5, 2.5, 7.5, 7.5]])
+        gt_classes = tf.constant([2, 10, -1], dtype=tf.float32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        _, _, _, cls_weights = rpn_encoder(rois, gt_boxes, gt_classes)
+        # the 2nd level found 2 positive matches, the 3rd level found no match
+        expected_cls_weights = {
+            2: tf.constant([[1.0], [1.0]]),
+            3: tf.constant([[0.0], [0.0]]),
+        }
+        self.assertAllClose(expected_cls_weights[2], cls_weights[2])
+        self.assertAllClose(expected_cls_weights[3], cls_weights[3])

--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -43,6 +43,7 @@ from keras_cv.models.mlp_mixer import MLPMixerB32
 from keras_cv.models.mlp_mixer import MLPMixerL16
 from keras_cv.models.mobilenet_v3 import MobileNetV3Large
 from keras_cv.models.mobilenet_v3 import MobileNetV3Small
+from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 from keras_cv.models.object_detection.retina_net.retina_net import RetinaNet
 from keras_cv.models.resnet_v1 import ResNet18
 from keras_cv.models.resnet_v1 import ResNet34

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -1,0 +1,326 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+from keras_cv.bounding_box.converters import _decode
+from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
+from keras_cv.layers.object_detection.roi_generator import ROIGenerator
+from keras_cv.layers.object_detection.roi_sampler import _ROISampler
+from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
+from keras_cv.layers.object_detection.roi_align import _ROIAligner
+from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
+
+
+def _resnet50_backbone():
+    inputs = tf.keras.layers.Input(shape=(None, None, 3))
+    x = inputs
+
+    backbone = tf.keras.applications.ResNet50(include_top=False, input_tensor=x)
+
+    c2_output, c3_output, c4_output, c5_output = [
+        backbone.get_layer(layer_name).output
+        for layer_name in [
+            "conv2_block3_out",
+            "conv3_block4_out",
+            "conv4_block6_out",
+            "conv5_block3_out",
+        ]
+    ]
+    return tf.keras.Model(
+        inputs=inputs, outputs=[c2_output, c3_output, c4_output, c5_output]
+    )
+
+
+class FeaturePyramid(tf.keras.layers.Layer):
+    """Builds the Feature Pyramid with the feature maps from the backbone."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.conv_c2_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
+        self.conv_c3_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
+        self.conv_c4_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
+        self.conv_c5_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
+        self.conv_c6_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
+
+        self.conv_c2_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
+        self.conv_c3_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
+        self.conv_c4_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
+        self.conv_c5_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
+        self.conv_c6_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
+        self.conv_c6_pool = tf.keras.layers.MaxPool2D()
+        self.upsample_2x = tf.keras.layers.UpSampling2D(2)
+
+    def call(self, inputs, training=None):
+        c2_output, c3_output, c4_output, c5_output = inputs
+
+        c6_output = self.conv_c6_pool(c5_output)
+        p6_output = self.conv_c6_1x1(c6_output)
+        p5_output = self.conv_c5_1x1(c5_output)
+        p4_output = self.conv_c4_1x1(c4_output)
+        p3_output = self.conv_c3_1x1(c3_output)
+        p2_output = self.conv_c2_1x1(c2_output)
+
+        p5_output = p5_output + self.upsample_2x(p6_output)
+        p4_output = p4_output + self.upsample_2x(p5_output)
+        p3_output = p3_output + self.upsample_2x(p4_output)
+        p2_output = p2_output + self.upsample_2x(p3_output)
+
+        p6_output = self.conv_c6_3x3(p6_output)
+        p5_output = self.conv_c5_3x3(p5_output)
+        p4_output = self.conv_c4_3x3(p4_output)
+        p3_output = self.conv_c3_3x3(p3_output)
+        p2_output = self.conv_c2_3x3(p2_output)
+
+        return {2: p2_output, 3: p3_output, 4: p4_output, 5: p5_output, 6: p6_output}
+
+    def get_config(self):
+        config = {}
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class RPNHead(tf.keras.layers.Layer):
+    def __init__(
+        self,
+        num_anchors_per_location=3,
+        **kwargs,
+    ):
+        super(RPNHead, self).__init__(**kwargs)
+        self.num_anchors = num_anchors_per_location
+
+    def build(self, input_shape):
+        if isinstance(input_shape, (dict, list, tuple)):
+            input_shape = tf.nest.flatten(input_shape)
+            input_shape = input_shape[0]
+        filters = input_shape[-1]
+        self.conv = tf.keras.layers.Conv2D(
+            filters=filters,
+            kernel_size=3,
+            strides=1,
+            padding="same",
+            activation="relu",
+            kernel_initializer="truncated_normal",
+        )
+        self.objectness_logits = tf.keras.layers.Conv2D(
+            filters=self.num_anchors * 1,
+            kernel_size=1,
+            strides=1,
+            padding="same",
+            kernel_initializer="truncated_normal",
+        )
+        self.anchor_deltas = tf.keras.layers.Conv2D(
+            filters=self.num_anchors * 4,
+            kernel_size=1,
+            strides=1,
+            padding="same",
+            kernel_initializer="truncated_normal",
+        )
+
+    def call(self, feature_map):
+        def call_single_level(f_map):
+            batch_size = f_map.get_shape().as_list()[0]
+            if batch_size is None:
+                raise ValueError("Cannot handle static shape")
+            # [BS, H, W, C]
+            t = self.conv(f_map)
+            # [BS, H, W, K]
+            rpn_scores = self.objectness_logits(t)
+            # [BS, H, W, K * 4]
+            rpn_boxes = self.anchor_deltas(t)
+            # [BS, H*W*K, 4]
+            rpn_boxes = tf.reshape(rpn_boxes, [batch_size, -1, 4])
+            # [BS, H*W*K, 1]
+            rpn_scores = tf.reshape(rpn_scores, [batch_size, -1, 1])
+            return rpn_boxes, rpn_scores
+
+        if not isinstance(feature_map, (dict, list, tuple)):
+            return call_single_level(feature_map)
+        elif isinstance(feature_map, (list, tuple)):
+            rpn_boxes = []
+            rpn_scores = []
+            for f_map in feature_map:
+                rpn_box, rpn_score = call_single_level(f_map)
+                rpn_boxes.append(rpn_box)
+                rpn_scores.append(rpn_score)
+            rpn_boxes = tf.concat(rpn_boxes, axis=1)
+            rpn_scores = tf.concat(rpn_scores, axis=1)
+            return rpn_boxes, rpn_scores
+        else:
+            rpn_boxes = {}
+            rpn_scores = {}
+            for lvl, f_map in feature_map.items():
+                rpn_box, rpn_score = call_single_level(f_map)
+                rpn_boxes[lvl] = rpn_box
+                rpn_scores[lvl] = rpn_score
+            rpn_boxes = tf.concat(tf.nest.flatten(rpn_boxes), axis=1)
+            rpn_scores = tf.concat(tf.nest.flatten(rpn_scores), axis=1)
+            return rpn_boxes, rpn_scores
+
+    def get_config(self):
+        config = {
+            "num_anchors_per_location": self.num_anchors,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+# class agnostic regression
+class RCNNHead(tf.keras.layers.Layer):
+    def __init__(
+        self,
+        classes,
+        conv_dims=[],
+        fc_dims=[1024, 1024],
+        **kwargs,
+    ):
+        super(RCNNHead, self).__init__(**kwargs)
+        self.num_classes = classes
+        self.conv_dims = conv_dims
+        self.fc_dims = fc_dims
+        self.convs = []
+        for conv_dim in conv_dims:
+            layer = tf.keras.layers.Conv2D(
+                filters=conv_dim,
+                kernel_size=3,
+                strides=1,
+                padding="same",
+                activation="relu",
+            )
+            self.convs.append(layer)
+        self.fcs = []
+        for fc_dim in fc_dims:
+            layer = tf.keras.layers.Dense(units=fc_dim, activation="relu")
+            self.fcs.append(layer)
+        self.box_pred = tf.keras.layers.Dense(units=4)
+        self.cls_score = tf.keras.layers.Dense(units=classes + 1)
+
+    def call(self, feature_map):
+        x = feature_map
+        for conv in self.convs:
+            x = conv(x)
+        for fc in self.fcs:
+            x = fc(x)
+        rcnn_boxes = self.box_pred(x)
+        rcnn_scores = self.cls_score(x)
+        return rcnn_boxes, rcnn_scores
+
+    def get_config(self):
+        config = {
+            "classes": self.num_classes,
+            "conv_dims": self.conv_dims,
+            "fc_dims": self.fc_dims,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+# TODO(tanzheny): add more configurations
+class FasterRCNN(tf.keras.Model):
+    def __init__(
+        self,
+        classes,
+        bounding_box_format,
+        backbone=None,
+        **kwargs,
+    ):
+        self.bounding_box_format = bounding_box_format
+        super(FasterRCNN, self).__init__(**kwargs)
+        self.anchor_generator = AnchorGenerator(
+            bounding_box_format="xyxy",
+            sizes={2: 16.0, 3: 32.0, 4: 64.0, 5: 128.0, 6: 256.0},
+            scales=[2**x for x in [0, 1 / 3, 2 / 3]],
+            aspect_ratios=[0.5, 1.0, 2.0],
+            strides={i: 2**i for i in range(2, 7)},
+            clip_boxes=True,
+        )
+        self.rpn_head = RPNHead(num_anchors_per_location=9)
+        self.roi_generator = ROIGenerator(bounding_box_format="xyxy")
+        self.box_matcher = ArgmaxBoxMatcher(
+            thresholds=[0.0, 0.5], match_values=[-2, -1, 1]
+        )
+        self.roi_sampler = _ROISampler(
+            bounding_box_format="xyxy",
+            roi_matcher=self.box_matcher,
+            background_class=classes,
+            num_sampled_rois=512,
+        )
+        self.roi_pooler = _ROIAligner(bounding_box_format="xyxy")
+        self.rcnn_head = RCNNHead(classes)
+        self.backbone = backbone or _resnet50_backbone()
+        self.feature_pyramid = FeaturePyramid()
+        self.rpn_labeler = _RpnLabelEncoder(
+            anchor_format="xyxy",
+            gt_box_format="yxyx",
+            positive_threshold=0.7,
+            negative_threshold=0.3,
+            samples_per_image=256,
+            positive_fraction=0.5,
+        )
+
+    def call(self, images, gt_boxes=None, gt_classes=None, training=None):
+        feature_map = self.backbone(images, training=training)
+        feature_map = self.feature_pyramid(feature_map, training=training)
+        # [BS, num_anchors, 4], [BS, num_anchors, 1]
+        rpn_boxes, rpn_scores = self.rpn_head(feature_map)
+        anchors = self.anchor_generator(image_shape=tf.shape(images[0]))
+        if isinstance(anchors, (dict, list, tuple)):
+            anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
+        anchors = tf.reshape(anchors, [-1, 4])
+        # the decoded format is center_xywh
+        decoded_rpn_boxes = _decode(anchors, rpn_boxes, "xyxy")
+        decoded_rpn_boxes = bounding_box.convert_format(
+            decoded_rpn_boxes, source="center_xywh", target="xyxy"
+        )
+        rois, _ = self.roi_generator(
+            decoded_rpn_boxes, tf.squeeze(rpn_scores, axis=-1), training=training
+        )
+        if training:
+            rois = tf.stop_gradient(rois)
+            (
+                rois,
+                rcnn_box_targets,
+                rcnn_box_weights,
+                rcnn_cls_targets,
+                rcnn_cls_weights,
+            ) = self.roi_sampler(rois, gt_boxes, gt_classes)
+        feature_map = self.roi_pooler(feature_map, rois)
+        # [BS, H*W*K, pool_shape*C]
+        feature_map = tf.reshape(
+            feature_map, tf.concat([tf.shape(rois)[:2], [-1]], axis=0)
+        )
+        # [BS, H*W*K, 4], [BS, H*W*K, num_classes + 1]
+        rcnn_box_pred, rcnn_cls_pred = self.rcnn_head(feature_map)
+        res = {}
+        if training:
+            res["rcnn_box_pred"] = rcnn_box_pred
+            res["rcnn_cls_pred"] = rcnn_cls_pred
+            res["rpn_box_pred"] = rpn_boxes
+            res["rpn_cls_pred"] = rpn_scores
+            res["rcnn_box_targets"] = rcnn_box_targets
+            res["rcnn_box_weights"] = rcnn_box_weights
+            res["rcnn_cls_targets"] = rcnn_cls_targets
+            res["rcnn_cls_weights"] = rcnn_cls_weights
+        else:
+            # now it will be on "center_xywh" format
+            rois = bounding_box.convert_format(rois, source="yxyx", target="xyxy")
+            rcnn_box_pred = _decode(rois, rcnn_box_pred, anchor_format="xyxy")
+            rcnn_box_pred = bounding_box.convert_format(
+                rcnn_box_pred, source="center_xywh", target="yxyx"
+            )
+            res["rcnn_box_pred"] = rcnn_box_pred
+            res["rcnn_cls_pred"] = rcnn_cls_pred
+
+        return res

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -17,10 +17,10 @@ import tensorflow as tf
 from keras_cv import bounding_box
 from keras_cv.bounding_box.converters import _decode
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
+from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
-from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -273,12 +273,14 @@ class FasterRCNN(tf.keras.Model):
         self.anchor_generator = AnchorGenerator(
             bounding_box_format="yxyx",
             sizes={2: 16.0, 3: 32.0, 4: 64.0, 5: 128.0, 6: 256.0},
-            scales=[2**x for x in [0, 1 / 3, 2 / 3]],
-            aspect_ratios=[0.5, 1.0, 2.0],
+            # scales=[2**x for x in [0, 1 / 3, 2 / 3]],
+            scales=[2**x for x in [0]],
+            # aspect_ratios=[0.5, 1.0, 2.0],
+            aspect_ratios=[1.0],
             strides={i: 2**i for i in range(2, 7)},
             clip_boxes=True,
         )
-        self.rpn_head = RPNHead(num_anchors_per_location=9)
+        self.rpn_head = RPNHead(num_anchors_per_location=1)
         self.roi_generator = ROIGenerator(bounding_box_format="yxyx")
         self.box_matcher = ArgmaxBoxMatcher(
             thresholds=[0.0, 0.5], match_values=[-2, -1, 1]
@@ -295,7 +297,7 @@ class FasterRCNN(tf.keras.Model):
         self.feature_pyramid = FeaturePyramid()
         self.rpn_labeler = _RpnLabelEncoder(
             anchor_format="yxyx",
-            gt_box_format="yxyx",
+            ground_truth_box_format="yxyx",
             positive_threshold=0.7,
             negative_threshold=0.3,
             samples_per_image=256,

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -273,14 +273,12 @@ class FasterRCNN(tf.keras.Model):
         self.anchor_generator = AnchorGenerator(
             bounding_box_format="yxyx",
             sizes={2: 16.0, 3: 32.0, 4: 64.0, 5: 128.0, 6: 256.0},
-            # scales=[2**x for x in [0, 1 / 3, 2 / 3]],
-            scales=[2**x for x in [0]],
-            # aspect_ratios=[0.5, 1.0, 2.0],
-            aspect_ratios=[1.0],
+            scales=[2**x for x in [0, 1 / 3, 2 / 3]],
+            aspect_ratios=[0.5, 1.0, 2.0],
             strides={i: 2**i for i in range(2, 7)},
             clip_boxes=True,
         )
-        self.rpn_head = RPNHead(num_anchors_per_location=1)
+        self.rpn_head = RPNHead(num_anchors_per_location=9)
         self.roi_generator = ROIGenerator(bounding_box_format="yxyx")
         self.box_matcher = ArgmaxBoxMatcher(
             thresholds=[0.0, 0.5], match_values=[-2, -1, 1]

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -1,0 +1,72 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
+
+
+class FasterRCNNTest(tf.test.TestCase):
+    def test_faster_rcnn_infer(self):
+        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        images = tf.random.normal([2, 512, 512, 3])
+        gt_boxes = tf.constant(
+            [
+                [[32.0, 32.0, 64.0, 64.0], [-1.0, -1.0, -1.0, -1.0]],
+                [[32.0, 32.0, 128.0, 128.0], [128.0, 128.0, 156.0, 156.0]],
+            ]
+        )
+        gt_classes = tf.constant(
+            [
+                [[1.0], [-1.0]],
+                [
+                    [
+                        25.0,
+                    ],
+                    [76.0],
+                ],
+            ]
+        )
+        outputs = model(images, gt_boxes, gt_classes, training=False)
+        # 1000 proposals in inference
+        self.assertAllEqual([2, 1000, 81], outputs["rcnn_cls_pred"].shape)
+        self.assertAllEqual([2, 1000, 4], outputs["rcnn_box_pred"].shape)
+
+    def test_faster_rcnn_train(self):
+        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        images = tf.random.normal([2, 512, 512, 3])
+        gt_boxes = tf.constant(
+            [
+                [[32.0, 32.0, 64.0, 64.0], [-1.0, -1.0, -1.0, -1.0]],
+                [[32.0, 32.0, 128.0, 128.0], [128.0, 128.0, 156.0, 156.0]],
+            ]
+        )
+        gt_classes = tf.constant(
+            [
+                [[1.0], [-1.0]],
+                [
+                    [
+                        25.0,
+                    ],
+                    [76.0],
+                ],
+            ]
+        )
+        outputs = model(images, gt_boxes, gt_classes, training=True)
+        # 512 sampled proposals in inference
+        self.assertAllEqual([2, 512, 81], outputs["rcnn_cls_pred"].shape)
+        self.assertAllEqual([2, 512, 4], outputs["rcnn_box_pred"].shape)
+        # (128*128 + 64*64 + 32*32+16*16+8*8) * 9 = 196416
+        self.assertAllEqual([2, 196416, 4], outputs["rpn_box_pred"].shape)
+        self.assertAllEqual([2, 196416, 1], outputs["rpn_cls_pred"].shape)

--- a/keras_cv/ops/sampling_test.py
+++ b/keras_cv/ops/sampling_test.py
@@ -98,7 +98,7 @@ class BalancedSamplingTest(tf.test.TestCase):
         num_samples = 20
         positive_fraction = 0.1
         with self.assertRaisesRegex(ValueError, "has less element"):
-            res = balanced_sample(
+            _ = balanced_sample(
                 positive_matches, negative_matches, num_samples, positive_fraction
             )
 


### PR DESCRIPTION
Adding the most complicated workflow we have so far.

FasterRCNN model that can be trained end to end.
1-2 components required for this model has been marked as private class, not public APIs until we have reached SOTA results.
The training script is unstable for now, and it uses custom training loop, switching to model.fit until we have reached SOTA results.

Several components has been improved:
1. iou allows masking
2. a private _encode and _decode for converting from box format to tx, ty, tw, th
3. fixed a bug in anchor generator
4. a temporary support for ROIAlign
5. a re-write of the sampling method since the original vectorized_map approach doesn't work for large scale of inputs