### PR TITLE
Pre-trained weights for EfficientNetV2B2

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -81,6 +81,23 @@
             "validation_accuracy": "0.7560"
         }
     },
+    "efficientnetv2b2": {
+        "v0": {
+            "accelerators": 8,
+            "args": {
+                "batch_size": "64",
+                "initial_learning_rate": ".0125"
+            },
+            "contributor": "ianstenbit",
+            "epochs_trained": 313,
+            "script": {
+                "name": "basic_training.py",
+                "version": "02b41ea91b972cdd29c27dbc4d79e6a0b4e90de2"
+            },
+            "tensorboard_logs": "https://tensorboard.dev/experiment/iyhN2qvIRrqj6C0Q328drg/",
+            "validation_accuracy": "0.7699"
+        }
+    },
     "resnet50v2": {
         "v0": {
             "accelerators": 2,

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -59,7 +59,7 @@ ALIASES = {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },
-    "efficientnetv2b1": {
+    "efficientnetv2b2": {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -59,6 +59,10 @@ ALIASES = {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },
+    "efficientnetv2b1": {
+        "imagenet": "imagenet/classification-v0",
+        "imagenet/classification": "imagenet/classification-v0",
+    },
     "resnet50v2": {
         "imagenet": "imagenet/classification-v2",
         "imagenet/classification": "imagenet/classification-v2",
@@ -85,6 +89,10 @@ WEIGHTS_CONFIG = {
     "efficientnetv2b1": {
         "imagenet/classification-v0": "3f92fc9d7b141ec9e85ffe60d301fb49103ba17b148bdd638971a77f1b8db010",
         "imagenet/classification-v0-notop": "359aaa5c1e863c8438d94052791e72ef29345d07703d06284e1069829f85932f",
+    },
+    "efficientnetv2b2": {
+        "imagenet/classification-v0": "1667d21b50e6c5b851a69c98503fa5ae707b82dbae8c900fe59ab1a93d60d694",
+        "imagenet/classification-v0-notop": "e118aadfab7e93ff939fb81c88c189cbd7fb2b7ddd7314fbf2badb7c551aa119",
     },
     "resnet50v2": {
         "imagenet/classification-v0": "11bde945b54d1dca65101be2648048abca8a96a51a42820d87403486389790db",


### PR DESCRIPTION
These score 76.99% top-1, compared to 80.5% top-1 on Keras applications (95.6% of benchmark result)