### PR TITLE
Shuffle dataset every epoch for basic_training

### DIFF
--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -153,7 +153,8 @@ information about preparing this dataset at keras_cv/datasets/imagenet/README.md
 train_ds = imagenet.load(
     split="train",
     tfrecord_path=FLAGS.imagenet_path,
-    shuffle_buffer=BATCH_SIZE * 2,
+    shuffle_buffer=BATCH_SIZE * 8,
+    reshuffle_each_iteration=True,
 )
 test_ds = imagenet.load(
     split="validation",


### PR DESCRIPTION
I've verified that this doesn't meaningfully change epoch time, and IIUC this should be enabled in all cases for imagenet training.