### PR TITLE
removing the usage of len to allow saving models in the saved_model format

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/__internal__/layers/group_normalization.py
+++ b/keras_cv/models/generative/stable_diffusion/__internal__/layers/group_normalization.py
@@ -84,7 +84,7 @@ class GroupNormalization(tf.keras.layers.Layer):
         return gamma, beta
 
     def _create_broadcast_shape(self, input_shape):
-        broadcast_shape = [1] * len(input_shape)
+        broadcast_shape = [1] * input_shape.shape[0]
         broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
         broadcast_shape.insert(self.axis, self.groups)
         return broadcast_shape


### PR DESCRIPTION
this len forbids the framework from saving these models in the saved_model format replacing with the shape is what it's recommended

# What does this PR do?

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

@LukeWood 
