### PR TITLE
Introduce testing decorators

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -16,10 +16,13 @@ import tensorflow as tf
 from tensorflow.keras import mixed_precision
 
 from keras_cv.models import StableDiffusion
+from keras_cv.testing import integration
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    def DISABLED_test_end_to_end_golden_value(self):
+
+    @integration
+    def test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 
@@ -34,12 +37,14 @@ class StableDiffusionTest(tf.test.TestCase):
         text_encoding = stablediff.encode_text(prompt)
         self.assertAllClose(img, stablediff.generate_image(text_encoding), atol=1e-4)
 
-    def DISABLED_test_mixed_precision(self):
+    @integration
+    def test_mixed_precision(self):
         mixed_precision.set_global_policy("mixed_float16")
         stablediff = StableDiffusion(128, 128)
         _ = stablediff.text_to_image("Testing123 haha!")
 
-    def DISABLED_test_generate_image_rejects_noise_and_seed(self):
+    @integration
+    def test_generate_image_rejects_noise_and_seed(self):
         stablediff = StableDiffusion(128, 128)
 
         with self.assertRaisesRegex(

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -20,8 +20,7 @@ from keras_cv.testing import integration
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    @integration
-    def test_end_to_end_golden_value(self):
+    def DISABLED_test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 
@@ -36,14 +35,12 @@ class StableDiffusionTest(tf.test.TestCase):
         text_encoding = stablediff.encode_text(prompt)
         self.assertAllClose(img, stablediff.generate_image(text_encoding), atol=1e-4)
 
-    @integration
-    def test_mixed_precision(self):
+    def DISABLED_test_mixed_precision(self):
         mixed_precision.set_global_policy("mixed_float16")
         stablediff = StableDiffusion(128, 128)
         _ = stablediff.text_to_image("Testing123 haha!")
 
-    @integration
-    def test_generate_image_rejects_noise_and_seed(self):
+    def DISABLED_test_generate_image_rejects_noise_and_seed(self):
         stablediff = StableDiffusion(128, 128)
 
         with self.assertRaisesRegex(

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -20,7 +20,6 @@ from keras_cv.testing import integration
 
 
 class StableDiffusionTest(tf.test.TestCase):
-
     @integration
     def test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"

--- a/keras_cv/testing/__init__.py
+++ b/keras_cv/testing/__init__.py
@@ -1,0 +1,2 @@
+from keras_cv.testing.utils import integration
+from keras_cv.testing.utils import requires_custom_ops

--- a/keras_cv/testing/__init__.py
+++ b/keras_cv/testing/__init__.py
@@ -1,2 +1,16 @@
+# Copyright 2022 The KerasCV Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
 from keras_cv.testing.utils import integration
 from keras_cv.testing.utils import requires_custom_ops

--- a/keras_cv/testing/utils.py
+++ b/keras_cv/testing/utils.py
@@ -1,0 +1,30 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def integration(test_fn):
+    # local scoped import to make installation only required in testing mode
+    import pytest
+
+    return pytest.skipif(
+        "INTEGRATION" not in os.environ or os.environ["SKIP_CUSTOM_OPS"] != "true"
+    )(test_fn)
+
+
+def requires_custom_ops(test_fn):
+    import pytest
+
+    return pytest.skipif(
+        "SKIP_CUSTOM_OPS" not in os.environ or os.environ["SKIP_CUSTOM_OPS"] != "true",
+    )(test_fn)

--- a/keras_cv/testing/utils.py
+++ b/keras_cv/testing/utils.py
@@ -11,20 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 
 def integration(test_fn):
     # local scoped import to make installation only required in testing mode
     import pytest
 
-    return pytest.skipif(
-        "INTEGRATION" not in os.environ or os.environ["SKIP_CUSTOM_OPS"] != "true"
+    return pytest.mark.skipif(
+        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
+        reason="Integration test.  Set environment variable `INTEGRATION=True`"
+        " to run.",
     )(test_fn)
 
 
 def requires_custom_ops(test_fn):
     import pytest
 
-    return pytest.skipif(
+    return pytest.mark.skipif(
         "SKIP_CUSTOM_OPS" not in os.environ or os.environ["SKIP_CUSTOM_OPS"] != "true",
+        reason="Requires custom ops.  Set environment variable `SKIP_CUSTOM_OPS=True`"
+        " to run.",
     )(test_fn)


### PR DESCRIPTION
These decorators allow you to skip tests if they require lots of resources, time, or custom C++ ops.

They're pretty trivial, and just make tests opt-in.