### PR TITLE
Allow compute_iou to take boxes of different shape.

### DIFF
--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -17,6 +17,47 @@ import tensorflow as tf
 from keras_cv import bounding_box
 
 
+def _compute_area(box):
+    """Computes area for bounding boxes
+
+    Args:
+      box: [N, 4] or [batch_size, N, 4] float Tensor, either batched
+        or unbatched boxes.
+    Returns:
+      a float Tensor of [N] or [batch_size, N]
+    """
+    y_min, x_min, y_max, x_max = tf.split(box, num_or_size_splits=4, axis=-1)
+    return tf.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
+
+
+def _compute_intersection(boxes1, boxes2):
+    """Computes intersection area between two sets of boxes.
+
+    Args:
+      boxes1: [N, 4] or [batch_size, N, 4] float Tensor boxes.
+      boxes2: [M, 4] or [batch_size, M, 4] float Tensor boxes.
+    Returns:
+      a [N, M] or [batch_size, N, M] float Tensor.
+    """
+    y_min1, x_min1, y_max1, x_max1 = tf.split(boxes1, num_or_size_splits=4, axis=-1)
+    y_min2, x_min2, y_max2, x_max2 = tf.split(boxes2, num_or_size_splits=4, axis=-1)
+    boxes2_rank = len(boxes2.shape)
+    perm = [1, 0] if boxes2_rank == 2 else [0, 2, 1]
+    # [N, M] or [batch_size, N, M]
+    intersect_ymax = tf.minimum(y_max1, tf.transpose(y_max2, perm))
+    intersect_ymin = tf.maximum(y_min1, tf.transpose(y_min2, perm))
+    intersect_xmax = tf.minimum(x_max1, tf.transpose(x_max2, perm))
+    intersect_xmin = tf.maximum(x_min1, tf.transpose(x_min2, perm))
+
+    intersect_height = intersect_ymax - intersect_ymin
+    intersect_width = intersect_xmax - intersect_xmin
+    zeros_t = tf.cast(0, intersect_height.dtype)
+    intersect_height = tf.maximum(zeros_t, intersect_height)
+    intersect_width = tf.maximum(zeros_t, intersect_width)
+
+    return intersect_height * intersect_width
+
+
 def compute_iou(
     boxes1,
     boxes2,
@@ -50,16 +91,19 @@ def compute_iou(
     boxes1_rank = len(boxes1.shape)
     boxes2_rank = len(boxes2.shape)
 
-    if (
-        boxes1_rank != boxes2_rank
-        or boxes1_rank not in [2, 3]
-        or boxes2_rank not in [2, 3]
-    ):
+    if boxes1_rank not in [2, 3]:
         raise ValueError(
-            "compute_iou() expects both boxes to be batched, or both "
-            f"boxes to be unbatched.  Received len(boxes1.shape)={boxes1_rank}, "
-            f"len(boxes2.shape)={boxes2_rank}.  Expected either len(boxes1.shape)=2 AND "
-            "len(boxes2.shape)=2, or len(boxes1.shape)=3 AND len(boxes2.shape)=3."
+            "compute_iou() expects boxes1 to be batched, or "
+            f"to be unbatched. Received len(boxes1.shape)={boxes1_rank}, "
+            f"len(boxes2.shape)={boxes2_rank}. Expected either len(boxes1.shape)=2 AND "
+            "or len(boxes1.shape)=3."
+        )
+    if boxes2_rank not in [2, 3]:
+        raise ValueError(
+            "compute_iou() expects boxes2 to be batched, or "
+            f"to be unbatched. Received len(boxes1.shape)={boxes1_rank}, "
+            f"len(boxes2.shape)={boxes2_rank}. Expected either len(boxes2.shape)=2 AND "
+            "or len(boxes2.shape)=3."
         )
 
     if bounding_box_format.startswith("rel"):
@@ -75,39 +119,19 @@ def compute_iou(
         boxes2, source=bounding_box_format, target=target
     )
 
-    def compute_iou_for_batch(boxes):
-        boxes1, boxes2 = boxes
-        zero = tf.convert_to_tensor(0.0, boxes1.dtype)
-        boxes1_ymin, boxes1_xmin, boxes1_ymax, boxes1_xmax = tf.unstack(
-            boxes1[..., :4, None], 4, axis=-2
-        )
-        boxes2_ymin, boxes2_xmin, boxes2_ymax, boxes2_xmax = tf.unstack(
-            boxes2[None, ..., :4], 4, axis=-1
-        )
-        boxes1_width = tf.maximum(zero, boxes1_xmax - boxes1_xmin)
-        boxes1_height = tf.maximum(zero, boxes1_ymax - boxes1_ymin)
-        boxes2_width = tf.maximum(zero, boxes2_xmax - boxes2_xmin)
-        boxes2_height = tf.maximum(zero, boxes2_ymax - boxes2_ymin)
-        boxes1_area = boxes1_width * boxes1_height
-        boxes2_area = boxes2_width * boxes2_height
-        intersect_ymin = tf.maximum(boxes1_ymin, boxes2_ymin)
-        intersect_xmin = tf.maximum(boxes1_xmin, boxes2_xmin)
-        intersect_ymax = tf.minimum(boxes1_ymax, boxes2_ymax)
-        intersect_xmax = tf.minimum(boxes1_xmax, boxes2_xmax)
-        intersect_width = tf.maximum(zero, intersect_xmax - intersect_xmin)
-        intersect_height = tf.maximum(zero, intersect_ymax - intersect_ymin)
-        intersect_area = intersect_width * intersect_height
-
-        union_area = boxes1_area + boxes2_area - intersect_area
-        return tf.math.divide_no_nan(intersect_area, union_area)
+    intersect_area = _compute_intersection(boxes1, boxes2)
+    boxes1_area = _compute_area(boxes1)
+    boxes2_area = _compute_area(boxes2)
+    boxes2_area_rank = len(boxes2_area.shape)
+    boxes2_axis = 1 if (boxes2_area_rank == 2) else 0
+    boxes1_area = tf.expand_dims(boxes1_area, axis=-1)
+    boxes2_area = tf.expand_dims(boxes2_area, axis=boxes2_axis)
+    union_area = boxes1_area + boxes2_area - intersect_area
+    res = tf.math.divide_no_nan(intersect_area, union_area)
 
     if boxes1_rank == 2:
-        res = compute_iou_for_batch((boxes1, boxes2))
         perm = [1, 0]
     else:
-        res = tf.map_fn(
-            compute_iou_for_batch, elems=(boxes1, boxes2), dtype=boxes1.dtype
-        )
         perm = [0, 2, 1]
 
     if not use_masking:

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -75,10 +75,15 @@ def compute_iou(
     are unbatched and by [`batch`, `boxes1_index`,`boxes2_index`] if the boxes are
     batched.
 
+    The users can pass `boxes1` and `boxes2` to be different ranks. For example:
+    1) `boxes1`: [batch_size, M, 4], `boxes2`: [batch_size, N, 4] -> return [batch_size, M, N].
+    2) `boxes1`: [batch_size, M, 4], `boxes2`: [N, 4] -> return [batch_size, M, N]
+    3) `boxes1`: [M, 4], `boxes2`: [batch_size, N, 4] -> return [batch_size, M, N]
+    4) `boxes1`: [M, 4], `boxes2`: [N, 4] -> return [M, N]
+
     Args:
       boxes1: a list of bounding boxes in 'corners' format. Can be batched or unbatched.
-      boxes2: a list of bounding boxes in 'corners' format. This should match the rank and
-        shape of boxes1.
+      boxes2: a list of bounding boxes in 'corners' format. Can be batched or unbatched.
       bounding_box_format: a case-insensitive string which is one of `"xyxy"`,
         `"rel_xyxy"`, `"xyWH"`, `"center_xyWH"`, `"yxyx"`, `"rel_yxyx"`.
         For detailed information on the supported format, see the

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -26,7 +26,7 @@ def _compute_area(box):
     Returns:
       a float Tensor of [N] or [batch_size, N]
     """
-    y_min, x_min, y_max, x_max = tf.split(box, num_or_size_splits=4, axis=-1)
+    y_min, x_min, y_max, x_max = tf.split(box[..., :4], num_or_size_splits=4, axis=-1)
     return tf.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
 
 
@@ -39,8 +39,12 @@ def _compute_intersection(boxes1, boxes2):
     Returns:
       a [N, M] or [batch_size, N, M] float Tensor.
     """
-    y_min1, x_min1, y_max1, x_max1 = tf.split(boxes1, num_or_size_splits=4, axis=-1)
-    y_min2, x_min2, y_max2, x_max2 = tf.split(boxes2, num_or_size_splits=4, axis=-1)
+    y_min1, x_min1, y_max1, x_max1 = tf.split(
+        boxes1[..., :4], num_or_size_splits=4, axis=-1
+    )
+    y_min2, x_min2, y_max2, x_max2 = tf.split(
+        boxes2[..., :4], num_or_size_splits=4, axis=-1
+    )
     boxes2_rank = len(boxes2.shape)
     perm = [1, 0] if boxes2_rank == 2 else [0, 2, 1]
     # [N, M] or [batch_size, N, M]

--- a/keras_cv/bounding_box/iou_test.py
+++ b/keras_cv/bounding_box/iou_test.py
@@ -92,3 +92,69 @@ class IoUTest(tf.test.TestCase):
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
         self.assertAllClose(expected_result, result.numpy())
+
+    def test_batched_boxes1_unbatched_boxes2(self):
+        bb1 = [100, 101, 200, 201]
+        bb1_off_by_1_pred = [101, 102, 201, 202]
+        iou_bb1_bb1_off = 0.96097656633
+        top_left_bounding_box = [0, 2, 1, 3]
+        far_away_box = [1300, 1400, 1500, 1401]
+        another_far_away_pred = [1000, 1400, 1200, 1401]
+
+        # Rows represent predictions, columns ground truths
+        expected_result = np.array(
+            [
+                [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+                [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        sample_y_true = tf.constant(
+            [
+                [bb1, top_left_bounding_box, far_away_box],
+                [bb1, top_left_bounding_box, far_away_box],
+            ],
+            dtype=tf.float32,
+        )
+        sample_y_pred = tf.constant(
+            [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
+            dtype=tf.float32,
+        )
+
+        result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
+        self.assertAllClose(expected_result, result.numpy())
+
+    def test_unbatched_boxes1_batched_boxes2(self):
+        bb1 = [100, 101, 200, 201]
+        bb1_off_by_1_pred = [101, 102, 201, 202]
+        iou_bb1_bb1_off = 0.96097656633
+        top_left_bounding_box = [0, 2, 1, 3]
+        far_away_box = [1300, 1400, 1500, 1401]
+        another_far_away_pred = [1000, 1400, 1200, 1401]
+
+        # Rows represent predictions, columns ground truths
+        expected_result = np.array(
+            [
+                [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+                [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        sample_y_true = tf.constant(
+            [
+                [bb1, top_left_bounding_box, far_away_box],
+            ],
+            dtype=tf.float32,
+        )
+        sample_y_pred = tf.constant(
+            [
+                [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
+                [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
+            ],
+            dtype=tf.float32,
+        )
+
+        result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
+        self.assertAllClose(expected_result, result.numpy())

--- a/keras_cv/layers/object_detection/rpn_label_encoder_test.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder_test.py
@@ -84,3 +84,48 @@ class RpnLabelEncoderTest(tf.test.TestCase):
         }
         self.assertAllClose(expected_cls_weights[2], cls_weights[2])
         self.assertAllClose(expected_cls_weights[3], cls_weights[3])
+
+    def test_rpn_label_encoder_batched(self):
+        rpn_encoder = _RpnLabelEncoder(
+            anchor_format="xyxy",
+            ground_truth_box_format="xyxy",
+            positive_threshold=0.7,
+            negative_threshold=0.3,
+            positive_fraction=0.5,
+            samples_per_image=2,
+        )
+        rois = tf.constant(
+            [[0, 0, 5, 5], [2.5, 2.5, 7.5, 7.5], [5, 5, 10, 10], [7.5, 7.5, 12.5, 12.5]]
+        )
+        # the 3rd box will generate 0 IOUs and not sampled.
+        gt_boxes = tf.constant([[10, 10, 15, 15], [2.5, 2.5, 7.5, 7.5]])
+        gt_classes = tf.constant([2, 10, -1], dtype=tf.int32)
+        gt_classes = gt_classes[..., tf.newaxis]
+        rois = rois[tf.newaxis, ...]
+        gt_boxes = gt_boxes[tf.newaxis, ...]
+        gt_classes = gt_classes[tf.newaxis, ...]
+        box_targets, box_weights, cls_targets, cls_weights = rpn_encoder(
+            rois, gt_boxes, gt_classes
+        )
+        # all rois will be matched to the 2nd gt boxes, and encoded
+        expected_box_targets = (
+            tf.constant(
+                [
+                    [0.5, 0.5, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                    [-0.5, -0.5, 0.0, 0.0],
+                    [0.5, 0.5, 0.0, 0.0],
+                ]
+            )
+            / 0.1
+        )
+        expected_box_targets = expected_box_targets[tf.newaxis, ...]
+        self.assertAllClose(expected_box_targets, box_targets)
+        # only foreground and background classes
+        self.assertAllClose(tf.reduce_max(cls_targets), 1.0)
+        self.assertAllClose(tf.reduce_min(cls_targets), 0.0)
+        # all weights between 0 and 1
+        self.assertAllClose(tf.reduce_max(cls_weights), 1.0)
+        self.assertAllClose(tf.reduce_min(cls_weights), 0.0)
+        self.assertAllClose(tf.reduce_max(box_weights), 1.0)
+        self.assertAllClose(tf.reduce_min(box_weights), 0.0)

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -367,9 +367,6 @@ class FasterRCNN(tf.keras.Model):
             )
         return rcnn_box_pred, rcnn_cls_pred
 
-    # def train_step(self, data):
-    #     print("data is {}".format(data))
-
     # TODO(tanzhenyu): override train_step and improve call output signature.
     def call(self, images, gt_boxes=None, gt_classes=None, training=None):
         image_shape = tf.shape(images[0])

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -329,6 +329,47 @@ class FasterRCNN(tf.keras.Model):
             positive_fraction=0.5,
         )
 
+    def _call_rpn(self, images, training=None):
+        image_shape = tf.shape(images[0])
+        feature_map = self.backbone(images, training=training)
+        feature_map = self.feature_pyramid(feature_map, training=training)
+        # [BS, num_anchors, 4], [BS, num_anchors, 1]
+        rpn_boxes, rpn_scores = self.rpn_head(feature_map)
+        anchors = self.anchor_generator(image_shape=image_shape)
+        # the decoded format is center_xywh, convert to yxyx
+        decoded_rpn_boxes = _decode_deltas_to_boxes(
+            anchors=anchors,
+            boxes_delta=rpn_boxes,
+            anchor_format="yxyx",
+            box_format="yxyx",
+            variance=[0.1, 0.1, 0.2, 0.2],
+        )
+        rois, _ = self.roi_generator(decoded_rpn_boxes, rpn_scores, training=training)
+        rois = _clip_boxes(rois, "yxyx", image_shape)
+        return rois, feature_map, rpn_boxes, rpn_scores
+
+    def _call_rcnn(self, rois, feature_map, training=None):
+        feature_map = self.roi_pooler(feature_map, rois)
+        # [BS, H*W*K, pool_shape*C]
+        feature_map = tf.reshape(
+            feature_map, tf.concat([tf.shape(rois)[:2], [-1]], axis=0)
+        )
+        # [BS, H*W*K, 4], [BS, H*W*K, num_classes + 1]
+        rcnn_box_pred, rcnn_cls_pred = self.rcnn_head(feature_map)
+        if not training:
+            # now it will be on "center_yxhw" format, convert to target format
+            rcnn_box_pred = _decode_deltas_to_boxes(
+                anchors=rois,
+                boxes_delta=rcnn_box_pred,
+                anchor_format="yxyx",
+                box_format=self.bounding_box_format,
+                variance=[0.1, 0.1, 0.2, 0.2],
+            )
+        return rcnn_box_pred, rcnn_cls_pred
+
+    # def train_step(self, data):
+    #     print("data is {}".format(data))
+
     # TODO(tanzhenyu): override train_step and improve call output signature.
     def call(self, images, gt_boxes=None, gt_classes=None, training=None):
         image_shape = tf.shape(images[0])

--- a/keras_cv/ops/sampling.py
+++ b/keras_cv/ops/sampling.py
@@ -35,7 +35,7 @@ def balanced_sample(
         of all collected samples.
 
     Returns:
-      selected_indicators: [`num_samples`] or [batch_size, `num_samples`]
+      selected_indicators: [N] or [batch_size, N]
         integer Tensor, 1 for indicating the index is sampled, 0 for
         indicating the index is not sampled.
     """


### PR DESCRIPTION
Allow _RPNLabelEncoder to take batched inputs.
Move the data labeling from data pipeline to model pipeline. This
 1) _might_ come with a performance cost (but I haven't noticed any regression), but 
 2) in the long run it get us better performance if we want more data augmentation in the data pipeline.
 3) make supporting `model.fit` more native and users don't have to encode labels if they build their own dataset.

