### PR TITLE
Add text-conditioned in-painting functionality to Keras Stable Diffusion

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/image_encoder.py
+++ b/keras_cv/models/generative/stable_diffusion/image_encoder.py
@@ -63,7 +63,7 @@ class ImageEncoder(keras.Sequential):
 
         if download_weights:
             image_encoder_weights_fpath = keras.utils.get_file(
-                origin="https://huggingface.co/fchollet/stable-diffusion/blob/main/vae_encoder.h5",
-                file_hash="f142c8c94c6853cd19d8bfb9c10aa762c057566f54456398beea6a70a639bf48",
+                origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/vae_encoder.h5",
+                file_hash="c60fb220a40d090e0f86a6ab4c312d113e115c87c40ff75d11ffcf380aab7ebb",
             )
             self.load_weights(image_encoder_weights_fpath)

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -317,7 +317,7 @@ class StableDiffusion:
             )
 
         image = tf.squeeze(image)
-        image = tf.cast(image, dtype=tf.float32) / 255. * 2. - 1.
+        image = tf.cast(image, dtype=tf.float32) / 255.0 * 2.0 - 1.0
         image = tf.expand_dims(image, axis=0)
         known_x0 = self.image_encoder(image)
         if image.shape.rank == 3:
@@ -330,9 +330,7 @@ class StableDiffusion:
         )
         mask = tf.squeeze(mask)
         if mask.shape.rank == 2:
-            mask = tf.repeat(
-                tf.expand_dims(mask, axis=0), batch_size, axis=0
-            )
+            mask = tf.repeat(tf.expand_dims(mask, axis=0), batch_size, axis=0)
         mask = tf.expand_dims(mask, axis=-1)
 
         context = encoded_text

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -345,7 +345,12 @@ class StableDiffusion:
         if image.shape.rank == 3:
             known_x0 = tf.repeat(known_x0, batch_size, axis=0)
 
-        mask = tf.cast(tf.squeeze(mask), dtype=tf.float32)
+        mask = tf.expand_dims(mask, axis=-1)
+        mask = tf.cast(
+            tf.nn.max_pool2d(mask, ksize=8, strides=8, padding="SAME"),
+            dtype=tf.float32,
+        )
+        mask = tf.squeeze(mask)
         if mask.shape.rank == 2:
             mask = tf.repeat(
                 tf.expand_dims(mask, axis=0), batch_size, axis=0


### PR DESCRIPTION
This PR adds in-painting support for the Keras port of Stable Diffusion following the RePaint method proposed in https://arxiv.org/abs/2201.09865. Also updated the URL and checksum of the model weights of the VAE Encoder.

Following are demo images:

Original Image with caption "a realistic photo of a chef cooking on mars.":
![original](https://user-images.githubusercontent.com/26168216/199214705-af8fe352-407f-428a-aa12-a4fc9ff562d6.png)

Mask Image:
![image](https://user-images.githubusercontent.com/26168216/199215398-122fdcc9-bc0b-4bcc-ad84-fcef4b9d2628.png)

Inpainted with caption "a realistic photo of a chef making a fruit salad.":
![image](https://user-images.githubusercontent.com/26168216/199215031-e40baebe-24c5-4d67-a3f5-8dddc94a9278.png)

Inpainted with caption "a realistic photo of a chef with a boombox.":
![image](https://user-images.githubusercontent.com/26168216/199215238-559d4085-f7ce-48e4-8f37-b4f61437e521.png)
 
