### PR TITLE
Added mixed_precision support for preprocessing layers.

### DIFF
--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -47,7 +47,10 @@ class AutoContrast(BaseImageAugmentationLayer):
     def augment_image(self, image, transformation=None, **kwargs):
         original_image = image
         image = preprocessing.transform_value_range(
-            image, original_range=self.value_range, target_range=(0, 255)
+            image,
+            original_range=self.value_range,
+            target_range=(0, 255),
+            dtype=self.compute_dtype,
         )
 
         low = tf.reduce_min(tf.reduce_min(image, axis=0), axis=0)
@@ -58,7 +61,10 @@ class AutoContrast(BaseImageAugmentationLayer):
         image = image * scale[None, None] + offset[None, None]
         result = tf.clip_by_value(image, 0.0, 255.0)
         result = preprocessing.transform_value_range(
-            result, original_range=(0, 255), target_range=self.value_range
+            result,
+            original_range=(0, 255),
+            target_range=self.value_range,
+            dtype=self.compute_dtype,
         )
         # don't process NaN channels
         result = tf.where(tf.math.is_nan(result), original_image, result)

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -109,7 +109,7 @@ class CutMix(BaseImageAugmentationLayer):
 
         bounding_box_area = cut_height * cut_width
         lambda_sample = 1.0 - bounding_box_area / (image_height * image_width)
-        lambda_sample = tf.cast(lambda_sample, dtype=images.dtype)
+        lambda_sample = tf.cast(lambda_sample, dtype=self.compute_dtype)
 
         images = fill_utils.fill_rectangle(
             images,

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -109,7 +109,7 @@ class CutMix(BaseImageAugmentationLayer):
 
         bounding_box_area = cut_height * cut_width
         lambda_sample = 1.0 - bounding_box_area / (image_height * image_width)
-        lambda_sample = tf.cast(lambda_sample, dtype=tf.float32)
+        lambda_sample = tf.cast(lambda_sample, dtype=images.dtype)
 
         images = fill_utils.fill_rectangle(
             images,

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -99,7 +99,7 @@ class Equalization(BaseImageAugmentationLayer):
 
     def augment_image(self, image, **kwargs):
         image = preprocessing.transform_value_range(
-            image, self.value_range, (0, 255), dtype=image.dtype
+            image, self.value_range, (0, 255), dtype=self.compute_dtype
         )
         image = tf.cast(image, tf.int32)
         image = tf.map_fn(
@@ -108,8 +108,10 @@ class Equalization(BaseImageAugmentationLayer):
         )
 
         image = tf.transpose(image, [1, 2, 0])
-        image = tf.cast(image, tf.float32)
-        image = preprocessing.transform_value_range(image, (0, 255), self.value_range)
+        image = tf.cast(image, self.compute_dtype)
+        image = preprocessing.transform_value_range(
+            image, (0, 255), self.value_range, dtype=self.compute_dtype
+        )
         return image
 
     def augment_bounding_boxes(self, bounding_boxes, **kwargs):

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -157,11 +157,11 @@ class GridMask(BaseImageAugmentationLayer):
         # compute fill
         if self.fill_mode == "constant":
             fill_value = tf.fill(input_shape, self.fill_value)
-            fill_value = tf.cast(fill_value, dtype=image.dtype)
+            fill_value = tf.cast(fill_value, dtype=self.compute_dtype)
         else:
             # gaussian noise
             fill_value = self._random_generator.random_normal(
-                shape=input_shape, dtype=image.dtype
+                shape=input_shape, dtype=self.compute_dtype
             )
 
         return mask, fill_value

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -157,6 +157,7 @@ class GridMask(BaseImageAugmentationLayer):
         # compute fill
         if self.fill_mode == "constant":
             fill_value = tf.fill(input_shape, self.fill_value)
+            fill_value = tf.cast(fill_value, dtype=image.dtype)
         else:
             # gaussian noise
             fill_value = self._random_generator.random_normal(

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -199,12 +199,17 @@ class Mosaic(BaseImageAugmentationLayer):
         area = input_height * input_width
 
         # labels are in the same ratio as the area of the images
-        top_left_ratio = (center_x * center_y) / area
-        top_right_ratio = ((input_width - center_x) * center_y) / area
-        bottom_left_ratio = (center_x * (input_height - center_y)) / area
-        bottom_right_ratio = (
-            (input_width - center_x) * (input_height - center_y)
-        ) / area
+        top_left_ratio = tf.cast((center_x * center_y) / area, dtype=labels.dtype)
+        top_right_ratio = tf.cast(
+            ((input_width - center_x) * center_y) / area, dtype=labels.dtype
+        )
+        bottom_left_ratio = tf.cast(
+            (center_x * (input_height - center_y)) / area, dtype=labels.dtype
+        )
+        bottom_right_ratio = tf.cast(
+            ((input_width - center_x) * (input_height - center_y)) / area,
+            dtype=labels.dtype,
+        )
 
         label = (
             labels_for_mosaic[0] * top_left_ratio

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -88,6 +88,7 @@ class Posterization(BaseImageAugmentationLayer):
             images=image,
             original_range=[0, 255],
             target_range=self._value_range,
+            dtype=self.compute_dtype,
         )
 
     def augment_bounding_boxes(self, bounding_boxes, **kwargs):

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -73,10 +73,12 @@ class RandomChannelShift(BaseImageAugmentationLayer):
 
     def _get_shift(self):
         invert = preprocessing.random_inversion(self._random_generator)
-        return invert * self.factor() * 0.5
+        return tf.cast(invert * self.factor() * 0.5, dtype=self.compute_dtype)
 
     def augment_image(self, image, transformation=None, **kwargs):
-        image = preprocessing.transform_value_range(image, self.value_range, (0, 1))
+        image = preprocessing.transform_value_range(
+            image, self.value_range, (0, 1), dtype=self.compute_dtype
+        )
         unstack_rgb = tf.unstack(image, axis=-1)
 
         result = []
@@ -88,7 +90,9 @@ class RandomChannelShift(BaseImageAugmentationLayer):
             axis=-1,
         )
         result = tf.clip_by_value(result, 0.0, 1.0)
-        image = preprocessing.transform_value_range(result, (0, 1), self.value_range)
+        image = preprocessing.transform_value_range(
+            result, (0, 1), self.value_range, dtype=self.compute_dtype
+        )
         return image
 
     def augment_bounding_boxes(self, bounding_boxes, **kwargs):

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -55,7 +55,7 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
         self.seed = seed
 
     def get_random_transformation(self, **kwargs):
-        return self.factor()
+        return self.factor(dtype=kwargs["image"].dtype)
 
     def augment_image(self, image, transformation=None, **kwargs):
         degenerate = tf.image.grayscale_to_rgb(tf.image.rgb_to_grayscale(image))

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -55,7 +55,7 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
         self.seed = seed
 
     def get_random_transformation(self, **kwargs):
-        return self.factor(dtype=kwargs["image"].dtype)
+        return self.factor(dtype=self.compute_dtype)
 
     def augment_image(self, image, transformation=None, **kwargs):
         degenerate = tf.image.grayscale_to_rgb(tf.image.rgb_to_grayscale(image))

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -118,7 +118,7 @@ class RandomColorJitter(BaseImageAugmentationLayer):
             image,
             original_range=self.value_range,
             target_range=(0, 255),
-            dtype=image.dtype,
+            dtype=self.compute_dtype,
         )
         image = self.random_brightness(image)
         image = self.random_contrast(image)
@@ -128,7 +128,7 @@ class RandomColorJitter(BaseImageAugmentationLayer):
             image,
             original_range=(0, 255),
             target_range=self.value_range,
-            dtype=image.dtype,
+            dtype=self.compute_dtype,
         )
         return image
 

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -156,10 +156,10 @@ class RandomCutout(BaseImageAugmentationLayer):
         input_shape = tf.shape(inputs)
         if self.fill_mode == "constant":
             fill_value = tf.fill(input_shape, self.fill_value)
-            fill_value = tf.cast(fill_value, dtype=inputs.dtype)
+            fill_value = tf.cast(fill_value, dtype=self.compute_dtype)
         else:
             # gaussian noise
-            fill_value = tf.random.normal(input_shape, dtype=inputs.dtype)
+            fill_value = tf.random.normal(input_shape, dtype=self.compute_dtype)
 
         return fill_value
 

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -156,9 +156,10 @@ class RandomCutout(BaseImageAugmentationLayer):
         input_shape = tf.shape(inputs)
         if self.fill_mode == "constant":
             fill_value = tf.fill(input_shape, self.fill_value)
+            fill_value = tf.cast(fill_value, dtype=inputs.dtype)
         else:
             # gaussian noise
-            fill_value = tf.random.normal(input_shape)
+            fill_value = tf.random.normal(input_shape, dtype=inputs.dtype)
 
         return fill_value
 

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -98,6 +98,8 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
 
     @staticmethod
     def get_kernel(factor, filter_size):
+        # We are running this in float32, regardless of layer's self.compute_dtype.
+        # Calculating blur_filter in lower precision will corrupt the final results.
         x = tf.cast(
             tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=tf.float32
         )

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -59,7 +59,7 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
                 )
 
     def get_random_transformation(self, **kwargs):
-        factor = self.factor()
+        factor = self.factor(dtype=kwargs["image"].dtype)
         blur_v = RandomGaussianBlur.get_kernel(factor, self.y)
         blur_h = RandomGaussianBlur.get_kernel(factor, self.x)
         blur_v = tf.reshape(blur_v, [self.y, 1, 1, 1])
@@ -94,12 +94,13 @@ class RandomGaussianBlur(BaseImageAugmentationLayer):
 
     @staticmethod
     def get_kernel(factor, filter_size):
+
         x = tf.cast(
-            tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=tf.float32
+            tf.range(-filter_size // 2 + 1, filter_size // 2 + 1), dtype=factor.dtype
         )
-        blur_filter = tf.exp(
-            -tf.pow(x, 2.0) / (2.0 * tf.pow(tf.cast(factor, dtype=tf.float32), 2.0))
-        )
+        # TODO: are we ok with running this in FP16?
+        # The alternative is to compute in FP32 and cast return value to factor.dtype
+        blur_filter = tf.exp(-tf.pow(x, 2.0) / (2.0 * tf.pow(factor, 2.0)))
         blur_filter /= tf.reduce_sum(blur_filter)
         return blur_filter
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -63,12 +63,17 @@ class RandomHue(BaseImageAugmentationLayer):
         return invert * self.factor() * 0.5
 
     def augment_image(self, image, transformation=None, **kwargs):
-        image = preprocessing.transform_value_range(image, self.value_range, (0, 1))
+        image = preprocessing.transform_value_range(
+            image, self.value_range, (0, 1), dtype=self.compute_dtype
+        )
+
         # tf.image.adjust_hue expects floats to be in range [0, 1]
         image = tf.image.adjust_hue(image, delta=transformation)
         # RandomHue is one of the rare KPLs that needs to clip
         image = tf.clip_by_value(image, 0, 1)
-        image = preprocessing.transform_value_range(image, (0, 1), self.value_range)
+        image = preprocessing.transform_value_range(
+            image, (0, 1), self.value_range, dtype=self.compute_dtype
+        )
         return image
 
     def augment_bounding_boxes(self, bounding_boxes, **kwargs):

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -60,11 +60,14 @@ class RandomSharpness(BaseImageAugmentationLayer):
         self.seed = seed
 
     def get_random_transformation(self, **kwargs):
-        return self.factor(dtype=kwargs["image"].dtype)
+        return self.factor(dtype=self.compute_dtype)
 
     def augment_image(self, image, transformation=None, **kwargs):
         image = preprocessing.transform_value_range(
-            image, original_range=self.value_range, target_range=(0, 255)
+            image,
+            original_range=self.value_range,
+            target_range=(0, 255),
+            dtype=self.compute_dtype,
         )
         original_image = image
 
@@ -79,7 +82,9 @@ class RandomSharpness(BaseImageAugmentationLayer):
         # gaussian blur.
         kernel = (
             tf.constant(
-                [[1, 1, 1], [1, 5, 1], [1, 1, 1]], dtype=image.dtype, shape=[3, 3, 1, 1]
+                [[1, 1, 1], [1, 5, 1], [1, 1, 1]],
+                dtype=self.compute_dtype,
+                shape=[3, 3, 1, 1],
             )
             / 13.0
         )
@@ -107,7 +112,10 @@ class RandomSharpness(BaseImageAugmentationLayer):
         # Blend the final result.
         result = preprocessing.blend(original_image, result, transformation)
         result = preprocessing.transform_value_range(
-            result, original_range=(0, 255), target_range=self.value_range
+            result,
+            original_range=(0, 255),
+            target_range=self.value_range,
+            dtype=self.compute_dtype,
         )
         return result
 

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -60,7 +60,7 @@ class RandomSharpness(BaseImageAugmentationLayer):
         self.seed = seed
 
     def get_random_transformation(self, **kwargs):
-        return self.factor()
+        return self.factor(dtype=kwargs["image"].dtype)
 
     def augment_image(self, image, transformation=None, **kwargs):
         image = preprocessing.transform_value_range(
@@ -79,7 +79,7 @@ class RandomSharpness(BaseImageAugmentationLayer):
         # gaussian blur.
         kernel = (
             tf.constant(
-                [[1, 1, 1], [1, 5, 1], [1, 1, 1]], dtype=tf.float32, shape=[3, 3, 1, 1]
+                [[1, 1, 1], [1, 5, 1], [1, 1, 1]], dtype=image.dtype, shape=[3, 3, 1, 1]
             )
             / 13.0
         )

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -89,20 +89,26 @@ class Solarization(BaseImageAugmentationLayer):
 
     def get_random_transformation(self, **kwargs):
         return (
-            self.addition_factor(dtype=kwargs["image"].dtype),
-            self.threshold_factor(dtype=kwargs["image"].dtype),
+            self.addition_factor(dtype=self.compute_dtype),
+            self.threshold_factor(dtype=self.compute_dtype),
         )
 
     def augment_image(self, image, transformation=None, **kwargs):
         (addition, threshold) = transformation
         image = preprocessing.transform_value_range(
-            image, original_range=self.value_range, target_range=(0, 255)
+            image,
+            original_range=self.value_range,
+            target_range=(0, 255),
+            dtype=self.compute_dtype,
         )
         result = image + addition
         result = tf.clip_by_value(result, 0, 255)
         result = tf.where(result < threshold, result, 255 - result)
         result = preprocessing.transform_value_range(
-            result, original_range=(0, 255), target_range=self.value_range
+            result,
+            original_range=(0, 255),
+            target_range=self.value_range,
+            dtype=self.compute_dtype,
         )
         return result
 

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -88,7 +88,10 @@ class Solarization(BaseImageAugmentationLayer):
         self.value_range = value_range
 
     def get_random_transformation(self, **kwargs):
-        return (self.addition_factor(), self.threshold_factor())
+        return (
+            self.addition_factor(dtype=kwargs["image"].dtype),
+            self.threshold_factor(dtype=kwargs["image"].dtype),
+        )
 
     def augment_image(self, image, transformation=None, **kwargs):
         (addition, threshold) = transformation

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -92,27 +92,26 @@ TEST_CONFIGURATIONS = [
     ),
     ("RandomShear", preprocessing.RandomShear, {"x_factor": 0.3, "x_factor": 0.3}),
     ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
+    ("Mosaic", preprocessing.Mosaic, {}),
+    ("CutMix", preprocessing.CutMix, {}),
 ]
 
 NO_CPU_FP16_KERNEL_LAYERS = [
     preprocessing.RandomSaturation,
     preprocessing.RandomColorJitter,
+    preprocessing.RandomHue,
 ]
 
 
 class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
-    @parameterized.named_parameters(
-        *TEST_CONFIGURATIONS,
-        ("CutMix", preprocessing.CutMix, {}),
-        ("Mosaic", preprocessing.Mosaic, {}),
-    )
+    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
     def test_can_run_in_mixed_precision(self, layer_cls, init_args):
         if not tf.config.list_physical_devices("GPU"):
             if layer_cls in NO_CPU_FP16_KERNEL_LAYERS:
                 self.skipTest(
-                    "`RandomSaturation` and `RandomColorJitter` both use "
-                    "`tf.image.adjust_saturation`, which doesn't have FLOAT16 CPU "
-                    "kernel registered. Skipping."
+                    "There is currently no float16 CPU kernel registered for operations"
+                    " `tf.image.adjust_saturation`, and `tf.image.adjust_hue`. "
+                    "Skipping."
                 )
 
         tf.keras.mixed_precision.set_global_policy("mixed_float16")
@@ -128,7 +127,7 @@ class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Do NOT affect other tests
+        # Do not affect other tests
         tf.keras.mixed_precision.set_global_policy("float32")
 
 


### PR DESCRIPTION
# What does this PR do?
It was reported that some preprocessing layers do not run in mixed float16. This PR is an attempt to fix this.

Fixes #734 

This PR introduces two things:
1. Adds test for running in mixed precision for Keras-CV preprocessing layers.
2. Fix those layers that can be fixed from Python side.

### Affected layers:
Running (added in this PR) `keras_cv/layers/preprocessing/with_mixed_precision_test.py`, without changing the existing code, shows which layers are affected:
* GridMask
* CutMix
* Mosaic (throws some `OP_REQUIRES failed at functional_ops.cc:373` warning)
* RandomColorDegeneration 
* RandomCutout 
* RandomGaussianBlur
* RandomSharpness
* Solarization
* RandomColorJitter  
* RandomSaturation 

I managed to fix all, but two layers: RandomColorJitter and RandomSaturation. Both of these use `tf.image.adjust_saturation` which doesn't have CPU Float16 kernel registered. I believe this would have to be fixed from Tensorflow side.

The above layers should still work on the GPU though.

# Limitations
The majority of the problems were caused by explicitly casting to float32, which worked if the images were also in float32. I mostly added casting to `images.dtype` or fetching some Factor component with different dtype.

I am not sure, however, about running some computations in float16, as previously they were running in float32.
For example in: Mosaic and RandomGaussianBlur. I added a TODO so you could provide a comment whether you think this is ok or not.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @tanzhenyu @ianstenbit 
