### PR TITLE
Fixed efficientnet v1 correct pad.

### DIFF
--- a/keras_cv/models/efficientnet_v1.py
+++ b/keras_cv/models/efficientnet_v1.py
@@ -187,7 +187,7 @@ def correct_pad(inputs, kernel_size):
     Returns:
       A tuple.
     """
-    img_dim = 2
+    img_dim = 1
     input_size = backend.int_shape(inputs)[img_dim : (img_dim + 2)]
     if isinstance(kernel_size, int):
         kernel_size = (kernel_size, kernel_size)


### PR DESCRIPTION
# What does this PR do?
The `correct_pad` function in efficientnet v1 is using the wrong `image_dim`. It assumes `channels_first`, while keras-cv operates on `channels_last`. 

Reference function: [here](https://github.com/keras-team/keras/blob/bb78a0caaea0503728784c0fa5cf547c623633b0/keras/applications/imagenet_utils.py#L441)

The weights should load anyway, but the metric values will be affected.
(I'm not sure if this is big enough for a separate issue first)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood 
