### PR TITLE
[Object Detection] Update retinanet predict loop to enable TPU support

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -457,8 +457,8 @@ class RetinaNet(ObjectDetectionBaseModel):
         self._update_metrics(y_for_metrics, predictions)
         return {m.name: m.result() for m in self.metrics}
 
-    def predict_step(self, x):
-        predictions = super().predict_step(x)
+    def predict(self, x, **kwargs):
+        predictions = super().predict(x, **kwargs)
         return self.decode_training_predictions(x, predictions)
 
     def _update_metrics(self, y_true, y_pred):


### PR DESCRIPTION
I've tested the full training + evaluation loop on TPU on [Colab](https://colab.sandbox.google.com/drive/16Lb6rMcFvtoic7DLd89Ap5-VxLa1dX_4?resourcekey=0-sDnh3nGFCx-6c7l_jnxShQ) with this change, and it's all working: