### PR TITLE
Lazy-load components of StableDiffusion and make them visible to users

### DIFF
--- a/keras_cv/models/generative/stable_diffusion/__init__.py
+++ b/keras_cv/models/generative/stable_diffusion/__init__.py
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.models.generative.stable_diffusion.stable_diffusion import Decoder
+from keras_cv.models.generative.stable_diffusion.stable_diffusion import DiffusionModel
+from keras_cv.models.generative.stable_diffusion.stable_diffusion import ImageEncoder
+from keras_cv.models.generative.stable_diffusion.stable_diffusion import SimpleTokenizer
 from keras_cv.models.generative.stable_diffusion.stable_diffusion import StableDiffusion
+from keras_cv.models.generative.stable_diffusion.stable_diffusion import TextEncoder

--- a/keras_cv/models/generative/stable_diffusion/decoder.py
+++ b/keras_cv/models/generative/stable_diffusion/decoder.py
@@ -29,7 +29,7 @@ from keras_cv.models.generative.stable_diffusion.__internal__.layers.resnet_bloc
 
 
 class Decoder(keras.Sequential):
-    def __init__(self, img_height, img_width, name=None):
+    def __init__(self, img_height, img_width, name=None, download_weights=True):
         super().__init__(
             [
                 keras.layers.Input((img_height // 8, img_width // 8, 4)),
@@ -63,3 +63,10 @@ class Decoder(keras.Sequential):
             ],
             name=name,
         )
+
+        if download_weights:
+            decoder_weights_fpath = keras.utils.get_file(
+                origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_decoder.h5",
+                file_hash="ad350a65cc8bc4a80c8103367e039a3329b4231c2469a1093869a345f55b1962",
+            )
+            self.load_weights(decoder_weights_fpath)

--- a/keras_cv/models/generative/stable_diffusion/diffusion_model.py
+++ b/keras_cv/models/generative/stable_diffusion/diffusion_model.py
@@ -24,7 +24,9 @@ from keras_cv.models.generative.stable_diffusion.__internal__.layers.padded_conv
 
 
 class DiffusionModel(keras.Model):
-    def __init__(self, img_height, img_width, max_text_length, name=None):
+    def __init__(
+        self, img_height, img_width, max_text_length, name=None, download_weights=True
+    ):
         context = keras.layers.Input((max_text_length, 768))
         t_embed_input = keras.layers.Input((320,))
         latent = keras.layers.Input((img_height // 8, img_width // 8, 4))
@@ -101,6 +103,13 @@ class DiffusionModel(keras.Model):
         output = PaddedConv2D(4, kernel_size=3, padding=1)(x)
 
         super().__init__([latent, t_embed_input, context], output, name=name)
+
+        if download_weights:
+            diffusion_model_weights_fpath = keras.utils.get_file(
+                origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_diffusion_model.h5",
+                file_hash="8799ff9763de13d7f30a683d653018e114ed24a6a819667da4f5ee10f9e805fe",
+            )
+            self.load_weights(diffusion_model_weights_fpath)
 
 
 class ResBlock(keras.layers.Layer):

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion.py
@@ -89,44 +89,21 @@ class StableDiffusion:
         img_width = round(img_width / 128) * 128
         self.img_height = img_height
         self.img_width = img_width
-        self.tokenizer = SimpleTokenizer()
 
-        # Create models
-        self.text_encoder = TextEncoder(MAX_PROMPT_LENGTH)
-        self.diffusion_model = DiffusionModel(img_height, img_width, MAX_PROMPT_LENGTH)
-        self.decoder = Decoder(img_height, img_width)
-        # lazy initialize image encoder
+        # lazy initialize the component models and the tokenizer
         self._image_encoder = None
+        self._text_encoder = None
+        self._diffusion_model = None
+        self._decoder = None
+        self._tokenizer = None
 
         self.jit_compile = jit_compile
-
-        if jit_compile:
-            self.text_encoder.compile(jit_compile=True)
-            self.diffusion_model.compile(jit_compile=True)
-            self.decoder.compile(jit_compile=True)
 
         print(
             "By using this model checkpoint, you acknowledge that its usage is "
             "subject to the terms of the CreativeML Open RAIL-M license at "
             "https://raw.githubusercontent.com/CompVis/stable-diffusion/main/LICENSE"
         )
-        # Load weights
-        text_encoder_weights_fpath = keras.utils.get_file(
-            origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_encoder.h5",
-            file_hash="4789e63e07c0e54d6a34a29b45ce81ece27060c499a709d556c7755b42bb0dc4",
-        )
-        diffusion_model_weights_fpath = keras.utils.get_file(
-            origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_diffusion_model.h5",
-            file_hash="8799ff9763de13d7f30a683d653018e114ed24a6a819667da4f5ee10f9e805fe",
-        )
-        decoder_weights_fpath = keras.utils.get_file(
-            origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_decoder.h5",
-            file_hash="ad350a65cc8bc4a80c8103367e039a3329b4231c2469a1093869a345f55b1962",
-        )
-
-        self.text_encoder.load_weights(text_encoder_weights_fpath)
-        self.diffusion_model.load_weights(diffusion_model_weights_fpath)
-        self.decoder.load_weights(decoder_weights_fpath)
 
     def text_to_image(
         self,
@@ -309,6 +286,51 @@ class StableDiffusion:
         if self.jit_compile:
             self._image_encoder.compile(jit_compile=True)
         return self._image_encoder
+
+    @property
+    def text_encoder(self):
+        """text_encoder returns the text encoder with pretrained weights.
+        Can be overriden for tasks like textual inversion where the text encoder
+        needs to be modified.
+        """
+        if self._text_encoder is None:
+            self._text_encoder = TextEncoder(MAX_PROMPT_LENGTH)
+        if self.jit_compile:
+            self._text_encoder.compile(jit_compile=True)
+        return self._text_encoder
+
+    @property
+    def diffusion_model(self):
+        """diffusion_model returns the diffusion model with pretrained weights.
+        Can be overriden for tasks where the diffusion model needs to be modified.
+        """
+        if self._diffusion_model is None:
+            self._diffusion_model = DiffusionModel(
+                self.img_height, self.img_width, MAX_PROMPT_LENGTH
+            )
+        if self.jit_compile:
+            self._diffusion_model.compile(jit_compile=True)
+        return self._diffusion_model
+
+    @property
+    def decoder(self):
+        """decoder returns the diffusion image decoder model with pretrained weights.
+        Can be overriden for tasks where the decoder needs to be modified.
+        """
+        if self._decoder is None:
+            self._decoder = Decoder(self.img_height, self.img_width)
+        if self.jit_compile:
+            self._decoder.compile(jit_compile=True)
+        return self._decoder
+
+    @property
+    def tokenizer(self):
+        """tokenizer returns the tokenizer used for text inputs.
+        Can be overriden for tasks like textual inversion where the tokenizer needs to be modified.
+        """
+        if self._tokenizer is None:
+            self._tokenizer = SimpleTokenizer()
+        return self._tokenizer
 
     def _get_timestep_embedding(self, timestep, batch_size, dim=320, max_period=10000):
         half = dim // 2

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -19,7 +19,7 @@ from keras_cv.models import StableDiffusion
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    def test_end_to_end_golden_value(self):
+    def DISABLED_test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 
@@ -32,12 +32,12 @@ class StableDiffusionTest(tf.test.TestCase):
             img, stablediff.generate_image(text_encoding, seed=1337), atol=1e-4
         )
 
-    def test_mixed_precision(self):
+    def DISABLED_test_mixed_precision(self):
         mixed_precision.set_global_policy("mixed_float16")
         stablediff = StableDiffusion(128, 128)
         _ = stablediff.text_to_image("Testing123 haha!")
 
-    def test_generate_image_rejects_noise_and_seed(self):
+    def DISABLED_test_generate_image_rejects_noise_and_seed(self):
         stablediff = StableDiffusion(128, 128)
 
         with self.assertRaisesRegex(

--- a/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/generative/stable_diffusion/stable_diffusion_test.py
@@ -19,7 +19,7 @@ from keras_cv.models import StableDiffusion
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    def DISABLED_test_end_to_end_golden_value(self):
+    def test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 
@@ -32,12 +32,12 @@ class StableDiffusionTest(tf.test.TestCase):
             img, stablediff.generate_image(text_encoding, seed=1337), atol=1e-4
         )
 
-    def DISABLED_test_mixed_precision(self):
+    def test_mixed_precision(self):
         mixed_precision.set_global_policy("mixed_float16")
         stablediff = StableDiffusion(128, 128)
         _ = stablediff.text_to_image("Testing123 haha!")
 
-    def DISABLED_test_generate_image_rejects_noise_and_seed(self):
+    def test_generate_image_rejects_noise_and_seed(self):
         stablediff = StableDiffusion(128, 128)
 
         with self.assertRaisesRegex(

--- a/keras_cv/models/generative/stable_diffusion/text_encoder.py
+++ b/keras_cv/models/generative/stable_diffusion/text_encoder.py
@@ -18,7 +18,7 @@ from tensorflow.experimental import numpy as tfnp
 
 
 class TextEncoder(keras.Model):
-    def __init__(self, max_length, name=None):
+    def __init__(self, max_length, name=None, download_weights=True):
         tokens = keras.layers.Input(shape=(max_length,), dtype="int32", name="tokens")
         positions = keras.layers.Input(
             shape=(max_length,), dtype="int32", name="positions"
@@ -28,6 +28,13 @@ class TextEncoder(keras.Model):
             x = CLIPEncoderLayer()(x)
         embedded = keras.layers.LayerNormalization(epsilon=1e-5)(x)
         super().__init__([tokens, positions], embedded, name=name)
+
+        if download_weights:
+            text_encoder_weights_fpath = keras.utils.get_file(
+                origin="https://huggingface.co/fchollet/stable-diffusion/resolve/main/kcv_encoder.h5",
+                file_hash="4789e63e07c0e54d6a34a29b45ce81ece27060c499a709d556c7755b42bb0dc4",
+            )
+            self.load_weights(text_encoder_weights_fpath)
 
 
 class CLIPEmbedding(keras.layers.Layer):


### PR DESCRIPTION
Open question:
Should we accept components as constructor parameters for StableDiffusion?
I am leaning toward yes. That way, a user could do something like this:

```
from keras_cv.models.generative.stable_diffusion import TextEncoder
from keras_cv.models import StableDiffusion

text_encoder = TextEncoder()
# Do something to the text_encoder (e.g. add tokens via textual inversion)

sd = StableDiffusion(512, 512, text_encoder=text_encoder)
```

Thoughts?