### PR TITLE
[Backbone Training] added 50/50 between cutmix and mixup, changed default hold steps

### DIFF
--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -186,6 +186,7 @@ AUGMENT_LAYERS = [
     keras_cv.layers.RandAugment(value_range=(0, 255), magnitude=0.3),
 ]
 
+
 @tf.function
 def augment(img, label):
     inputs = {"images": img, "labels": label}

--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -192,7 +192,7 @@ def augment(img, label):
     inputs = {"images": img, "labels": label}
     for layer in AUGMENT_LAYERS:
         inputs = layer(inputs)
-    if tf.random().uniform(()) > 0.5:
+    if tf.random().uniform() > 0.5:
         inputs = keras_cv.layers.CutMix()(inputs)
     else:
         inputs = keras_cv.layers.MixUp()(inputs)

--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -192,7 +192,7 @@ def augment(img, label):
     inputs = {"images": img, "labels": label}
     for layer in AUGMENT_LAYERS:
         inputs = layer(inputs)
-    if tf.random().uniform() > 0.5:
+    if tf.random.uniform() > 0.5:
         inputs = keras_cv.layers.CutMix()(inputs)
     else:
         inputs = keras_cv.layers.MixUp()(inputs)

--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -99,7 +99,7 @@ flags.DEFINE_float(
 
 flags.DEFINE_float(
     "warmup_hold_steps_percentage",
-    0.1,
+    0.45,
     "For how many steps expressed in percentage (0..1 float) of total steps should the schedule hold the initial learning rate after warmup is finished, and before applying cosine decay.",
 )
 
@@ -184,15 +184,18 @@ def crop_and_resize(img, label):
 AUGMENT_LAYERS = [
     keras_cv.layers.RandomFlip(mode="horizontal"),
     keras_cv.layers.RandAugment(value_range=(0, 255), magnitude=0.3),
-    keras_cv.layers.CutMix(),
 ]
-
 
 @tf.function
 def augment(img, label):
     inputs = {"images": img, "labels": label}
     for layer in AUGMENT_LAYERS:
         inputs = layer(inputs)
+    if tf.random().uniform(()) > 0.5:
+        inputs = keras_cv.layers.CutMix()(inputs)
+    else:
+        inputs = keras_cv.layers.MixUp()(inputs)
+
     return inputs["images"], inputs["labels"]
 
 


### PR DESCRIPTION
# What does this PR do?

Tested on Imagenette - shows a ~2% increase in accuracy over the original script. Unclear how much this translates to ImageNet (if it does).

- Hold steps updated to default to 45% (decay starts around the first reduction on plateau in the `ReduceLROnPlateau` alternative)
- Each batch is augmented either with Mixup or Cutmix with a 50/50 probability between them
- The script that produced the plot uses RandAugment with `magnitude` of `0.7` instead of `0.3` for both runs

<img width="819" alt="image" src="https://user-images.githubusercontent.com/60978046/199594739-44b95c01-d848-4f29-bd69-8d847921d038.png">

P.S. I made the labels a bit weird - both use the same CutMix/MixUp policy, not just the other one. The only difference between these is the LR schedule (reduce on plateau vs warmup + decay).

@ianstenbit 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
