### PR TITLE
Add some pre-trained weight info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Thank you to all of our wonderful contributors!
 ## Pretrained Weights
 Many models in KerasCV come with pre-trained weights. With the exception of StableDiffusion,
 all of these weights are trained using Keras and KerasCV components and training scripts in this
-repository. Models may not be trained with the same parameters described in their original papers.
-Performance metrics for pre-trained weights can be found in the training history for each task.
-For example, see ImageNet classification training history for backbone models [here](examples/training/classification/imagenet/training_history.json).
+repository. Models may not be trained with the same parameters or preprocessing pipeline
+described in their original papers. Performance metrics for pre-trained weights can be found
+in the training history for each task. For example, see ImageNet classification training
+history for backbone models [here](examples/training/classification/imagenet/training_history.json).
 All results are reproducible using the training scripts in this repository. Pre-trained weights
 operate on images that have been rescaled using a simple `1/255` rescaling layer.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Thank you to all of our wonderful contributors!
   <img src="https://contrib.rocks/image?repo=keras-team/keras-cv" />
 </a>
 
+## Pretrained Weights
+Many models in KerasCV come with pre-trained weights. With the exception of StableDiffusion,
+all of these weights are trained using Keras and KerasCV components and training scripts in this
+repository. Models may not be trained with the same parameters described in their original papers.
+Performance metrics for pre-trained weights can be found in the training history for each task.
+For example, see ImageNet classification training history for backbone models [here](examples/training/classification/imagenet/training_history.json).
+All results are reproducible using the training scripts in this repository.
+
 ## Citing KerasCV
 
 If KerasCV helps your research, we appreciate your citations.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ all of these weights are trained using Keras and KerasCV components and training
 repository. Models may not be trained with the same parameters described in their original papers.
 Performance metrics for pre-trained weights can be found in the training history for each task.
 For example, see ImageNet classification training history for backbone models [here](examples/training/classification/imagenet/training_history.json).
-All results are reproducible using the training scripts in this repository.
+All results are reproducible using the training scripts in this repository. Pre-trained weights
+operate on images that have been rescaled using a simple `1/255` rescaling layer.
 
 ## Citing KerasCV
 


### PR DESCRIPTION
(Based on conversation in #906)

In the long-term we should provide a nice table of all of our weights' metrics (like Keras Applications), including a ranking system. This is a stop-gap to explain our weights a bit for new users.