### PR TITLE
Improve FasterRCNN model quality.

### DIFF
--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -38,7 +38,7 @@ eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
 
-
+# TODO: migrate to KPL.
 def resize_and_crop_image(
     image,
     desired_size,

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -38,6 +38,7 @@ eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
 
+
 # TODO: migrate to KPL.
 def resize_and_crop_image(
     image,

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -25,23 +25,143 @@ import tensorflow_datasets as tfds
 
 import keras_cv
 
-physical_devices = tf.config.list_physical_devices("GPU")
-tf.config.set_visible_devices(physical_devices[:1], "GPU")
-
 # parameters from FasterRCNN [paper](https://arxiv.org/pdf/1506.01497.pdf)
 
 global_batch = 4
-image_size = [256, 256, 3]
+image_size = [640, 640, 3]
 train_ds = tfds.load(
-    "voc/2007", split="train+test", with_info=False, shuffle_files=True
+    "voc/2007", split="train+validation", with_info=False, shuffle_files=True
 ).concatenate(
-    tfds.load("voc/2012", split="train+test", with_info=False, shuffle_files=True)
+    tfds.load("voc/2012", split="train+validation", with_info=False, shuffle_files=True)
 )
-eval_ds = tfds.load("voc/2007", split="validation", with_info=False).concatenate(
-    tfds.load("voc/2012", split="validation", with_info=False)
-)
+eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
+
+
+def resize_and_crop_image(
+    image,
+    desired_size,
+    padded_size,
+    aug_scale_min=1.0,
+    aug_scale_max=1.0,
+    seed=1,
+    method=tf.image.ResizeMethod.BILINEAR,
+):
+    with tf.name_scope("resize_and_crop_image"):
+        image_size = tf.cast(tf.shape(image)[0:2], tf.float32)
+
+        random_jittering = aug_scale_min != 1.0 or aug_scale_max != 1.0
+
+        if random_jittering:
+            random_scale = tf.random.uniform(
+                [], aug_scale_min, aug_scale_max, seed=seed
+            )
+            scaled_size = tf.round(random_scale * desired_size)
+        else:
+            scaled_size = desired_size
+
+        scale = tf.minimum(
+            scaled_size[0] / image_size[0], scaled_size[1] / image_size[1]
+        )
+        scaled_size = tf.round(image_size * scale)
+
+        # Computes 2D image_scale.
+        image_scale = scaled_size / image_size
+
+        # Selects non-zero random offset (x, y) if scaled image is larger than
+        # desired_size.
+        if random_jittering:
+            max_offset = scaled_size - desired_size
+            max_offset = tf.where(
+                tf.less(max_offset, 0), tf.zeros_like(max_offset), max_offset
+            )
+            offset = max_offset * tf.random.uniform(
+                [
+                    2,
+                ],
+                0,
+                1,
+                seed=seed,
+            )
+            offset = tf.cast(offset, tf.int32)
+        else:
+            offset = tf.zeros((2,), tf.int32)
+
+        scaled_image = tf.image.resize(
+            image, tf.cast(scaled_size, tf.int32), method=method
+        )
+
+        if random_jittering:
+            scaled_image = scaled_image[
+                offset[0] : offset[0] + desired_size[0],
+                offset[1] : offset[1] + desired_size[1],
+                :,
+            ]
+
+        output_image = tf.image.pad_to_bounding_box(
+            scaled_image, 0, 0, padded_size[0], padded_size[1]
+        )
+
+        image_info = tf.stack(
+            [
+                image_size,
+                tf.constant(desired_size, dtype=tf.float32),
+                image_scale,
+                tf.cast(offset, tf.float32),
+            ]
+        )
+        return output_image, image_info
+
+
+def resize_and_crop_boxes(boxes, image_scale, output_size, offset):
+    with tf.name_scope("resize_and_crop_boxes"):
+        # Adjusts box coordinates based on image_scale and offset.
+        boxes *= tf.tile(tf.expand_dims(image_scale, axis=0), [1, 2])
+        boxes -= tf.tile(tf.expand_dims(offset, axis=0), [1, 2])
+        # Clips the boxes.
+        boxes = clip_boxes(boxes, output_size)
+        return boxes
+
+
+def clip_boxes(boxes, image_shape):
+    if boxes.shape[-1] != 4:
+        raise ValueError(
+            "boxes.shape[-1] is {:d}, but must be 4.".format(boxes.shape[-1])
+        )
+
+    with tf.name_scope("clip_boxes"):
+        if isinstance(image_shape, list) or isinstance(image_shape, tuple):
+            height, width = image_shape
+            max_length = [height, width, height, width]
+        else:
+            image_shape = tf.cast(image_shape, dtype=boxes.dtype)
+            height, width = tf.unstack(image_shape, axis=-1)
+            max_length = tf.stack([height, width, height, width], axis=-1)
+
+        clipped_boxes = tf.math.maximum(tf.math.minimum(boxes, max_length), 0.0)
+        return clipped_boxes
+
+
+def get_non_empty_box_indices(boxes):
+    # Selects indices if box height or width is 0.
+    height = boxes[:, 2] - boxes[:, 0]
+    width = boxes[:, 3] - boxes[:, 1]
+    indices = tf.where(tf.logical_and(tf.greater(height, 0), tf.greater(width, 0)))
+    return indices[:, 0]
+
+
+def resize_fn(image, gt_boxes, gt_classes):
+    image, image_info = resize_and_crop_image(
+        image, image_size[:2], image_size[:2], 0.8, 1.25
+    )
+    gt_boxes = resize_and_crop_boxes(
+        gt_boxes, image_info[2, :], image_info[1, :], image_info[3, :]
+    )
+    indices = get_non_empty_box_indices(gt_boxes)
+    gt_boxes = tf.gather(gt_boxes, indices)
+    gt_classes = tf.gather(gt_classes, indices)
+    return image, gt_boxes, gt_classes
 
 
 def flip_fn(image, boxes):
@@ -55,17 +175,13 @@ def flip_fn(image, boxes):
 def proc_train_fn(bounding_box_format, img_size):
     anchors = model.anchor_generator(image_shape=img_size)
     anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
-    resizing = tf.keras.layers.Resizing(
-        height=img_size[0], width=img_size[1], crop_to_aspect_ratio=False
-    )
 
     def apply(inputs):
         image = inputs["image"]
         image = tf.cast(image, tf.float32)
         image = tf.keras.applications.resnet50.preprocess_input(image)
-        image = resizing(image)
         gt_boxes = inputs["objects"]["bbox"]
-        # image, gt_boxes = flip_fn(image, gt_boxes)
+        image, gt_boxes = flip_fn(image, gt_boxes)
         gt_boxes = keras_cv.bounding_box.convert_format(
             gt_boxes,
             images=image,
@@ -73,6 +189,7 @@ def proc_train_fn(bounding_box_format, img_size):
             target=bounding_box_format,
         )
         gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
+        image, gt_boxes, gt_classes = resize_fn(image, gt_boxes, gt_classes)
         gt_classes = tf.expand_dims(gt_classes, axis=-1)
         box_targets, box_weights, cls_targets, cls_weights = model.rpn_labeler(
             anchors, gt_boxes, gt_classes
@@ -93,20 +210,15 @@ def proc_train_fn(bounding_box_format, img_size):
 def pad_fn(examples):
     gt_boxes = examples.pop("gt_boxes")
     gt_classes = examples.pop("gt_classes")
-    examples["gt_boxes"] = gt_boxes.to_tensor(default_value=-1.0)
-    examples["gt_classes"] = gt_classes.to_tensor(default_value=-1.0)
+    examples["gt_boxes"] = gt_boxes.to_tensor(
+        default_value=-1.0, shape=[global_batch, 32, 4]
+    )
+    examples["gt_classes"] = gt_classes.to_tensor(
+        default_value=-1.0, shape=[global_batch, 32, 1]
+    )
     return examples
 
 
-def filter_fn(examples):
-    gt_boxes = examples["objects"]["bbox"]
-    if tf.shape(gt_boxes)[0] <= 0 or tf.reduce_sum(gt_boxes) < 0:
-        return False
-    else:
-        return True
-
-
-train_ds = train_ds.filter(filter_fn)
 train_ds = train_ds.map(
     proc_train_fn(bounding_box_format="yxyx", img_size=image_size),
     num_parallel_calls=tf.data.AUTOTUNE,
@@ -115,9 +227,9 @@ train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(global_batch, drop_remainder=True)
 )
 train_ds = train_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
+train_ds = train_ds.shuffle(8)
 train_ds = train_ds.prefetch(2)
 
-eval_ds = eval_ds.filter(filter_fn)
 eval_ds = eval_ds.map(
     proc_train_fn(bounding_box_format="yxyx", img_size=image_size),
     num_parallel_calls=tf.data.AUTOTUNE,
@@ -146,14 +258,14 @@ rcnn_reg_metric = tf.keras.metrics.Mean()
 rcnn_cls_metric = tf.keras.metrics.Mean()
 
 lr_decay = tf.keras.optimizers.schedules.PiecewiseConstantDecay(
-    boundaries=[80000], values=[0.001, 0.0001]
+    boundaries=[36000, 50000], values=[0.005, 0.0005, 0.00005]
 )
 
 optimizer = tf.keras.optimizers.SGD(
     learning_rate=lr_decay, momentum=0.9, global_clipnorm=10.0
 )
 
-weight_decay = 0.00001
+weight_decay = 0.0003
 step = 0
 
 
@@ -173,9 +285,10 @@ def compute_loss(examples, training):
         rpn_reg_loss_fn(box_targets, rpn_box_pred, box_weights)
     )
     # avoid divide by zero
-    positive_boxes = tf.reduce_sum(box_weights) + 0.01
+    # positive_boxes = tf.reduce_sum(box_weights) + 0.01
     # x4 given huber loss reduce_mean on the box dimension
-    rpn_reg_loss /= positive_boxes * 0.25
+    # rpn_reg_loss /= positive_boxes * 0.25
+    rpn_reg_loss /= model.rpn_labeler.samples_per_image * global_batch * 0.25
     rpn_cls_loss = tf.reduce_sum(
         rpn_cls_loss_fn(cls_targets, rpn_cls_pred, cls_weights)
     )
@@ -188,8 +301,9 @@ def compute_loss(examples, training):
         )
     )
     # avoid divide by zero
-    positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
-    rcnn_reg_loss /= positive_rois * 0.25
+    # positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
+    # rcnn_reg_loss /= positive_rois * 0.25
+    rcnn_reg_loss /= model.roi_sampler.num_sampled_rois * global_batch * 0.25
     rcnn_cls_loss = tf.reduce_sum(
         rcnn_cls_loss_fn(
             outputs["rcnn_cls_targets"],
@@ -199,9 +313,11 @@ def compute_loss(examples, training):
     )
     # 512 is for num_sampled_rois
     rcnn_cls_loss /= model.roi_sampler.num_sampled_rois * global_batch
-    l2_loss = weight_decay * tf.add_n(
-        [tf.nn.l2_loss(var) for var in model.trainable_variables]
-    )
+    l2_vars = []
+    for var in model.trainable_variables:
+        if "bn" not in var.name:
+            l2_vars.append(var)
+    l2_loss = weight_decay * tf.add_n([tf.nn.l2_loss(var) for var in l2_vars])
     total_loss = rpn_reg_loss + rpn_cls_loss + rcnn_reg_loss + rcnn_cls_loss + l2_loss
     return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, l2_loss, total_loss
 
@@ -240,7 +356,7 @@ rcnn_cls_loss = 0.0
 l2_loss = 0.0
 step_size = 500
 
-for epoch in range(40):
+for epoch in range(1, 21):
     for examples in train_ds:
         (
             step_rpn_reg_loss,
@@ -258,13 +374,16 @@ for epoch in range(40):
         step += 1
         if step % step_size == 0:
             print(
-                "step {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}, l2 loss {}".format(
+                "step {} rpn_reg {:.4}, rpn_cls {:.4}, rcnn_reg {:.4}, rcnn_cls {:.4}, l2 {:.4}, pos_rois {:.4}, neg_rois {:.4}, pos_anchors {:.4}".format(
                     step,
                     rpn_reg_loss / step_size,
                     rpn_cls_loss / step_size,
                     rcnn_reg_loss / step_size,
                     rcnn_cls_loss / step_size,
                     l2_loss / step_size,
+                    model.roi_sampler._positives.result(),
+                    model.roi_sampler._negatives.result(),
+                    model.rpn_labeler._positives.result(),
                 )
             )
             rpn_reg_loss = 0.0
@@ -272,10 +391,13 @@ for epoch in range(40):
             rcnn_reg_loss = 0.0
             rcnn_cls_loss = 0.0
             l2_loss = 0.0
+            model.roi_sampler._positives.reset_state()
+            model.roi_sampler._negatives.reset_state()
+            model.rpn_labeler._positives.reset_state()
     for examples in eval_ds:
         eval_step(examples)
     print(
-        "epoch {} rpn reg loss {}, rpn cls loss {}, rcnn reg loss {}, rcnn cls loss {}".format(
+        "epoch {} rpn reg loss {:.4}, rpn cls loss {:.4}, rcnn reg loss {:.4}, rcnn cls loss {:.4}".format(
             epoch,
             rpn_reg_metric.result(),
             rpn_cls_metric.result(),

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -25,25 +25,6 @@ class RequiresImagesException(Exception):
     pass
 
 
-def _clip_boxes(boxes, box_format, image_shape):
-    """Clip boxes to the boundaries of the image shape"""
-    if boxes.shape[-1] != 4:
-        raise ValueError(
-            "boxes.shape[-1] is {:d}, but must be 4.".format(boxes.shape[-1])
-        )
-
-    if isinstance(image_shape, list) or isinstance(image_shape, tuple):
-        height, width, _ = image_shape
-        max_length = [height, width, height, width]
-    else:
-        image_shape = tf.cast(image_shape, dtype=boxes.dtype)
-        height, width, _ = tf.unstack(image_shape, axis=-1)
-        max_length = tf.stack([height, width, height, width], axis=-1)
-
-    clipped_boxes = tf.math.maximum(tf.math.minimum(boxes, max_length), 0.0)
-    return clipped_boxes
-
-
 def _encode_box_to_deltas(
     anchors: tf.Tensor,
     boxes: tf.Tensor,

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -25,7 +25,7 @@ class RequiresImagesException(Exception):
     pass
 
 
-def clip_boxes(boxes, box_format, image_shape):
+def _clip_boxes(boxes, box_format, image_shape):
     """Clip boxes to the boundaries of the image shape"""
     if boxes.shape[-1] != 4:
         raise ValueError(

--- a/keras_cv/bounding_box/utils.py
+++ b/keras_cv/bounding_box/utils.py
@@ -92,6 +92,26 @@ def clip_to_image(bounding_boxes, images, bounding_box_format):
     return clipped_bounding_boxes
 
 
+# TODO (tanzhenyu): merge with clip_to_image
+def _clip_boxes(boxes, box_format, image_shape):
+    """Clip boxes to the boundaries of the image shape"""
+    if boxes.shape[-1] != 4:
+        raise ValueError(
+            "boxes.shape[-1] is {:d}, but must be 4.".format(boxes.shape[-1])
+        )
+
+    if isinstance(image_shape, list) or isinstance(image_shape, tuple):
+        height, width, _ = image_shape
+        max_length = [height, width, height, width]
+    else:
+        image_shape = tf.cast(image_shape, dtype=boxes.dtype)
+        height, width, _ = tf.unstack(image_shape, axis=-1)
+        max_length = tf.stack([height, width, height, width], axis=-1)
+
+    clipped_boxes = tf.math.maximum(tf.math.minimum(boxes, max_length), 0.0)
+    return clipped_boxes
+
+
 def _format_inputs(boxes, images):
     boxes_rank = len(boxes.shape)
     if boxes_rank > 3:

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -83,13 +83,14 @@ class ROISamplerTest(tf.test.TestCase):
         # only the 2nd ROI is chosen. No negative samples exist given we
         # select positive_threshold to be 0.1. (the minimum IOU is 1/7)
         # given num_sampled_rois=2, it selects the 1st ROI as well.
-        expected_rois = tf.constant([[2.5, 2.5, 7.5, 7.5], [0.0, 0.0, 5.0, 5.0]])
+        expected_rois = tf.constant([[5, 5, 10, 10], [0.0, 0.0, 5.0, 5.0]])
         expected_rois = expected_rois[tf.newaxis, ...]
         # all ROIs are matched to the 2nd gt box.
         # the boxes are encoded by dimensions, so the result is
         # tx, ty = (5.1 - 5.0) / 5 = 0.02, tx, ty = (5.1 - 2.5) / 5 = 0.52
-        expected_gt_boxes = tf.constant(
-            [[0.02, 0.02, 0.0, 0.0], [0.52, 0.52, 0.0, 0.0]]
+        # then divide by 0.1 as box variance.
+        expected_gt_boxes = (
+            tf.constant([[0.02, 0.02, 0.0, 0.0], [0.52, 0.52, 0.0, 0.0]]) / 0.1
         )
         expected_gt_boxes = expected_gt_boxes[tf.newaxis, ...]
         # only the 2nd ROI is chosen, and the negative ROI is mapped to 0.

--- a/keras_cv/layers/object_detection/rpn_label_encoder_test.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder_test.py
@@ -38,13 +38,16 @@ class RpnLabelEncoderTest(tf.test.TestCase):
             rois, gt_boxes, gt_classes
         )
         # all rois will be matched to the 2nd gt boxes, and encoded
-        expected_box_targets = tf.constant(
-            [
-                [0.5, 0.5, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0],
-                [-0.5, -0.5, 0.0, 0.0],
-                [0.5, 0.5, 0.0, 0.0],
-            ]
+        expected_box_targets = (
+            tf.constant(
+                [
+                    [0.5, 0.5, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [-0.5, -0.5, 0.0, 0.0],
+                    [0.5, 0.5, 0.0, 0.0],
+                ]
+            )
+            / 0.1
         )
         self.assertAllClose(expected_box_targets, box_targets)
         # only foreground and background classes
@@ -76,8 +79,8 @@ class RpnLabelEncoderTest(tf.test.TestCase):
         _, _, _, cls_weights = rpn_encoder(rois, gt_boxes, gt_classes)
         # the 2nd level found 2 positive matches, the 3rd level found no match
         expected_cls_weights = {
-            2: tf.constant([[1.0], [1.0]]),
-            3: tf.constant([[0.0], [0.0]]),
+            2: tf.constant([[0.0], [1.0]]),
+            3: tf.constant([[0.0], [1.0]]),
         }
         self.assertAllClose(expected_cls_weights[2], cls_weights[2])
         self.assertAllClose(expected_cls_weights[3], cls_weights[3])

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 
 from keras_cv import bounding_box
-from keras_cv.bounding_box.converters import _clip_boxes
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
+from keras_cv.bounding_box.utils import _clip_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
 from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 
 from keras_cv import bounding_box
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
+from keras_cv.bounding_box.converters import clip_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
 from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
@@ -56,7 +57,6 @@ class FeaturePyramid(tf.keras.layers.Layer):
         self.conv_c3_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
         self.conv_c4_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
         self.conv_c5_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
-        self.conv_c6_1x1 = tf.keras.layers.Conv2D(256, 1, 1, "same")
 
         self.conv_c2_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
         self.conv_c3_3x3 = tf.keras.layers.Conv2D(256, 3, 1, "same")
@@ -70,13 +70,12 @@ class FeaturePyramid(tf.keras.layers.Layer):
         c2_output, c3_output, c4_output, c5_output = inputs
 
         c6_output = self.conv_c6_pool(c5_output)
-        p6_output = self.conv_c6_1x1(c6_output)
+        p6_output = c6_output
         p5_output = self.conv_c5_1x1(c5_output)
         p4_output = self.conv_c4_1x1(c4_output)
         p3_output = self.conv_c3_1x1(c3_output)
         p2_output = self.conv_c2_1x1(c2_output)
 
-        p5_output = p5_output + self.upsample_2x(p6_output)
         p4_output = p4_output + self.upsample_2x(p5_output)
         p3_output = p3_output + self.upsample_2x(p4_output)
         p2_output = p2_output + self.upsample_2x(p3_output)
@@ -270,16 +269,25 @@ class FasterRCNN(tf.keras.Model):
     ):
         self.bounding_box_format = bounding_box_format
         super().__init__(**kwargs)
+        scales = [2**x for x in [0]]
+        aspect_ratios = [0.5, 1.0, 2.0]
         self.anchor_generator = AnchorGenerator(
             bounding_box_format="yxyx",
-            sizes={2: 16.0, 3: 32.0, 4: 64.0, 5: 128.0, 6: 256.0},
-            scales=[2**x for x in [0, 1 / 3, 2 / 3]],
-            aspect_ratios=[0.5, 1.0, 2.0],
+            # sizes={2: 16.0, 3: 32.0, 4: 64.0, 5: 128.0, 6: 256.0},
+            sizes={2: 32.0, 3: 64.0, 4: 128.0, 5: 256.0, 6: 512.0},
+            scales=scales,
+            aspect_ratios=aspect_ratios,
             strides={i: 2**i for i in range(2, 7)},
             clip_boxes=True,
         )
-        self.rpn_head = RPNHead(num_anchors_per_location=9)
-        self.roi_generator = ROIGenerator(bounding_box_format="yxyx")
+        self.rpn_head = RPNHead(
+            num_anchors_per_location=len(scales) * len(aspect_ratios)
+        )
+        self.roi_generator = ROIGenerator(
+            bounding_box_format="yxyx",
+            nms_score_threshold_train=float("-inf"),
+            nms_score_threshold_test=float("-inf"),
+        )
         self.box_matcher = ArgmaxBoxMatcher(
             thresholds=[0.0, 0.5], match_values=[-2, -1, 1]
         )
@@ -303,16 +311,22 @@ class FasterRCNN(tf.keras.Model):
         )
 
     def call(self, images, gt_boxes=None, gt_classes=None, training=None):
+        image_shape = tf.shape(images[0])
         feature_map = self.backbone(images, training=training)
         feature_map = self.feature_pyramid(feature_map, training=training)
         # [BS, num_anchors, 4], [BS, num_anchors, 1]
         rpn_boxes, rpn_scores = self.rpn_head(feature_map)
-        anchors = self.anchor_generator(image_shape=tf.shape(images[0]))
+        anchors = self.anchor_generator(image_shape=image_shape)
         if isinstance(anchors, (dict, list, tuple)):
             anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
         anchors = tf.reshape(anchors, [-1, 4])
         # the decoded format is center_xywh
-        decoded_rpn_boxes = _decode_deltas_to_boxes(anchors, rpn_boxes, "yxyx")
+        decoded_rpn_boxes = _decode_deltas_to_boxes(
+            anchors=anchors,
+            boxes_delta=rpn_boxes,
+            anchor_format="yxyx",
+            variance=[0.1, 0.1, 0.2, 0.2],
+        )
         decoded_rpn_boxes = bounding_box.convert_format(
             decoded_rpn_boxes, source="center_yxhw", target="yxyx"
         )
@@ -320,6 +334,7 @@ class FasterRCNN(tf.keras.Model):
             decoded_rpn_boxes, tf.squeeze(rpn_scores, axis=-1), training=training
         )
         if training:
+            rois = clip_boxes(rois, "yxyx", image_shape)
             rois = tf.stop_gradient(rois)
             (
                 rois,
@@ -348,7 +363,10 @@ class FasterRCNN(tf.keras.Model):
         else:
             # now it will be on "center_yxhw" format
             rcnn_box_pred = _decode_deltas_to_boxes(
-                rois, rcnn_box_pred, anchor_format="yxyx"
+                anchors=rois,
+                boxes_delta=rcnn_box_pred,
+                anchor_format="yxyx",
+                variance=[0.1, 0.1, 0.2, 0.2],
             )
             rcnn_box_pred = bounding_box.convert_format(
                 rcnn_box_pred, source="center_yxhw", target="yxyx"

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 
 from keras_cv import bounding_box
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
-from keras_cv.bounding_box.converters import clip_boxes
+from keras_cv.bounding_box.converters import _clip_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
 from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
@@ -334,7 +334,7 @@ class FasterRCNN(tf.keras.Model):
             decoded_rpn_boxes, tf.squeeze(rpn_scores, axis=-1), training=training
         )
         if training:
-            rois = clip_boxes(rois, "yxyx", image_shape)
+            rois = _clip_boxes(rois, "yxyx", image_shape)
             rois = tf.stop_gradient(rois)
             (
                 rois,

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 
 from keras_cv import bounding_box
-from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.bounding_box.converters import _clip_boxes
+from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
 from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -67,6 +67,6 @@ class FasterRCNNTest(tf.test.TestCase):
         # 512 sampled proposals in inference
         self.assertAllEqual([2, 512, 81], outputs["rcnn_cls_pred"].shape)
         self.assertAllEqual([2, 512, 4], outputs["rcnn_box_pred"].shape)
-        # (128*128 + 64*64 + 32*32+16*16+8*8) * 9 = 196416
-        self.assertAllEqual([2, 196416, 4], outputs["rpn_box_pred"].shape)
-        self.assertAllEqual([2, 196416, 1], outputs["rpn_cls_pred"].shape)
+        # (128*128 + 64*64 + 32*32+16*16+8*8) * 3 = 65472
+        self.assertAllEqual([2, 65472, 4], outputs["rpn_box_pred"].shape)
+        self.assertAllEqual([2, 65472, 1], outputs["rpn_cls_pred"].shape)

--- a/keras_cv/ops/sampling.py
+++ b/keras_cv/ops/sampling.py
@@ -48,18 +48,14 @@ def balanced_sample(
     # random_val = tf.random.uniform(tf.shape(positive_matches), minval=0., maxval=1.)
     zeros = tf.zeros_like(positive_matches, dtype=tf.float32)
     ones = tf.ones_like(positive_matches, dtype=tf.float32)
+    ones_rand = ones + tf.random.uniform(ones.shape, minval=-0.2, maxval=0.2)
     halfs = 0.5 * tf.ones_like(positive_matches, dtype=tf.float32)
+    halfs_rand = halfs + tf.random.uniform(halfs.shape, minval=-0.2, maxval=0.2)
     values = zeros
-    values = tf.where(positive_matches, ones, values)
-    values = tf.where(negative_matches, halfs, values)
+    values = tf.where(positive_matches, ones_rand, values)
+    values = tf.where(negative_matches, halfs_rand, values)
     num_pos_samples = int(num_samples * positive_fraction)
     valid_matches = tf.logical_or(positive_matches, negative_matches)
-    num_valid_samples = tf.reduce_sum(tf.cast(valid_matches, tf.int32), axis=-1)
-    tf.debugging.assert_greater_equal(
-        num_valid_samples,
-        num_pos_samples,
-        message=f"num_valid_samples > num_pos_samples {num_pos_samples}",
-    )
     # this might contain negative samples as well
     _, positive_indices = tf.math.top_k(values, k=num_pos_samples)
     selected_indicators = tf.cast(
@@ -70,11 +66,6 @@ def balanced_sample(
     # setting all excessive positive matches to zeros as well
     values = tf.where(positive_matches, zeros, values)
     num_neg_samples = num_samples - num_pos_samples
-    tf.debugging.assert_greater_equal(
-        num_valid_samples,
-        num_pos_samples,
-        message=f"num_valid_samples > num_neg_samples {num_neg_samples}",
-    )
     _, negative_indices = tf.math.top_k(values, k=num_neg_samples)
     selected_indices = tf.concat([positive_indices, negative_indices], axis=-1)
     selected_indicators = tf.reduce_sum(tf.one_hot(selected_indices, depth=N), axis=-2)


### PR DESCRIPTION
This PR add mores paper specific training logic and improves FasterRCNN model quality / training by:
1) add padding
2) add variance during box encoding and decoding
3) less anchor gen
4) larger image size
5) more aggressive resizing

It makes the training script a little more verbose, which is intentional given our data augmentation layers set do not support native box format and paper specific resizing logic.
