### PR TITLE
Implement bounding boxes for center crop

### DIFF
--- a/examples/layers/preprocessing/bounding_box/center_crop_demo.py
+++ b/examples/layers/preprocessing/bounding_box/center_crop_demo.py
@@ -1,0 +1,36 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+center_crop_demo.py shows how to use the CenterCrop preprocessing layer for
+object detection.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+
+def main():
+    dataset = demo_utils.load_voc_dataset(bounding_box_format="rel_xyxy")
+    center_crop = preprocessing.CenterCrop(
+        180,
+        112,
+        bounding_box_format="rel_xyxy",
+    )
+    result = dataset.map(center_crop, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_data(result, bounding_box_format="rel_xyxy")
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow.keras.layers import CenterCrop
 from tensorflow.keras.layers import RandomBrightness
 from tensorflow.keras.layers import RandomContrast
 from tensorflow.keras.layers import RandomCrop
@@ -36,6 +35,7 @@ from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
+from keras_cv.layers.preprocessing.center_crop import CenterCrop
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle
 from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.equalization import Equalization

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -15,7 +15,6 @@
 # Also export the image KPLs from core keras, so that user can import all the image
 # KPLs from one place.
 
-from tensorflow.keras.layers import CenterCrop
 from tensorflow.keras.layers import RandomBrightness
 from tensorflow.keras.layers import RandomContrast
 from tensorflow.keras.layers import RandomCrop
@@ -31,6 +30,7 @@ from keras_cv.layers.preprocessing.auto_contrast import AutoContrast
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
+from keras_cv.layers.preprocessing.center_crop import CenterCrop
 from keras_cv.layers.preprocessing.channel_shuffle import ChannelShuffle
 from keras_cv.layers.preprocessing.cut_mix import CutMix
 from keras_cv.layers.preprocessing.equalization import Equalization

--- a/keras_cv/layers/preprocessing/center_crop.py
+++ b/keras_cv/layers/preprocessing/center_crop.py
@@ -1,0 +1,171 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from tensorflow import keras
+
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class CenterCrop(BaseImageAugmentationLayer):
+    """A preprocessing layer which crops images.
+
+    The input images should have values in the `[0-255]` or `[0-1]` range.
+
+    Input shape:
+        3D (unbatched) or 4D (batched) tensor with shape:
+        `(..., height, width, channels)`, in `"channels_last"` format
+
+    Output shape:
+        3D (unbatched) or 4D (batched) tensor with shape:
+        `(..., height, width, channels)`, in `"channels_last"` format
+
+    Args:
+        height: Integer, the height of the output shape.
+        width: Integer, the width of the output shape.
+
+    Call arguments:
+        inputs: Tensor representing images of shape
+            `(batch_size, width, height, channels)`, with dtype tf.float32 / tf.uint8,
+            ` or (width, height, channels)`, with dtype tf.float32 / tf.uint8
+        training: A boolean argument that determines whether the call should be run
+            in inference mode or training mode. Default: True.
+
+    Usage:
+    ```python
+    (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+    channel_shuffle = keras_cv.layers.CenterCrop(10, 10)
+    augmented_images = channel_shuffle(images)
+    ```
+    """
+
+    def __init__(self, height: int, width: int, bounding_box_format=None, seed=None, **kwargs):
+        super().__init__(seed=seed, **kwargs)
+        self.height = height
+        self.width = width
+        self.bounding_box_format = bounding_box_format
+        self.base_layer_ = keras.layers.CenterCrop(self.height, self.width)
+
+    def augment_image(self, image, transformation=None, **kwargs):
+        image = self.base_layer_(image)
+        return image
+
+    def get_random_transformation(
+            self,
+            image=None,
+            label=None,
+            bounding_boxes=None,
+            keypoints=None,
+            segmentation_mask=None,
+    ):
+        image_shape = tf.shape(image)
+        return image_shape[-3], image_shape[-2]
+
+    def _transform_bounding_boxes(self, bounding_boxes, transformation):
+        original_height, original_width = transformation
+        h_diff = original_height - self.height
+        w_diff = original_width - self.width
+        do_crop = tf.logical_and(h_diff >= 0, w_diff >= 0)
+
+        def upsample_target_dims():
+            target_height_ = tf.cast(
+                tf.cast(original_width * self.height, "float32") / self.width, "int32"
+            )
+            target_width_ = tf.cast(
+                tf.cast(original_height * self.width, "float32") / self.height, "int32"
+            )
+            target_height_ = tf.minimum(original_height, target_height_)
+            target_width_ = tf.minimum(original_width, target_width_)
+            return target_height_, target_width_
+
+        target_height, target_width = tf.cond(
+            do_crop,
+            lambda: (self.height, self.width),
+            upsample_target_dims
+        )
+
+        h_perc = keras.backend.cast(target_height / original_height, bounding_boxes.dtype)
+        w_perc = keras.backend.cast(target_width / original_width, bounding_boxes.dtype)
+        h0 = 0.5 - 0.5 * h_perc
+        w0 = 0.5 - 0.5 * w_perc
+        x1, y1, x2, y2, rest = tf.split(
+            bounding_boxes, [1, 1, 1, 1, bounding_boxes.shape[-1] - 4], axis=-1
+        )
+        bounding_boxes = tf.concat(
+            [
+                (x1 - w0) / w_perc,
+                (y1 - h0) / h_perc,
+                (x2 - w0) / w_perc,
+                (y2 - h0) / h_perc,
+                rest,
+            ],
+            axis=-1,
+        )
+
+        return bounding_boxes
+
+    def augment_bounding_boxes(self, bounding_boxes, transformation=None, image=None, **kwargs):
+        if self.bounding_box_format is None:
+            raise ValueError(
+                "`CenterCrop()` was called with bounding boxes,"
+                "but no `bounding_box_format` was specified in the constructor."
+                "Please specify a bounding box format in the constructor. i.e."
+                "`CenterCrop(bounding_box_format='xyxy')`"
+            )
+
+        input_shape = (transformation[0], transformation[1], 3)
+        output_shape = (self.height, self.width, 3)
+
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            source=self.bounding_box_format,
+            target="rel_xyxy",
+            image_shape=input_shape
+        )
+
+        bounding_boxes = self._transform_bounding_boxes(bounding_boxes, transformation)
+
+        bounding_boxes = bounding_box.clip_to_image(
+            bounding_boxes,
+            bounding_box_format="rel_xyxy",
+            images=None,
+            image_shape=output_shape
+        )
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            source="rel_xyxy",
+            target=self.bounding_box_format,
+            dtype=self.compute_dtype,
+            image_shape=output_shape
+        )
+        return bounding_boxes
+
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        segmentation_mask = self.base_layer_(segmentation_mask)
+        return segmentation_mask
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"height": self.height, "width": self.width})
+        return config
+
+    def compute_output_shape(self, input_shape):
+        return self.base_layer_.compute_output_shape(input_shape)

--- a/keras_cv/layers/preprocessing/center_crop_test.py
+++ b/keras_cv/layers/preprocessing/center_crop_test.py
@@ -1,0 +1,148 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv import bounding_box
+from keras_cv.layers import preprocessing
+
+
+class CenterCropTest(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.product(
+        target_height=[5, 10, 15, 20],
+        target_width=[5, 10, 15, 20]
+    )
+    def test_same_results(self, target_height, target_width):
+        images = tf.random.normal((2, 10, 10, 3))
+
+        original_layer = tf.keras.layers.CenterCrop(target_height, target_width)
+        layer = preprocessing.CenterCrop(target_height, target_width)
+
+        original_output_image = original_layer(images)
+        output = layer({'images': images})
+
+        self.assertShapeEqual(original_output_image, output['images'])
+        self.assertAllClose(original_output_image, output['images'])
+
+    def test_bounding_boxes_case_crop(self):
+        images = tf.random.normal([2, 20, 20, 3])
+        bboxes = tf.constant(
+            [
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ],
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ]
+            ], dtype=tf.float32
+        )
+        bboxes = bounding_box.add_class_id(bboxes)
+
+        layer = preprocessing.CenterCrop(10, 10, bounding_box_format='xyxy')
+
+        outputs = layer({'images': images, 'bounding_boxes': bboxes})
+
+        expected_bboxes = tf.constant(
+            [
+                [0, 0, 10, 10, 0],
+                [0, 0, 5, 5, 0],
+                [-10, -10, -10, -10, -1],
+                [-10, -10, -10, -10, -1],
+            ]
+        )
+
+        self.assertAllClose(outputs['images'], images[:, 5:15, 5:15, :])
+        self.assertAllClose(outputs['bounding_boxes'][0], expected_bboxes)
+        self.assertAllClose(outputs['bounding_boxes'][1], expected_bboxes)
+
+    def test_bounding_boxes_upsample1(self):
+        images = tf.random.normal([2, 20, 20, 3])
+        bboxes = tf.constant(
+            [
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ],
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ]
+            ], dtype=tf.float32
+        )
+        bboxes = bounding_box.add_class_id(bboxes)
+
+        layer = preprocessing.CenterCrop(10, 30, bounding_box_format='xyxy')
+
+        outputs = layer({'images': images, 'bounding_boxes': bboxes})
+
+        expected_bboxes = tf.constant(
+            [
+                [0, 0, 22.5, 10, 0],
+                [0, 0, 15, 5, 0],
+                [-30, -10, -30, -10, -1],
+                [-30, -10, -30, -10, -1],
+            ]
+        )
+
+        self.assertAllClose(outputs['bounding_boxes'][0], expected_bboxes)
+        self.assertAllClose(outputs['bounding_boxes'][1], expected_bboxes)
+
+    def test_bounding_boxes_upsample2(self):
+        images = tf.random.normal([2, 20, 20, 3])
+        bboxes = tf.constant(
+            [
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ],
+                [
+                    [0, 0, 15, 15],
+                    [0, 0, 10, 10],
+                    [0, 0, 5, 5],
+                    [18, 18, 20, 20]
+                ]
+            ], dtype=tf.float32
+        )
+        bboxes = bounding_box.add_class_id(bboxes)
+
+        layer = preprocessing.CenterCrop(25, 50, bounding_box_format='xyxy')
+
+        outputs = layer({'images': images, 'bounding_boxes': bboxes})
+
+        expected_bboxes = tf.constant(
+            [
+                [0, 0, 37.5, 25, 0],
+                [0, 0, 25, 12.5, 0],
+                [-50, -25, -50, -25, -1],
+                [-50, -25, -50, -25, -1],
+            ]
+        )
+
+        self.assertAllClose(outputs['bounding_boxes'][0], expected_bboxes)
+        self.assertAllClose(outputs['bounding_boxes'][1], expected_bboxes)


### PR DESCRIPTION
# What does this PR do?

Implement # (https://github.com/keras-team/keras-cv/issues/731)

![centercrop](https://user-images.githubusercontent.com/25134196/201373479-81f2b5fa-0dfa-4860-a8f8-edc6b7d951d5.png)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

@LukeWood and @tanzhenyu