### PR TITLE
compatiable stable diffusion model save for tf2

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/__internal__/layers/group_normalization.py
+++ b/keras_cv/models/generative/stable_diffusion/__internal__/layers/group_normalization.py
@@ -84,7 +84,7 @@ class GroupNormalization(tf.keras.layers.Layer):
         return gamma, beta
 
     def _create_broadcast_shape(self, input_shape):
-        broadcast_shape = [1] * len(input_shape)
+        broadcast_shape = [1] * input_shape.shape[0]
         broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
         broadcast_shape.insert(self.axis, self.groups)
         return broadcast_shape


### PR DESCRIPTION
# What does this PR do?
env: tensorflow2.9 + cuda11
when I save diffusion model as saved_model, I get this report from tensorflow
TypeError: Exception encountered when calling layer "group_normalization_60" (type GroupNormalization).

len is not well defined for a symbolic Tensor (Shape:0). Please call `x.shape` rather than `len(x)` for shape information.

Call arguments received by layer "group_normalization_60" (type GroupNormalization):
  • args=('tf.Tensor(shape=(None, 64, 64, 320), dtype=float16)',)
  • kwargs=<class 'inspect._empty'>

I think changes is minor, not necessary for creat issue
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?
