### PR TITLE
fixed transformer encoder dims per head

### DIFF
--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -306,7 +306,6 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
             {
                 "project_dim": 128,
                 "num_heads": 2,
-                "intermediate_dim": 128,
                 "mlp_dim": 128,
                 "mlp_dropout": 0.1,
                 "attention_dropout": 0.1,

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -59,9 +59,7 @@ class TransformerEncoder(layers.Layer):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        # hidden_dim by authors
         self.project_dim = project_dim
-        # intermediate_dim by authors
         self.mlp_dim = mlp_dim
         self.num_heads = num_heads
         self.mlp_dropout = mlp_dropout

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -23,7 +23,6 @@ class TransformerEncoder(layers.Layer):
 
     Args:
         project_dim: the dimensionality of the projection of the encoder
-        intermediate_dim: the intermediate dimensionality of the transformer encoder
         mlp_dim: the intermediate dimensionality of the MLP head before projecting to `project_dim`
         num_heads: the number of heads for the `MultiHeadAttention` layer
         mlp_dropout: default 0.1, the dropout rate to apply between the layers of the MLP head of the encoder
@@ -35,14 +34,12 @@ class TransformerEncoder(layers.Layer):
 
     ```
     project_dim = 1024
-    intermediate_dim = 768
     mlp_dim = 3072
     num_heads = 4
 
     patches = keras_cv.layers.Patching(patch_size)(cat_img)
     encoded_patches = keras_cv.layers.PatchEmbedding(project_dim=project_dim)(patches)
     trans_encoded = keras_cv.layers.TransformerEncoder(project_dim=project_dim,
-                                                       intermediate_dim=intermediate_dim,
                                                        mlp_dim = mlp_dim,
                                                        num_heads=num_heads)(encoded_patches)
 
@@ -54,7 +51,6 @@ class TransformerEncoder(layers.Layer):
         self,
         project_dim,
         num_heads,
-        intermediate_dim,
         mlp_dim,
         mlp_dropout=0.1,
         attention_dropout=0.1,
@@ -63,9 +59,9 @@ class TransformerEncoder(layers.Layer):
         **kwargs,
     ):
         super().__init__(**kwargs)
-
+        # hidden_dim by authors
         self.project_dim = project_dim
-        self.intermediate_dim = intermediate_dim
+        # intermediate_dim by authors
         self.mlp_dim = mlp_dim
         self.num_heads = num_heads
         self.mlp_dropout = mlp_dropout
@@ -78,7 +74,7 @@ class TransformerEncoder(layers.Layer):
         self.layer_norm2 = layers.LayerNormalization(epsilon=self.layer_norm_epsilon)
         self.attn = layers.MultiHeadAttention(
             num_heads=self.num_heads,
-            key_dim=self.project_dim,
+            key_dim=self.project_dim // self.num_heads,
             dropout=self.attention_dropout,
         )
         self.dense1 = layers.Dense(self.mlp_units[0], activation=activation)
@@ -116,7 +112,6 @@ class TransformerEncoder(layers.Layer):
         config.update(
             {
                 "project_dim": self.project_dim,
-                "intermediate_dim": self.intermediate_dim,
                 "mlp_dim": self.mlp_dim,
                 "num_heads": self.num_heads,
                 "attention_dropout": self.attention_dropout,

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -22,7 +22,7 @@ class TransformerEncoder(layers.Layer):
     Transformer encoder block implementation as a Keras Layer.
 
     Args:
-        project_dim: the dimensionality of the projection of the encoder
+        project_dim: the dimensionality of the projection of the encoder, and output of the `MultiHeadAttention`
         mlp_dim: the intermediate dimensionality of the MLP head before projecting to `project_dim`
         num_heads: the number of heads for the `MultiHeadAttention` layer
         mlp_dropout: default 0.1, the dropout rate to apply between the layers of the MLP head of the encoder

--- a/keras_cv/layers/transformer_encoder_test.py
+++ b/keras_cv/layers/transformer_encoder_test.py
@@ -20,7 +20,7 @@ from keras_cv.layers import TransformerEncoder
 class TransformerEncoderTest(tf.test.TestCase):
     def test_return_type_and_shape(self):
         layer = TransformerEncoder(
-            project_dim=128, num_heads=2, intermediate_dim=64, mlp_dim=128
+            project_dim=128, num_heads=2, mlp_dim=128
         )
 
         inputs = tf.random.normal([1, 197, 128])
@@ -31,7 +31,7 @@ class TransformerEncoderTest(tf.test.TestCase):
 
     def test_wrong_input_dims(self):
         layer = TransformerEncoder(
-            project_dim=128, num_heads=2, intermediate_dim=64, mlp_dim=128
+            project_dim=128, num_heads=2, mlp_dim=128
         )
         # Input dims must equal output dims because of the addition
         # of the residual to the final layer
@@ -44,7 +44,7 @@ class TransformerEncoderTest(tf.test.TestCase):
 
     def test_wrong_project_dims(self):
         layer = TransformerEncoder(
-            project_dim=256, num_heads=2, intermediate_dim=64, mlp_dim=128
+            project_dim=256, num_heads=2, mlp_dim=128
         )
         # Input dims must equal output dims because of the addition
         # of the residual to the final layer

--- a/keras_cv/layers/transformer_encoder_test.py
+++ b/keras_cv/layers/transformer_encoder_test.py
@@ -19,9 +19,7 @@ from keras_cv.layers import TransformerEncoder
 
 class TransformerEncoderTest(tf.test.TestCase):
     def test_return_type_and_shape(self):
-        layer = TransformerEncoder(
-            project_dim=128, num_heads=2, mlp_dim=128
-        )
+        layer = TransformerEncoder(project_dim=128, num_heads=2, mlp_dim=128)
 
         inputs = tf.random.normal([1, 197, 128])
         output = layer(inputs, training=True)
@@ -30,9 +28,7 @@ class TransformerEncoderTest(tf.test.TestCase):
         self.assertEquals(output.shape, [1, 197, 128])
 
     def test_wrong_input_dims(self):
-        layer = TransformerEncoder(
-            project_dim=128, num_heads=2, mlp_dim=128
-        )
+        layer = TransformerEncoder(project_dim=128, num_heads=2, mlp_dim=128)
         # Input dims must equal output dims because of the addition
         # of the residual to the final layer
         inputs = tf.random.normal([1, 197, 256])
@@ -43,9 +39,7 @@ class TransformerEncoderTest(tf.test.TestCase):
             layer(inputs, training=True)
 
     def test_wrong_project_dims(self):
-        layer = TransformerEncoder(
-            project_dim=256, num_heads=2, mlp_dim=128
-        )
+        layer = TransformerEncoder(project_dim=256, num_heads=2, mlp_dim=128)
         # Input dims must equal output dims because of the addition
         # of the residual to the final layer
         inputs = tf.random.normal([1, 197, 128])


### PR DESCRIPTION
# What does this PR do?

Fixes overlooked dimensionality issue with the use of the `MultiHeadAttention` layer in `keras_cv.layers.TransformerEncoder`. It should be:

```
        self.attn = layers.MultiHeadAttention(
            num_heads=self.num_heads,
            key_dim=self.project_dim // self.num_heads,
            dropout=self.attention_dropout,
        )
```

And not:

```
        self.attn = layers.MultiHeadAttention(
            num_heads=self.num_heads,
            key_dim=self.project_dim,
            dropout=self.attention_dropout,
        )
```

The latter makes the params skyrocket. Updated tests as well, and removed unused arg from the call.
My bad!

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?

## Who can review?
@tanzhenyu 