### PR TITLE
Address review comments from #874

### DIFF
--- a/keras_cv/models/segmentation/__internal__/segmentation_head.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head.py
@@ -32,6 +32,12 @@ class SegmentationHead(layers.Layer):
             to 256.
         activations: str or 'tf.keras.activations', activation functions between the
             conv2D layers and the final classification layer. Default to 'relu'
+        output_scale_factor: int, or a pair of ints, for scale up the output mask.
+            This is useful to scale the output mask back to same size as the input
+            image. When single int is provided, the mask will be scaled with same
+            ratio on both width and height. When a pair of ints are provided, they will
+            be parsed as (height_factor, width_factor). Default to None, which means
+            no resize will happen to the output mask tensor.
 
     Sample code
     ```python
@@ -48,13 +54,15 @@ class SegmentationHead(layers.Layer):
     ```
     """
 
-    def __init__(self, classes, convs=2, filters=256, activations="relu", **kwargs):
+    def __init__(self, classes, convs=2, filters=256, activations="relu",
+                 output_scale_factor=None, **kwargs):
         """"""
         super().__init__(**kwargs)
         self.classes = classes
         self.convs = convs
         self.filters = filters
         self.activations = activations
+        self.output_scale_factor = output_scale_factor
 
         self._conv_layers = []
         self._bn_layers = []
@@ -77,6 +85,9 @@ class SegmentationHead(layers.Layer):
             filters=self.classes,
             kernel_size=1,
             padding="same",
+            # Force the dtype of the classification head to float32 to avoid the NAN loss
+            # issue when used with mixed precision API.
+            dtype=tf.float32,
         )
 
     def call(self, inputs):
@@ -96,6 +107,8 @@ class SegmentationHead(layers.Layer):
             x = bn_layer(x)
             x = tf.keras.activations.get(self.activations)(x)
 
+        if self.output_scale_factor is not None:
+            x = tf.keras.layers.UpSampling2D(self.output_scale_factor)(x)
         x = self._classification_layer(x)
         return x
 

--- a/keras_cv/models/segmentation/__internal__/segmentation_head.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head.py
@@ -32,7 +32,7 @@ class SegmentationHead(layers.Layer):
             to 256.
         activations: str or 'tf.keras.activations', activation functions between the
             conv2D layers and the final classification layer. Default to 'relu'
-        output_scale_factor: int, or a pair of ints, for scale up the output mask.
+        output_scale_factor: int, or a pair of ints, for upsample the output mask.
             This is useful to scale the output mask back to same size as the input
             image. When single int is provided, the mask will be scaled with same
             ratio on both width and height. When a pair of ints are provided, they will

--- a/keras_cv/models/segmentation/__internal__/segmentation_head.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head.py
@@ -54,8 +54,15 @@ class SegmentationHead(layers.Layer):
     ```
     """
 
-    def __init__(self, classes, convs=2, filters=256, activations="relu",
-                 output_scale_factor=None, **kwargs):
+    def __init__(
+        self,
+        classes,
+        convs=2,
+        filters=256,
+        activations="relu",
+        output_scale_factor=None,
+        **kwargs,
+    ):
         """"""
         super().__init__(**kwargs)
         self.classes = classes

--- a/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
@@ -39,3 +39,31 @@ class SegmentationHeadTest(tf.test.TestCase):
         head = SegmentationHead(classes=11)
         with self.assertRaisesRegexp(ValueError, "Expect the inputs to be a dict"):
             head(list_input)
+
+    def test_scale_up_output(self):
+        p3 = tf.ones([2, 32, 32, 3])
+        p4 = tf.ones([2, 16, 16, 3])
+        p5 = tf.ones([2, 8, 8, 3])
+        inputs = {3: p3, 4: p4, 5: p5}
+
+        head = SegmentationHead(classes=11, output_scale_factor=4)
+
+        output = head(inputs)
+        # The output shape will scale up 4x
+        self.assertEquals(output.shape, [2, 32 * 4, 32 * 4, 11])
+
+    def test_dtype_for_classification_head(self):
+        p3 = tf.ones([2, 32, 32, 3])
+        p4 = tf.ones([2, 16, 16, 3])
+        p5 = tf.ones([2, 8, 8, 3])
+        inputs = {3: p3, 4: p4, 5: p5}
+
+        tf.keras.mixed_precision.set_global_policy('mixed_float16')
+        head = SegmentationHead(classes=11, output_scale_factor=4)
+
+        _ = head(inputs)
+
+        # Make sure the dtype of the classification head is still float32, which will
+        # avoid NAN loss issue for mixed precision
+        self.assertEquals(head._classification_layer.dtype, tf.float32)
+        self.assertEquals(head._classification_layer.compute_dtype, tf.float32)

--- a/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
@@ -58,7 +58,7 @@ class SegmentationHeadTest(tf.test.TestCase):
         p5 = tf.ones([2, 8, 8, 3])
         inputs = {3: p3, 4: p4, 5: p5}
 
-        tf.keras.mixed_precision.set_global_policy('mixed_float16')
+        tf.keras.mixed_precision.set_global_policy("mixed_float16")
         head = SegmentationHead(classes=11, output_scale_factor=4)
 
         _ = head(inputs)

--- a/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
+++ b/keras_cv/models/segmentation/__internal__/segmentation_head_test.py
@@ -57,13 +57,15 @@ class SegmentationHeadTest(tf.test.TestCase):
         p4 = tf.ones([2, 16, 16, 3])
         p5 = tf.ones([2, 8, 8, 3])
         inputs = {3: p3, 4: p4, 5: p5}
+        try:
+            tf.keras.mixed_precision.set_global_policy("mixed_float16")
+            head = SegmentationHead(classes=11, output_scale_factor=4)
 
-        tf.keras.mixed_precision.set_global_policy("mixed_float16")
-        head = SegmentationHead(classes=11, output_scale_factor=4)
+            _ = head(inputs)
 
-        _ = head(inputs)
-
-        # Make sure the dtype of the classification head is still float32, which will
-        # avoid NAN loss issue for mixed precision
-        self.assertEquals(head._classification_layer.dtype, tf.float32)
-        self.assertEquals(head._classification_layer.compute_dtype, tf.float32)
+            # Make sure the dtype of the classification head is still float32, which will
+            # avoid NAN loss issue for mixed precision
+            self.assertEquals(head._classification_layer.dtype, tf.float32)
+            self.assertEquals(head._classification_layer.compute_dtype, tf.float32)
+        finally:
+            tf.keras.mixed_precision.set_global_policy(None)

--- a/keras_cv/models/segmentation/deeplab.py
+++ b/keras_cv/models/segmentation/deeplab.py
@@ -109,9 +109,16 @@ class DeepLabV3(tf.keras.models.Model):
 
         self._segmentation_head_passed = segmentation_head
         if segmentation_head is None:
+            # Scale up the output when using FPN, to keep the output shape same as the
+            # input shape.
+            if isinstance(self.decoder, keras_cv.layers.FeaturePyramid):
+                output_scale_factor = pow(2, self.decoder.min_level)
+            else:
+                output_scale_factor = None
+
             segmentation_head = (
                 keras_cv.models.segmentation.__internal__.SegmentationHead(
-                    classes=classes
+                    classes=classes, output_scale_factor=output_scale_factor
                 )
             )
         self.segmentation_head = segmentation_head

--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -48,13 +48,12 @@ class DeeplabTest(tf.test.TestCase):
         self.assertEquals(output.shape, [2, 32, 32, 11])
 
     def test_mixed_precision(self):
-        tf.keras.mixed_precision.set_global_policy('mixed_float16')
+        tf.keras.mixed_precision.set_global_policy("mixed_float16")
         model = segmentation.DeepLabV3(classes=11, include_rescaling=True)
-        input_image = tf.random.uniform(shape=[2, 256, 256, 3], dtype=)
+        input_image = tf.random.uniform(shape=[2, 256, 256, 3])
         output = model(input_image, training=True)
 
         self.assertEquals(output.dtype, tf.float32)
-
 
     def test_invalid_backbone_model(self):
         with self.assertRaisesRegex(

--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -29,9 +29,7 @@ class DeeplabTest(tf.test.TestCase):
         input_image = tf.random.uniform(shape=[2, 256, 256, 3])
         output = model(input_image, training=True)
 
-        # Note that there are 2^2 down scale for the output, so the output mask size is
-        # [64, 64]
-        self.assertEquals(output.shape, [2, 64, 64, 11])
+        self.assertEquals(output.shape, [2, 256, 256, 11])
 
     def test_deeplab_model_with_components(self):
         backbone = models.ResNet50V2(
@@ -48,6 +46,15 @@ class DeeplabTest(tf.test.TestCase):
         # Note that we pick the min_level to be 3, which means there is a 2^3 scale for
         # the output.
         self.assertEquals(output.shape, [2, 32, 32, 11])
+
+    def test_mixed_precision(self):
+        tf.keras.mixed_precision.set_global_policy('mixed_float16')
+        model = segmentation.DeepLabV3(classes=11, include_rescaling=True)
+        input_image = tf.random.uniform(shape=[2, 256, 256, 3], dtype=)
+        output = model(input_image, training=True)
+
+        self.assertEquals(output.dtype, tf.float32)
+
 
     def test_invalid_backbone_model(self):
         with self.assertRaisesRegex(

--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -43,9 +43,7 @@ class DeeplabTest(tf.test.TestCase):
         input_image = tf.random.uniform(shape=[2, 256, 256, 3])
         output = model(input_image, training=True)
 
-        # Note that we pick the min_level to be 3, which means there is a 2^3 scale for
-        # the output.
-        self.assertEquals(output.shape, [2, 32, 32, 11])
+        self.assertEquals(output.shape, [2, 256, 256 11])
 
     def test_mixed_precision(self):
         tf.keras.mixed_precision.set_global_policy("mixed_float16")

--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -43,7 +43,7 @@ class DeeplabTest(tf.test.TestCase):
         input_image = tf.random.uniform(shape=[2, 256, 256, 3])
         output = model(input_image, training=True)
 
-        self.assertEquals(output.shape, [2, 256, 256 11])
+        self.assertEquals(output.shape, [2, 256, 256, 11])
 
     def test_mixed_precision(self):
         tf.keras.mixed_precision.set_global_policy("mixed_float16")


### PR DESCRIPTION
# What does this PR do?

1. Add a param to scale up the output for segmentation head so that the output mask
can have the same shape as the input image.
2. Enforce the output layer dtype to float32, to avoid the numerical issue when running
with mixed precision.

Fixes #874


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
