### PR TITLE
Implement bounding boxes for RandomCropAndResize

### DIFF
--- a/examples/layers/preprocessing/bounding_box/random_crop_and_resize_demo.py
+++ b/examples/layers/preprocessing/bounding_box/random_crop_and_resize_demo.py
@@ -1,0 +1,40 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+random_crop_and_resize_demo.py shows how to use the RandomCropAndResize preprocessing layer for
+object detection.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+IMG_SIZE = (256, 256)
+BATCH_SIZE = 9
+
+
+def main():
+    dataset = demo_utils.load_voc_dataset(bounding_box_format="rel_xyxy")
+    random_rotation = preprocessing.RandomCropAndResize(
+        target_size=IMG_SIZE,
+        crop_area_factor=(0.5, 0.5),
+        aspect_ratio_factor=(0.5, 0.5),
+        bounding_box_format="rel_xyxy"
+    )
+    result = dataset.map(random_rotation, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_data(result, bounding_box_format="rel_xyxy")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/layers/preprocessing/bounding_box/random_crop_and_resize_demo.py
+++ b/examples/layers/preprocessing/bounding_box/random_crop_and_resize_demo.py
@@ -30,7 +30,7 @@ def main():
         target_size=IMG_SIZE,
         crop_area_factor=(0.5, 0.5),
         aspect_ratio_factor=(0.5, 0.5),
-        bounding_box_format="rel_xyxy"
+        bounding_box_format="rel_xyxy",
     )
     result = dataset.map(random_rotation, num_parallel_calls=tf.data.AUTOTUNE)
     demo_utils.visualize_data(result, bounding_box_format="rel_xyxy")

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -14,8 +14,8 @@
 
 import tensorflow as tf
 
-from keras_cv import core
 from keras_cv import bounding_box
+from keras_cv import core
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -59,14 +59,14 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
     """
 
     def __init__(
-            self,
-            target_size,
-            crop_area_factor,
-            aspect_ratio_factor,
-            interpolation="bilinear",
-            bounding_box_format=None,
-            seed=None,
-            **kwargs,
+        self,
+        target_size,
+        crop_area_factor,
+        aspect_ratio_factor,
+        interpolation="bilinear",
+        bounding_box_format=None,
+        seed=None,
+        **kwargs,
     ):
         super().__init__(seed=seed, **kwargs)
 
@@ -92,7 +92,7 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
         self.bounding_box_format = bounding_box_format
 
     def get_random_transformation(
-            self, image=None, label=None, bounding_box=None, **kwargs
+        self, image=None, label=None, bounding_box=None, **kwargs
     ):
         crop_area_factor = self.crop_area_factor()
         aspect_ratio = self.aspect_ratio_factor()
@@ -169,7 +169,7 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
         return output
 
     def augment_bounding_boxes(
-            self, bounding_boxes, transformation=None, image=None, **kwargs
+        self, bounding_boxes, transformation=None, image=None, **kwargs
     ):
         if self.bounding_box_format is None:
             raise ValueError(
@@ -186,7 +186,9 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
             images=image,
         )
 
-        bounding_boxes = RandomCropAndResize._transform_bounding_boxes(bounding_boxes, transformation)
+        bounding_boxes = RandomCropAndResize._transform_bounding_boxes(
+            bounding_boxes, transformation
+        )
 
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes,
@@ -210,14 +212,14 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
         return tf.cast(outputs, self.compute_dtype)
 
     def _check_class_arguments(
-            self, target_size, crop_area_factor, aspect_ratio_factor
+        self, target_size, crop_area_factor, aspect_ratio_factor
     ):
         if (
-                not isinstance(target_size, (tuple, list))
-                or len(target_size) != 2
-                or not isinstance(target_size[0], int)
-                or not isinstance(target_size[1], int)
-                or isinstance(target_size, int)
+            not isinstance(target_size, (tuple, list))
+            or len(target_size) != 2
+            or not isinstance(target_size[0], int)
+            or not isinstance(target_size[1], int)
+            or isinstance(target_size, int)
         ):
             raise ValueError(
                 "`target_size` must be tuple of two integers. "
@@ -225,9 +227,9 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
             )
 
         if (
-                not isinstance(crop_area_factor, (tuple, list, core.FactorSampler))
-                or isinstance(crop_area_factor, float)
-                or isinstance(crop_area_factor, int)
+            not isinstance(crop_area_factor, (tuple, list, core.FactorSampler))
+            or isinstance(crop_area_factor, float)
+            or isinstance(crop_area_factor, int)
         ):
             raise ValueError(
                 "`crop_area_factor` must be tuple of two positive floats less than "
@@ -236,9 +238,9 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
             )
 
         if (
-                not isinstance(aspect_ratio_factor, (tuple, list, core.FactorSampler))
-                or isinstance(aspect_ratio_factor, float)
-                or isinstance(aspect_ratio_factor, int)
+            not isinstance(aspect_ratio_factor, (tuple, list, core.FactorSampler))
+            or isinstance(aspect_ratio_factor, float)
+            or isinstance(aspect_ratio_factor, int)
         ):
             raise ValueError(
                 "`aspect_ratio_factor` must be tuple of two positive floats or "

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -155,7 +155,7 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
         x1, y1, x2, y2, rest = tf.split(
             bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
         )
-        output = tf.stack(
+        output = tf.concat(
             [
                 (x1 - t_x1) / t_dx,
                 (y1 - t_y1) / t_dy,
@@ -165,7 +165,6 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
             ],
             axis=-1,
         )
-        output = tf.squeeze(output, axis=1)
         return output
 
     def augment_bounding_boxes(

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import unittest
+
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import bounding_box
 from keras_cv.layers import preprocessing
 
 
@@ -81,8 +84,8 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_target_size_errors(self, target_size):
         with self.assertRaisesRegex(
-            ValueError,
-            "`target_size` must be tuple of two integers. Received target_size=(.*)",
+                ValueError,
+                "`target_size` must be tuple of two integers. Received target_size=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=target_size,
@@ -97,9 +100,9 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_aspect_ratio_factor_errors(self, aspect_ratio_factor):
         with self.assertRaisesRegex(
-            ValueError,
-            "`aspect_ratio_factor` must be tuple of two positive floats or "
-            "keras_cv.core.FactorSampler instance. Received aspect_ratio_factor=(.*)",
+                ValueError,
+                "`aspect_ratio_factor` must be tuple of two positive floats or "
+                "keras_cv.core.FactorSampler instance. Received aspect_ratio_factor=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=(224, 224),
@@ -114,10 +117,10 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_crop_area_factor_errors(self, crop_area_factor):
         with self.assertRaisesRegex(
-            ValueError,
-            "`crop_area_factor` must be tuple of two positive floats less than or "
-            "equal to 1 or keras_cv.core.FactorSampler instance. Received "
-            "crop_area_factor=(.*)",
+                ValueError,
+                "`crop_area_factor` must be tuple of two positive floats less than or "
+                "equal to 1 or keras_cv.core.FactorSampler instance. Received "
+                "crop_area_factor=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=(224, 224),
@@ -183,3 +186,130 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
         )
         output = layer(inputs, training=True)
         self.assertAllClose(output["segmentation_masks"], input_mask_resized)
+
+    def test_augment_bbox(self):
+        image = tf.zeros([20, 20, 3])
+        bboxes = tf.convert_to_tensor(
+            [
+                [
+                    [0, 0, 10, 10],
+                    [1, 1, 4, 4],
+                    [4, 4, 5, 5]
+                ]
+            ]
+        )
+
+        bboxes = bounding_box.add_class_id(bboxes)
+        input = {"images": [image], "bounding_boxes": bboxes}
+        mock_random = [0.1, 0.1, 0.1, 0.1]
+        layer = preprocessing.RandomCropAndResize(
+            target_size=(10, 10),
+            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            aspect_ratio_factor=(1.0, 1.0),
+            bounding_box_format="xyxy")
+
+        with unittest.mock.patch.object(
+                layer._random_generator,
+                "random_uniform",
+                side_effect=mock_random,
+        ):
+            output = layer(input, training=True)
+
+        expected_output = np.asarray(
+            [
+                [
+                    [0, 0, 10, 10, 0],
+                    [0, 0, 6, 6, 0],
+                    [6, 6, 8, 8, 0]
+                ]
+            ]
+        )
+        expected_output = np.reshape(expected_output, (1, 3, 5))
+        self.assertAllClose(expected_output, output["bounding_boxes"])
+
+    def test_augment_bbox_batched_input(self):
+        image = tf.zeros([20, 20, 3])
+
+        bboxes = tf.convert_to_tensor(
+            [
+                [
+                    [0, 0, 10, 10],
+                    [4, 4, 12, 12]
+                ],
+                [
+                    [4, 4, 12, 12],
+                    [0, 0, 10, 10]
+                ]
+            ]
+        )
+        bboxes = bounding_box.add_class_id(bboxes)
+        input = {"images": [image, image], "bounding_boxes": bboxes}
+        mock_random = [0.0, 0.0, 0.1, 0.1]
+        layer = preprocessing.RandomCropAndResize(
+            target_size=(18, 18),
+            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            aspect_ratio_factor=(1.0, 1.0),
+            bounding_box_format="xyxy")
+        with unittest.mock.patch.object(
+                layer._random_generator,
+                "random_uniform",
+                side_effect=mock_random,
+        ):
+            output = layer(input, training=True)
+
+        expected_output = np.asarray(
+            [
+                [
+                    [0, 0, 18, 18, 0],
+                    [8, 8, 18, 18, 0]
+                ],
+                [
+                    [8, 8, 18, 18, 0],
+                    [0, 0, 18, 18, 0]
+                ],
+            ]
+        )
+        expected_output = np.reshape(expected_output, (2, 2, 5))
+        self.assertAllClose(expected_output, output["bounding_boxes"])
+
+    def test_augment_bbox_ragged(self):
+        image = tf.zeros([2, 20, 20, 3])
+        bboxes = tf.ragged.constant(
+            [
+                [
+                    [0, 0, 10, 10],
+                    [4, 4, 12, 12]
+                ],
+                [
+                    [0, 0, 10, 10]
+                ]
+            ], dtype=tf.float32
+        )
+        bboxes = bounding_box.add_class_id(bboxes)
+        input = {"images": image, "bounding_boxes": bboxes}
+        mock_random = [0.0, 0.0, 0.1, 0.1]
+        layer = preprocessing.RandomCropAndResize(
+            target_size=(18, 18),
+            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            aspect_ratio_factor=(1.0, 1.0),
+            bounding_box_format="xyxy")
+        with unittest.mock.patch.object(
+            layer._random_generator,
+            "random_uniform",
+            side_effect=mock_random,
+        ):
+            output = layer(input, training=True)
+        expected_output = tf.ragged.constant(
+            [
+                [
+                    [0, 0, 18, 18, 0],
+                    [8, 8, 18, 18, 0]
+                ],
+                [
+                    [0, 0, 18, 18, 0]
+                ],
+            ],
+            dtype=tf.float32,
+            ragged_rank=1,
+        )
+        self.assertAllClose(expected_output, output["bounding_boxes"])

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -84,8 +84,8 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_target_size_errors(self, target_size):
         with self.assertRaisesRegex(
-                ValueError,
-                "`target_size` must be tuple of two integers. Received target_size=(.*)",
+            ValueError,
+            "`target_size` must be tuple of two integers. Received target_size=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=target_size,
@@ -100,9 +100,9 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_aspect_ratio_factor_errors(self, aspect_ratio_factor):
         with self.assertRaisesRegex(
-                ValueError,
-                "`aspect_ratio_factor` must be tuple of two positive floats or "
-                "keras_cv.core.FactorSampler instance. Received aspect_ratio_factor=(.*)",
+            ValueError,
+            "`aspect_ratio_factor` must be tuple of two positive floats or "
+            "keras_cv.core.FactorSampler instance. Received aspect_ratio_factor=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=(224, 224),
@@ -117,10 +117,10 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_crop_area_factor_errors(self, crop_area_factor):
         with self.assertRaisesRegex(
-                ValueError,
-                "`crop_area_factor` must be tuple of two positive floats less than or "
-                "equal to 1 or keras_cv.core.FactorSampler instance. Received "
-                "crop_area_factor=(.*)",
+            ValueError,
+            "`crop_area_factor` must be tuple of two positive floats less than or "
+            "equal to 1 or keras_cv.core.FactorSampler instance. Received "
+            "crop_area_factor=(.*)",
         ):
             _ = preprocessing.RandomCropAndResize(
                 target_size=(224, 224),
@@ -189,40 +189,27 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_augment_bbox(self):
         image = tf.zeros([20, 20, 3])
-        bboxes = tf.convert_to_tensor(
-            [
-                [
-                    [0, 0, 10, 10],
-                    [1, 1, 4, 4],
-                    [4, 4, 5, 5]
-                ]
-            ]
-        )
+        bboxes = tf.convert_to_tensor([[[0, 0, 10, 10], [1, 1, 4, 4], [4, 4, 5, 5]]])
 
         bboxes = bounding_box.add_class_id(bboxes)
         input = {"images": [image], "bounding_boxes": bboxes}
         mock_random = [0.1, 0.1, 0.1, 0.1]
         layer = preprocessing.RandomCropAndResize(
             target_size=(10, 10),
-            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            crop_area_factor=(0.5**2, 0.5**2),
             aspect_ratio_factor=(1.0, 1.0),
-            bounding_box_format="xyxy")
+            bounding_box_format="xyxy",
+        )
 
         with unittest.mock.patch.object(
-                layer._random_generator,
-                "random_uniform",
-                side_effect=mock_random,
+            layer._random_generator,
+            "random_uniform",
+            side_effect=mock_random,
         ):
             output = layer(input, training=True)
 
         expected_output = np.asarray(
-            [
-                [
-                    [0, 0, 10, 10, 0],
-                    [0, 0, 6, 6, 0],
-                    [6, 6, 8, 8, 0]
-                ]
-            ]
+            [[[0, 0, 10, 10, 0], [0, 0, 6, 6, 0], [6, 6, 8, 8, 0]]]
         )
         expected_output = np.reshape(expected_output, (1, 3, 5))
         self.assertAllClose(expected_output, output["bounding_boxes"])
@@ -231,42 +218,28 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
         image = tf.zeros([20, 20, 3])
 
         bboxes = tf.convert_to_tensor(
-            [
-                [
-                    [0, 0, 10, 10],
-                    [4, 4, 12, 12]
-                ],
-                [
-                    [4, 4, 12, 12],
-                    [0, 0, 10, 10]
-                ]
-            ]
+            [[[0, 0, 10, 10], [4, 4, 12, 12]], [[4, 4, 12, 12], [0, 0, 10, 10]]]
         )
         bboxes = bounding_box.add_class_id(bboxes)
         input = {"images": [image, image], "bounding_boxes": bboxes}
         mock_random = [0.0, 0.0, 0.1, 0.1]
         layer = preprocessing.RandomCropAndResize(
             target_size=(18, 18),
-            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            crop_area_factor=(0.5**2, 0.5**2),
             aspect_ratio_factor=(1.0, 1.0),
-            bounding_box_format="xyxy")
+            bounding_box_format="xyxy",
+        )
         with unittest.mock.patch.object(
-                layer._random_generator,
-                "random_uniform",
-                side_effect=mock_random,
+            layer._random_generator,
+            "random_uniform",
+            side_effect=mock_random,
         ):
             output = layer(input, training=True)
 
         expected_output = np.asarray(
             [
-                [
-                    [0, 0, 18, 18, 0],
-                    [8, 8, 18, 18, 0]
-                ],
-                [
-                    [8, 8, 18, 18, 0],
-                    [0, 0, 18, 18, 0]
-                ],
+                [[0, 0, 18, 18, 0], [8, 8, 18, 18, 0]],
+                [[8, 8, 18, 18, 0], [0, 0, 18, 18, 0]],
             ]
         )
         expected_output = np.reshape(expected_output, (2, 2, 5))
@@ -275,24 +248,17 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
     def test_augment_bbox_ragged(self):
         image = tf.zeros([2, 20, 20, 3])
         bboxes = tf.ragged.constant(
-            [
-                [
-                    [0, 0, 10, 10],
-                    [4, 4, 12, 12]
-                ],
-                [
-                    [0, 0, 10, 10]
-                ]
-            ], dtype=tf.float32
+            [[[0, 0, 10, 10], [4, 4, 12, 12]], [[0, 0, 10, 10]]], dtype=tf.float32
         )
         bboxes = bounding_box.add_class_id(bboxes)
         input = {"images": image, "bounding_boxes": bboxes}
         mock_random = [0.0, 0.0, 0.1, 0.1]
         layer = preprocessing.RandomCropAndResize(
             target_size=(18, 18),
-            crop_area_factor=(0.5 ** 2, 0.5 ** 2),
+            crop_area_factor=(0.5**2, 0.5**2),
             aspect_ratio_factor=(1.0, 1.0),
-            bounding_box_format="xyxy")
+            bounding_box_format="xyxy",
+        )
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
@@ -301,13 +267,8 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
             output = layer(input, training=True)
         expected_output = tf.ragged.constant(
             [
-                [
-                    [0, 0, 18, 18, 0],
-                    [8, 8, 18, 18, 0]
-                ],
-                [
-                    [0, 0, 18, 18, 0]
-                ],
+                [[0, 0, 18, 18, 0], [8, 8, 18, 18, 0]],
+                [[0, 0, 18, 18, 0]],
             ],
             dtype=tf.float32,
             ragged_rank=1,


### PR DESCRIPTION
# What does this PR do?

Fixes # ([issue](https://github.com/keras-team/keras-cv/issues/733)) (typo in the issue, the class name is `RandomCropAndResize` not `RandomResizedCrop`)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

@divyashreepathihalli @LukeWood 
