### PR TITLE
Add model fit for FasterRCNN.

### DIFF
--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -18,16 +18,36 @@ Date created: 2022/09/27
 Last modified: 2022/09/27
 Description: Use KerasCV to train a RetinaNet on Pascal VOC 2007.
 """
-from datetime import datetime
+import sys
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from absl import flags
 
 import keras_cv
 
+flags.DEFINE_string(
+    "weights_path", "~", "Directory which will be used to store weight checkpoints."
+)
+flags.DEFINE_string(
+    "tensorboard_path",
+    "~/logs",
+    "Directory which will be used to store tensorboard logs.",
+)
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
+
 # parameters from FasterRCNN [paper](https://arxiv.org/pdf/1506.01497.pdf)
 
-strategy = tf.distribute.MirroredStrategy()
+# Try to detect an available TPU. If none is present, default to MirroredStrategy
+try:
+    tpu = tf.distribute.cluster_resolver.TPUClusterResolver.connect()
+    strategy = tf.distribute.TPUStrategy(tpu)
+except ValueError:
+    # MirroredStrategy is best for a single machine with one or multiple GPUs
+    strategy = tf.distribute.MirroredStrategy()
+print("Number of accelerators: ", strategy.num_replicas_in_sync)
+
 local_batch = 4
 global_batch = local_batch * strategy.num_replicas_in_sync
 base_lr = 0.01 * global_batch / 16
@@ -241,13 +261,13 @@ eval_ds = eval_ds.prefetch(2)
 with strategy.scope():
     # The keras huber loss will sum all losses and divide by BS * N * 4, instead we want divide by BS
     # using NONE reduction as also summing creates issues
-    rpn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.NONE)
+    rpn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.SUM)
     rpn_cls_loss_fn = tf.keras.losses.BinaryCrossentropy(
-        from_logits=True, reduction=tf.keras.losses.Reduction.NONE
+        from_logits=True, reduction=tf.keras.losses.Reduction.SUM
     )
-    rcnn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.NONE)
+    rcnn_reg_loss_fn = tf.keras.losses.Huber(reduction=tf.keras.losses.Reduction.SUM)
     rcnn_cls_loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(
-        reduction=tf.keras.losses.Reduction.NONE
+        reduction=tf.keras.losses.Reduction.SUM
     )
 
     rpn_reg_metric = tf.keras.metrics.Mean()
@@ -267,167 +287,11 @@ with strategy.scope():
 weight_decay = 0.0001
 step = 0
 
-
-def compute_loss(examples, training):
-    image = examples["images"]
-    gt_boxes = examples["gt_boxes"]
-    gt_classes = examples["gt_classes"]
-    anchors = model.anchor_generator(image_shape=image_size)
-    anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
-    box_targets, box_weights, cls_targets, cls_weights = model.rpn_labeler(
-        anchors, gt_boxes, gt_classes
-    )
-    outputs = model(image, gt_boxes=gt_boxes, gt_classes=gt_classes, training=training)
-    rpn_box_pred, rpn_cls_pred = outputs["rpn_box_pred"], outputs["rpn_cls_pred"]
-    rpn_reg_loss = tf.reduce_sum(
-        rpn_reg_loss_fn(box_targets, rpn_box_pred, box_weights)
-    )
-    # avoid divide by zero
-    # positive_boxes = tf.reduce_sum(box_weights) + 0.01
-    # x4 given huber loss reduce_mean on the box dimension
-    # rpn_reg_loss /= positive_boxes * 0.25
-    rpn_reg_loss /= model.rpn_labeler.samples_per_image * global_batch * 0.25
-    rpn_cls_loss = tf.reduce_sum(
-        rpn_cls_loss_fn(cls_targets, rpn_cls_pred, cls_weights)
-    )
-    rpn_cls_loss /= model.rpn_labeler.samples_per_image * global_batch
-
-    rcnn_reg_loss = tf.reduce_sum(
-        rcnn_reg_loss_fn(
-            outputs["rcnn_box_targets"],
-            outputs["rcnn_box_pred"],
-            outputs["rcnn_box_weights"],
-        )
-    )
-    # avoid divide by zero
-    # positive_rois = tf.reduce_sum(outputs["rcnn_box_weights"]) + 0.01
-    # rcnn_reg_loss /= positive_rois * 0.25
-    rcnn_reg_loss /= model.roi_sampler.num_sampled_rois * global_batch * 0.25
-    rcnn_cls_loss = tf.reduce_sum(
-        rcnn_cls_loss_fn(
-            outputs["rcnn_cls_targets"],
-            outputs["rcnn_cls_pred"],
-            outputs["rcnn_cls_weights"],
-        )
-    )
-    # 512 is for num_sampled_rois
-    rcnn_cls_loss /= model.roi_sampler.num_sampled_rois * global_batch
-    l2_vars = []
-    for var in model.trainable_variables:
-        if "bn" not in var.name:
-            l2_vars.append(var)
-    l2_loss = weight_decay * tf.add_n([tf.nn.l2_loss(var) for var in l2_vars])
-    total_loss = rpn_reg_loss + rpn_cls_loss + rcnn_reg_loss + rcnn_cls_loss + l2_loss
-    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, l2_loss, total_loss
-
-
-@tf.function
-def train_step(examples):
-    with tf.GradientTape() as tape:
-        (
-            rpn_reg_loss,
-            rpn_cls_loss,
-            rcnn_reg_loss,
-            rcnn_cls_loss,
-            l2_loss,
-            total_loss,
-        ) = compute_loss(examples, training=True)
-    gradients = tape.gradient(total_loss, model.trainable_variables)
-    optimizer.apply_gradients(zip(gradients, model.trainable_variables))
-    return rpn_reg_loss, rpn_cls_loss, rcnn_reg_loss, rcnn_cls_loss, l2_loss, total_loss
-
-
-@tf.function
-def eval_step(examples):
-    (
-        rpn_reg_loss,
-        rpn_cls_loss,
-        rcnn_reg_loss,
-        rcnn_cls_loss,
-        _,
-        total_loss,
-    ) = compute_loss(examples, training=True)
-    # the loss is already divided by global batch, so Mean metrics need to scale back
-    num_syncs = strategy.num_replicas_in_sync
-    rpn_reg_metric.update_state(rpn_reg_loss * num_syncs)
-    rpn_cls_metric.update_state(rpn_cls_loss * num_syncs)
-    rcnn_reg_metric.update_state(rcnn_reg_loss * num_syncs)
-    rcnn_cls_metric.update_state(rcnn_cls_loss * num_syncs)
-    return total_loss
-
-
-@tf.function
-def distributed_train_step(dataset_inputs):
-    per_replica_losses = strategy.run(train_step, args=(dataset_inputs,))
-    return strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_losses, axis=None)
-
-
-@tf.function
-def distributed_eval_step(dataset_inputs):
-    return strategy.run(eval_step, args=(dataset_inputs,))
-
-
-rpn_reg_loss = 0.0
-rpn_cls_loss = 0.0
-rcnn_reg_loss = 0.0
-rcnn_cls_loss = 0.0
-l2_loss = 0.0
-step_size = 500
-
-dist_train_ds = strategy.experimental_distribute_dataset(train_ds)
-dist_eval_ds = strategy.experimental_distribute_dataset(eval_ds)
-
-for epoch in range(1, 19):
-    for examples in dist_train_ds:
-        (
-            step_rpn_reg_loss,
-            step_rpn_cls_loss,
-            step_rcnn_reg_loss,
-            step_rcnn_cls_loss,
-            step_l2_loss,
-            total_loss,
-        ) = distributed_train_step(examples)
-        rpn_reg_loss += step_rpn_reg_loss
-        rpn_cls_loss += step_rpn_cls_loss
-        rcnn_reg_loss += step_rcnn_reg_loss
-        rcnn_cls_loss += step_rcnn_cls_loss
-        l2_loss += step_l2_loss
-        step += 1
-        if step % step_size == 0:
-            print(
-                "step {} rpn_reg {:.4}, rpn_cls {:.4}, rcnn_reg {:.4}, rcnn_cls {:.4}, l2 {:.4}, pos_rois {:.4}, neg_rois {:.4}".format(
-                    step,
-                    rpn_reg_loss / step_size,
-                    rpn_cls_loss / step_size,
-                    rcnn_reg_loss / step_size,
-                    rcnn_cls_loss / step_size,
-                    l2_loss / step_size,
-                    model.roi_sampler._positives.result(),
-                    model.roi_sampler._negatives.result(),
-                )
-            )
-            rpn_reg_loss = 0.0
-            rpn_cls_loss = 0.0
-            rcnn_reg_loss = 0.0
-            rcnn_cls_loss = 0.0
-            l2_loss = 0.0
-            model.roi_sampler._positives.reset_state()
-            model.roi_sampler._negatives.reset_state()
-    for examples in dist_eval_ds:
-        _ = distributed_eval_step(examples)
-    print(
-        "epoch {} rpn reg loss {:.4}, rpn cls loss {:.4}, rcnn reg loss {:.4}, rcnn cls loss {:.4}".format(
-            epoch,
-            rpn_reg_metric.result(),
-            rpn_cls_metric.result(),
-            rcnn_reg_metric.result(),
-            rcnn_cls_metric.result(),
-        )
-    )
-    rpn_reg_metric.reset_state()
-    rpn_cls_metric.reset_state()
-    rcnn_reg_metric.reset_state()
-    rcnn_cls_metric.reset_state()
-    print(f"{datetime.now()} finished epoch {epoch}", flush=True)
-
-    model.save_weights(f"./weights_{epoch}.h5")
+callbacks = [
+    tf.keras.callbacks.ModelCheckpoint(FLAGS.weights_path, save_weights_only=True),
+    tf.keras.callbacks.TensorBoard(
+        log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
+    ),
+]
+model.compile(optimizer=optimizer)
+model.fit(train_ds, epochs=18, validation_data=eval_ds, callbacks=callbacks)

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -275,5 +275,11 @@ callbacks = [
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
     ),
 ]
-model.compile(optimizer=optimizer)
+model.compile(
+    optimizer=optimizer,
+    box_loss="Huber",
+    classification_loss="SparseCategoricalCrossentropy",
+    rpn_box_loss="Huber",
+    rpn_classification_loss="BinaryCrossentropy",
+)
 model.fit(train_ds, epochs=18, validation_data=eval_ds, callbacks=callbacks)

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -27,11 +27,13 @@ from absl import flags
 import keras_cv
 
 flags.DEFINE_string(
-    "weights_path", "weights_{epoch:02d}.h5", "Directory which will be used to store weight checkpoints."
+    "weights_path",
+    "weights_{epoch:02d}.h5",
+    "Directory which will be used to store weight checkpoints.",
 )
 flags.DEFINE_string(
     "tensorboard_path",
-    "~/logs",
+    "logs",
     "Directory which will be used to store tensorboard logs.",
 )
 FLAGS = flags.FLAGS

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -27,7 +27,7 @@ from absl import flags
 import keras_cv
 
 flags.DEFINE_string(
-    "weights_path", "~", "Directory which will be used to store weight checkpoints."
+    "weights_path", "weights_{epoch:02d}.h5", "Directory which will be used to store weight checkpoints."
 )
 flags.DEFINE_string(
     "tensorboard_path",

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -329,13 +329,12 @@ class FasterRCNN(tf.keras.Model):
             positive_fraction=0.5,
         )
 
-    def _call_rpn(self, images, training=None):
+    def _call_rpn(self, images, anchors, training=None):
         image_shape = tf.shape(images[0])
         feature_map = self.backbone(images, training=training)
         feature_map = self.feature_pyramid(feature_map, training=training)
         # [BS, num_anchors, 4], [BS, num_anchors, 1]
         rpn_boxes, rpn_scores = self.rpn_head(feature_map)
-        anchors = self.anchor_generator(image_shape=image_shape)
         # the decoded format is center_xywh, convert to yxyx
         decoded_rpn_boxes = _decode_deltas_to_boxes(
             anchors=anchors,
@@ -346,9 +345,11 @@ class FasterRCNN(tf.keras.Model):
         )
         rois, _ = self.roi_generator(decoded_rpn_boxes, rpn_scores, training=training)
         rois = _clip_boxes(rois, "yxyx", image_shape)
+        rpn_boxes = tf.concat(tf.nest.flatten(rpn_boxes), axis=1)
+        rpn_scores = tf.concat(tf.nest.flatten(rpn_scores), axis=1)
         return rois, feature_map, rpn_boxes, rpn_scores
 
-    def _call_rcnn(self, rois, feature_map, training=None):
+    def _call_rcnn(self, rois, feature_map):
         feature_map = self.roi_pooler(feature_map, rois)
         # [BS, H*W*K, pool_shape*C]
         feature_map = tf.reshape(
@@ -356,71 +357,151 @@ class FasterRCNN(tf.keras.Model):
         )
         # [BS, H*W*K, 4], [BS, H*W*K, num_classes + 1]
         rcnn_box_pred, rcnn_cls_pred = self.rcnn_head(feature_map)
-        if not training:
-            # now it will be on "center_yxhw" format, convert to target format
-            rcnn_box_pred = _decode_deltas_to_boxes(
-                anchors=rois,
-                boxes_delta=rcnn_box_pred,
-                anchor_format="yxyx",
-                box_format=self.bounding_box_format,
-                variance=[0.1, 0.1, 0.2, 0.2],
-            )
         return rcnn_box_pred, rcnn_cls_pred
 
-    # TODO(tanzhenyu): override train_step and improve call output signature.
-    def call(self, images, gt_boxes=None, gt_classes=None, training=None):
+    def call(self, images, training=None):
         image_shape = tf.shape(images[0])
-        feature_map = self.backbone(images, training=training)
-        feature_map = self.feature_pyramid(feature_map, training=training)
-        # [BS, num_anchors, 4], [BS, num_anchors, 1]
-        rpn_boxes, rpn_scores = self.rpn_head(feature_map)
         anchors = self.anchor_generator(image_shape=image_shape)
-        # the decoded format is center_xywh
-        decoded_rpn_boxes = _decode_deltas_to_boxes(
-            anchors=anchors,
-            boxes_delta=rpn_boxes,
-            anchor_format="yxyx",
-            box_format="yxyx",
-            variance=[0.1, 0.1, 0.2, 0.2],
-        )
-        rois, _ = self.roi_generator(decoded_rpn_boxes, rpn_scores, training=training)
-        rois = _clip_boxes(rois, "yxyx", image_shape)
-        if training:
-            rois = tf.stop_gradient(rois)
-            (
-                rois,
-                rcnn_box_targets,
-                rcnn_box_weights,
-                rcnn_cls_targets,
-                rcnn_cls_weights,
-            ) = self.roi_sampler(rois, gt_boxes, gt_classes)
-        feature_map = self.roi_pooler(feature_map, rois)
-        # [BS, H*W*K, pool_shape*C]
-        feature_map = tf.reshape(
-            feature_map, tf.concat([tf.shape(rois)[:2], [-1]], axis=0)
-        )
-        # [BS, H*W*K, 4], [BS, H*W*K, num_classes + 1]
-        rcnn_box_pred, rcnn_cls_pred = self.rcnn_head(feature_map)
-        res = {}
-        if training:
-            res["rcnn_box_pred"] = rcnn_box_pred
-            res["rcnn_cls_pred"] = rcnn_cls_pred
-            res["rpn_box_pred"] = tf.concat(tf.nest.flatten(rpn_boxes), axis=1)
-            res["rpn_cls_pred"] = tf.concat(tf.nest.flatten(rpn_scores), axis=1)
-            res["rcnn_box_targets"] = rcnn_box_targets
-            res["rcnn_box_weights"] = rcnn_box_weights
-            res["rcnn_cls_targets"] = rcnn_cls_targets
-            res["rcnn_cls_weights"] = rcnn_cls_weights
-        else:
-            # now it will be on "center_yxhw" format
-            rcnn_box_pred = _decode_deltas_to_boxes(
+        rois, feature_map, _, _ = self._call_rpn(images, anchors, training=training)
+        box_pred, cls_pred = self._call_rcnn(rois, feature_map)
+        if not training:
+            # box_pred is on "center_yxhw" format, convert to target format.
+            box_pred = _decode_deltas_to_boxes(
                 anchors=rois,
-                boxes_delta=rcnn_box_pred,
+                boxes_delta=box_pred,
                 anchor_format="yxyx",
                 box_format=self.bounding_box_format,
                 variance=[0.1, 0.1, 0.2, 0.2],
             )
-            res["rcnn_box_pred"] = rcnn_box_pred
-            res["rcnn_cls_pred"] = rcnn_cls_pred
+        return box_pred, cls_pred
 
-        return res
+    def compile(
+        self,
+        box_loss=None,
+        classification_loss=None,
+        rpn_box_loss=None,
+        rpn_classification_loss=None,
+        weight_decay=0.0001,
+        **kwargs,
+    ):
+        if "metrics" in kwargs.keys():
+            raise ValueError("currently metrics support is not supported intentionally")
+        reduction_type = tf.keras.losses.Reduction.SUM
+        if not box_loss:
+            box_loss = tf.keras.losses.Huber(reduction=reduction_type)
+        if not classification_loss:
+            classification_loss = tf.keras.losses.SparseCategoricalCrossentropy(
+                reduction=reduction_type
+            )
+        if not rpn_box_loss:
+            rpn_box_loss = tf.keras.losses.Huber(reduction=reduction_type)
+        if not rpn_classification_loss:
+            rpn_classification_loss = tf.keras.losses.BinaryCrossentropy(
+                from_logits=True, reduction=reduction_type
+            )
+        _validate_loss(box_loss, "box_loss")
+        _validate_loss(classification_loss, "classification_loss")
+        _validate_loss(rpn_box_loss, "rpn_box_loss")
+        _validate_loss(rpn_classification_loss, "rpn_classification_loss")
+        if not rpn_classification_loss.from_logits:
+            raise ValueError(
+                "`rpn_classification_loss` must come with `from_logits`=True"
+            )
+
+        self.rpn_box_loss = rpn_box_loss
+        self.rpn_cls_loss = rpn_classification_loss
+        self.box_loss = box_loss
+        self.cls_loss = classification_loss
+        self.weight_decay = weight_decay
+        losses = {
+            "box": self.box_loss,
+            "cls": self.cls_loss,
+            "rpn_box": self.rpn_box_loss,
+            "rpn_cls": self.rpn_cls_loss,
+        }
+        super().compile(loss=losses, **kwargs)
+
+    def compute_loss(self, images, gt_boxes, gt_classes, training):
+        image_shape = tf.shape(images[0])
+        local_batch = images.get_shape().as_list()[0]
+        if tf.distribute.has_strategy():
+            num_sync = tf.distribute.get_strategy().num_replicas_in_sync
+        else:
+            num_sync = 1
+        global_batch = local_batch * num_sync
+        anchors = self.anchor_generator(image_shape=image_shape)
+        (
+            rpn_box_targets,
+            rpn_box_weights,
+            rpn_cls_targets,
+            rpn_cls_weights,
+        ) = self.rpn_labeler(
+            tf.concat(tf.nest.flatten(anchors), axis=0), gt_boxes, gt_classes
+        )
+        rpn_box_weights /= self.rpn_labeler.samples_per_image * global_batch * 0.25
+        rpn_cls_weights /= self.rpn_labeler.samples_per_image * global_batch
+        rois, feature_map, rpn_box_pred, rpn_cls_pred = self._call_rpn(
+            images, anchors, training=training
+        )
+        rois = tf.stop_gradient(rois)
+        rois, box_targets, box_weights, cls_targets, cls_weights = self.roi_sampler(
+            rois, gt_boxes, gt_classes
+        )
+        box_weights /= self.roi_sampler.num_sampled_rois * global_batch * 0.25
+        cls_weights /= self.roi_sampler.num_sampled_rois * global_batch
+        box_pred, cls_pred = self._call_rcnn(rois, feature_map)
+        y_true = {
+            "rpn_box": rpn_box_targets,
+            "rpn_cls": rpn_cls_targets,
+            "box": box_targets,
+            "cls": cls_targets,
+        }
+        y_pred = {
+            "rpn_box": rpn_box_pred,
+            "rpn_cls": rpn_cls_pred,
+            "box": box_pred,
+            "cls": cls_pred,
+        }
+        weights = {
+            "rpn_box": rpn_box_weights,
+            "rpn_cls": rpn_cls_weights,
+            "box": box_weights,
+            "cls": cls_weights,
+        }
+        return super().compute_loss(
+            x=images, y=y_true, y_pred=y_pred, sample_weight=weights
+        )
+
+    def train_step(self, data):
+        images = data["images"]
+        gt_boxes = data["gt_boxes"]
+        gt_classes = data["gt_classes"]
+        with tf.GradientTape() as tape:
+            total_loss = self.compute_loss(images, gt_boxes, gt_classes, training=True)
+            reg_losses = []
+            if self.weight_decay:
+                for var in self.trainable_variables:
+                    if "bn" not in var.name:
+                        reg_losses.append(self.weight_decay * tf.nn.l2_loss(var))
+                l2_loss = tf.math.add_n(reg_losses)
+            total_loss += l2_loss
+        self.optimizer.minimize(total_loss, self.trainable_variables, tape=tape)
+        return self.compute_metrics(images, {}, {}, sample_weight={})
+
+    def test_step(self, data):
+        images = data["images"]
+        gt_boxes = data["gt_boxes"]
+        gt_classes = data["gt_classes"]
+        self.compute_loss(images, gt_boxes, gt_classes, training=False)
+        return self.compute_metrics(images, {}, {}, sample_weight={})
+
+
+def _validate_loss(loss, loss_name):
+    if not isinstance(loss, tf.keras.losses.Loss):
+        raise ValueError(
+            f"FasterRCNN only accepts `tf.keras.losses.Loss` for {loss_name}, got {loss}"
+        )
+    if loss.reduction != tf.keras.losses.Reduction.SUM:
+        raise ValueError(
+            f"FasterRCNN only accepts `SUM` reduction, got {loss.reduction}"
+        )

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -384,6 +384,8 @@ class FasterRCNN(tf.keras.Model):
         weight_decay=0.0001,
         **kwargs,
     ):
+        # TODO(tanzhenyu): Add metrics support once COCOMap issue is addressed.
+        # https://github.com/keras-team/keras-cv/issues/915
         if "metrics" in kwargs.keys():
             raise ValueError("currently metrics support is not supported intentionally")
         reduction_type = tf.keras.losses.Reduction.SUM

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -490,9 +490,11 @@ class FasterRCNN(tf.keras.Model):
         return self.compute_metrics(images, {}, {}, sample_weight={})
 
     def test_step(self, data):
-        images = data["images"]
-        gt_boxes = data["gt_boxes"]
-        gt_classes = data["gt_classes"]
+        images, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
+        if sample_weight is not None:
+            raise ValueError("`sample_weight` is currently not supported.")
+        gt_boxes = y["gt_boxes"]
+        gt_classes = y["gt_classes"]
         self.compute_loss(images, gt_boxes, gt_classes, training=False)
         return self.compute_metrics(images, {}, {}, sample_weight={})
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -379,17 +379,24 @@ class FasterRCNN(tf.keras.Model):
     # TODO(tanzhenyu): Support compile with metrics.
     def compile(
         self,
-        box_loss="Huber",
-        classification_loss="SparseCategoricalCrossentropy",
-        rpn_box_loss="Huber",
-        rpn_classification_loss="BinaryCrossentropy",
+        box_loss=None,
+        classification_loss=None,
+        rpn_box_loss=None,
+        rpn_classification_loss=None,
         weight_decay=0.0001,
+        loss=None,
         **kwargs,
     ):
         # TODO(tanzhenyu): Add metrics support once COCOMap issue is addressed.
         # https://github.com/keras-team/keras-cv/issues/915
         if "metrics" in kwargs.keys():
             raise ValueError("currently metrics support is not supported intentionally")
+        if loss is not None:
+            raise ValueError(
+                "`FasterRCNN` does not accept a `loss` to `compile()`. "
+                "Instead, please pass `box_loss` and `classification_loss`. "
+                "`loss` will be ignored during training."
+            )
         box_loss = _validate_and_get_loss(box_loss, "box_loss")
         classification_loss = _validate_and_get_loss(
             classification_loss, "classification_loss"
@@ -502,7 +509,7 @@ class FasterRCNN(tf.keras.Model):
 def _validate_and_get_loss(loss, loss_name):
     if isinstance(loss, str):
         loss = tf.keras.losses.get(loss)
-    if not isinstance(loss, tf.keras.losses.Loss):
+    if loss is None or not isinstance(loss, tf.keras.losses.Loss):
         raise ValueError(
             f"FasterRCNN only accepts `tf.keras.losses.Loss` for {loss_name}, got {loss}"
         )

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -43,3 +43,9 @@ class FasterRCNNTest(tf.test.TestCase):
                     from_logits=False
                 )
             )
+        with self.assertRaisesRegex(ValueError, "SUM"):
+            model.compile(
+                rpn_box_loss=tf.keras.losses.Huber(
+                    reduction=tf.keras.losses.Reduction.AUTO
+                )
+            )

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -37,7 +37,7 @@ class FasterRCNNTest(tf.test.TestCase):
         model = FasterRCNN(classes=80, bounding_box_format="yxyx")
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")
-        with self.assertRaisesRegex(ValueError, "from_logits"):
+        with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(
                 rpn_classification_loss=tf.keras.losses.BinaryCrossentropy(
                     from_logits=False

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -37,15 +37,9 @@ class FasterRCNNTest(tf.test.TestCase):
         model = FasterRCNN(classes=80, bounding_box_format="yxyx")
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")
-        with self.assertRaisesRegex(ValueError, "only accepts"):
+        with self.assertRaisesRegex(ValueError, "from_logits"):
             model.compile(
                 rpn_classification_loss=tf.keras.losses.BinaryCrossentropy(
                     from_logits=False
-                )
-            )
-        with self.assertRaisesRegex(ValueError, "SUM"):
-            model.compile(
-                rpn_box_loss=tf.keras.losses.Huber(
-                    reduction=tf.keras.losses.Reduction.AUTO
                 )
             )


### PR DESCRIPTION
Completing the story of `Model.fit` for FasterRCNN.
This is achieved by overriding `train_step` and `test_step`.
Testing it with Pascal VOC dataset, the performance / quality is similar to CTL.
Currently I'm not adding functionality to upload weights and benchmark test given we don't have a metrics system that produces the same result as pycoco yet.

Some design questions:
1) the compile method is following similar pattern of RetinaNet, i.e., compile(box_loss, cls_loss, ...). I think this is fine, but would like to have a consensus here.
2) the compile method uses `weight_decay` -- not too happy about it, but we cannot ask users to add `kernel_regularizer` for their backbones at this point. I think in TF2.10 we may be able to rely on `optimizers.SGDW` instead, but given weight decay should skip batch norm, and KerasCV should work with tf2.9 (I believe there's a huge optimizer bug fix which didn't get backported to 2.9), this seems to be the only way.
