### PR TITLE
Add better weights for ResNet50V2

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -110,6 +110,21 @@
             },
             "tensorboard_logs": "https://tensorboard.dev/experiment/TQ5r1EhXS4SDDagBD84rgA/",
             "validation_accuracy": "0.7550"
+        },
+        "v2": {
+            "accelerators": 8,
+            "args": {
+                "batch_size": "64",
+                "initial_learning_rate": ".0125"
+            },
+            "contributor": "ianstenbit",
+            "epochs_trained": 150,
+            "script": {
+                "name": "basic_training.py",
+                "version": "02b41ea91b972cdd29c27dbc4d79e6a0b4e90de2"
+            },
+            "tensorboard_logs": "https://tensorboard.dev/experiment/ReyWQHwETwah0nqlXl8BOA/",
+            "validation_accuracy": "0.7612"
         }
     },
     "script_authors": {

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -46,7 +46,8 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         classes: optional number of classes to classify images into, only to be
             specified if `include_top` is True.
         weights: one of `None` (random initialization), a pretrained weight file
-            path, or a reference to pre-trained weights (e.g. 'imagenet/classification') (see available pre-trained weights in weights.py)
+            path, or a reference to pre-trained weights (e.g. 'imagenet/classification')
+            (see available pre-trained weights in weights.py)
         input_shape: optional shape tuple, defaults to (None, None, 3).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras_cv/models/efficientnet_v2.py
+++ b/keras_cv/models/efficientnet_v2.py
@@ -530,8 +530,9 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
                     inputs will be passed through a `Rescaling(1/255.0)` layer.
         include_top: Whether to include the fully-connected
             layer at the top of the network.
-        weights: One of `None` (random initialization),
-                or the path to the weights file to be loaded.
+        weights: one of `None` (random initialization), a pretrained weight file
+            path, or a reference to pre-trained weights (e.g. 'imagenet/classification')
+            (see available pre-trained weights in weights.py)
         input_shape: Optional shape tuple.
             It should have exactly 3 inputs channels.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -76,8 +76,9 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
             network.  If provided, classes must be provided.
         classes: optional number of classes to classify images into, only to be
             specified if `include_top` is True.
-        weights: one of `None` (random initialization), or a pretrained weight file
-            path.
+        weights: one of `None` (random initialization), a pretrained weight file
+            path, or a reference to pre-trained weights (e.g. 'imagenet/classification')
+            (see available pre-trained weights in weights.py)
         input_shape: optional shape tuple, defaults to (None, None, 3).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -60,8 +60,8 @@ ALIASES = {
         "imagenet/classification": "imagenet/classification-v0",
     },
     "resnet50v2": {
-        "imagenet": "imagenet/classification-v1",
-        "imagenet/classification": "imagenet/classification-v1",
+        "imagenet": "imagenet/classification-v2",
+        "imagenet/classification": "imagenet/classification-v2",
     },
 }
 
@@ -91,5 +91,7 @@ WEIGHTS_CONFIG = {
         "imagenet/classification-v0-notop": "5b4aca4932c433d84f6aef58135472a4312ed2fa565d53fedcd6b0c24b54ab4a",
         "imagenet/classification-v1": "a32e5d9998e061527f6f947f36d8e794ad54dad71edcd8921cda7804912f3ee7",
         "imagenet/classification-v1-notop": "ac46b82c11070ab2f69673c41fbe5039c9eb686cca4f34cd1d79412fd136f1ae",
+        "imagenet/classification-v2": "5ee5a8ac650aaa59342bc48ffe770e6797a5550bcc35961e1d06685292c15921",
+        "imagenet/classification-v2-notop": "e711c83d6db7034871f6d345a476c8184eab99dbf3ffcec0c1d8445684890ad9",
     },
 }


### PR DESCRIPTION
These weights score 76.12% top-1 on ImageNet (better than the Keras Applications weights at 76.0%)