### PR TITLE
Add tf.function(jit_compile=True) for the PNG decode function.

### DIFF
--- a/keras_cv/datasets/pascal_voc/segmentation.py
+++ b/keras_cv/datasets/pascal_voc/segmentation.py
@@ -259,6 +259,9 @@ def _build_metadata(data_dir, image_ids):
     return result
 
 
+# With jit_compile=True, there will be 0.4 sec compilation overhead, but save about 0.2
+# sec per 1000 images. See https://github.com/keras-team/keras-cv/pull/943#discussion_r1001092882
+# for more details.
 @tf.function(jit_compile=True)
 def _decode_png_mask(mask):
     """Decode the raw PNG image and convert it to 2D tensor with probably class."""

--- a/keras_cv/datasets/pascal_voc/segmentation.py
+++ b/keras_cv/datasets/pascal_voc/segmentation.py
@@ -259,6 +259,7 @@ def _build_metadata(data_dir, image_ids):
     return result
 
 
+@tf.function(jit_compile=True)
 def _decode_png_mask(mask):
     """Decode the raw PNG image and convert it to 2D tensor with probably class."""
     # Cast the mask to int32 since the original uint8 will overflow when multiple with 256


### PR DESCRIPTION
# What does this PR do?
Change the decode function to be backed with XLA for better performance.

See https://github.com/keras-team/keras-cv/pull/943#discussion_r1001092882 for the actual performance result. 

In short, XLA compile introduce 0.4 sec overhead, but save 0.2 sec per 1000 examples.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

