### PR TITLE
Add pretrained EfficientNetV2b1 weights

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -64,6 +64,23 @@
             "validation_accuracy": "0.7527"
         }
     },
+    "efficientnetv2b1": {
+        "v0": {
+            "accelerators": 8,
+            "args": {
+                "batch_size": "64",
+                "initial_learning_rate": ".0125"
+            },
+            "contributor": "ianstenbit",
+            "epochs_trained": 288,
+            "script": {
+                "name": "basic_training.py",
+                "version": "e349ca5563b05548996f438fa03b2f34a8231ca3"
+            },
+            "tensorboard_logs": "https://tensorboard.dev/experiment/jQAQBh6LQUep18CDayP8ww/",
+            "validation_accuracy": "0.7560"
+        }
+    },
     "resnet50v2": {
         "v0": {
             "accelerators": 2,

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -55,6 +55,10 @@ ALIASES = {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },
+    "efficientnetv2b1": {
+        "imagenet": "imagenet/classification-v0",
+        "imagenet/classification": "imagenet/classification-v0",
+    },
     "resnet50v2": {
         "imagenet": "imagenet/classification-v1",
         "imagenet/classification": "imagenet/classification-v1",
@@ -77,6 +81,10 @@ WEIGHTS_CONFIG = {
     "efficientnetv2b0": {
         "imagenet/classification-v0": "da7975b6d4200dfdc3f859b0d028774e5e5dd4031d3e998a27dadc492dec4f3e",
         "imagenet/classification-v0-notop": "defe635bfa3cc3f2b9e89bfd53bbc3de28a1dc67026b4437a14f44476e7d0549",
+    },
+    "efficientnetv2b1": {
+        "imagenet/classification-v0": "3f92fc9d7b141ec9e85ffe60d301fb49103ba17b148bdd638971a77f1b8db010",
+        "imagenet/classification-v0-notop": "359aaa5c1e863c8438d94052791e72ef29345d07703d06284e1069829f85932f",
     },
     "resnet50v2": {
         "imagenet/classification-v0": "11bde945b54d1dca65101be2648048abca8a96a51a42820d87403486389790db",


### PR DESCRIPTION
Scores .756 on ImageNet top-1, vs .798 paper-claimed (~95% of claimed result)