### PR TITLE
[Object Detection] RetinaNet: custom predict_function

### DIFF
--- a/keras_cv/models/object_detection/object_detection_base_model.py
+++ b/keras_cv/models/object_detection/object_detection_base_model.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
+from keras.engine.training import _minimum_control_deps
+from keras.engine.training import reduce_per_replica
+from keras.utils import tf_utils
 from tensorflow import keras
 
 from keras_cv import bounding_box
@@ -111,3 +114,84 @@ class ObjectDetectionBaseModel(keras.Model):
             images=x,
         )
         return x, (y_for_metrics, y_training_target)
+
+    def make_predict_function(self, force=False):
+        if self.predict_function is not None and not force:
+            return self.predict_function
+
+        def step_function(model, iterator):
+            """Runs a single evaluation step."""
+
+            def run_step(data):
+                outputs = model.predict_step(data)
+                # Ensure counter is updated only if `test_step` succeeds.
+                with tf.control_dependencies(_minimum_control_deps(outputs)):
+                    model._predict_counter.assign_add(1)
+                return outputs
+
+            if self._jit_compile:
+                run_step = tf.function(
+                    run_step, jit_compile=True, reduce_retracing=True
+                )
+
+            data = next(iterator)
+            outputs = model.distribute_strategy.run(run_step, args=(data,))
+            outputs = reduce_per_replica(
+                outputs, self.distribute_strategy, reduction="concat"
+            )
+            # Note that this is the only deviation from the base keras.Model
+            # implementation. We add the decode_step inside of the computation
+            # graph but outside of the distribute_strategy (i.e on host CPU).
+            if not isinstance(data, tf.Tensor):
+                data = tf.concat(data.values, axis=0)
+            return self.decode_predictions(outputs, data)
+
+        # Special case if steps_per_execution is one.
+        if (
+            self._steps_per_execution is None
+            or self._steps_per_execution.numpy().item() == 1
+        ):
+
+            def predict_function(iterator):
+                """Runs an evaluation execution with a single step."""
+                return step_function(self, iterator)
+
+        else:
+
+            def predict_function(iterator):
+                """Runs an evaluation execution with multiple steps."""
+                outputs = step_function(self, iterator)
+                for _ in tf.range(self._steps_per_execution - 1):
+                    tf.autograph.experimental.set_loop_options(
+                        shape_invariants=[
+                            (
+                                outputs,
+                                tf.nest.map_structure(
+                                    lambda t: tf_utils.get_tensor_spec(
+                                        t, dynamic_batch=True
+                                    ).shape,
+                                    outputs,
+                                ),
+                            )
+                        ]
+                    )
+                    step_outputs = step_function(self, iterator)
+                    outputs = tf.nest.map_structure(
+                        lambda t1, t2: tf.concat([t1, t2]), outputs, step_outputs
+                    )
+                return outputs
+
+        if not self.run_eagerly:
+            predict_function = tf.function(predict_function, reduce_retracing=True)
+        self.predict_function = predict_function
+
+        return self.predict_function
+
+    def decode_predictions(self, predictions, images):
+        """Decode predictions (e.g. with an NmsPredictionDecoder).
+
+        By default, this returns raw training predictions.
+        Subclasses that which to return decoded boxes should override this method.
+        """
+
+        return predictions

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -484,8 +484,10 @@ class RetinaNet(ObjectDetectionBaseModel):
             outputs = reduce_per_replica(
                 outputs, self.distribute_strategy, reduction="concat"
             )
+            if not isinstance(data, tf.Tensor):
+                data = tf.concat(data.values, axis=0)
             return self.decode_training_predictions(
-                tf.concat(data.values, axis=0), outputs
+                data, outputs
             )
 
         # Special case if steps_per_execution is one.

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -14,6 +14,9 @@
 
 import numpy as np
 import tensorflow as tf
+from keras.engine.training import _minimum_control_deps
+from keras.engine.training import reduce_per_replica
+from keras.utils import tf_utils
 from tensorflow import keras
 
 import keras_cv
@@ -457,9 +460,74 @@ class RetinaNet(ObjectDetectionBaseModel):
         self._update_metrics(y_for_metrics, predictions)
         return {m.name: m.result() for m in self.metrics}
 
-    def predict(self, x, **kwargs):
-        predictions = super().predict(x, **kwargs)
-        return self.decode_training_predictions(x, predictions)
+    def make_predict_function(self, force=False):
+        if self.predict_function is not None and not force:
+            return self.predict_function
+
+        def step_function(model, iterator):
+            """Runs a single evaluation step."""
+
+            def run_step(data):
+                outputs = model.predict_step(data)
+                # Ensure counter is updated only if `test_step` succeeds.
+                with tf.control_dependencies(_minimum_control_deps(outputs)):
+                    model._predict_counter.assign_add(1)
+                return outputs
+
+            if self._jit_compile:
+                run_step = tf.function(
+                    run_step, jit_compile=True, reduce_retracing=True
+                )
+
+            data = next(iterator)
+            outputs = model.distribute_strategy.run(run_step, args=(data,))
+            outputs = reduce_per_replica(
+                outputs, self.distribute_strategy, reduction="concat"
+            )
+            return self.decode_training_predictions(
+                tf.concat(data.values, axis=0), outputs
+            )
+
+        # Special case if steps_per_execution is one.
+        if (
+            self._steps_per_execution is None
+            or self._steps_per_execution.numpy().item() == 1
+        ):
+
+            def predict_function(iterator):
+                """Runs an evaluation execution with a single step."""
+                return step_function(self, iterator)
+
+        else:
+
+            def predict_function(iterator):
+                """Runs an evaluation execution with multiple steps."""
+                outputs = step_function(self, iterator)
+                for _ in tf.range(self._steps_per_execution - 1):
+                    tf.autograph.experimental.set_loop_options(
+                        shape_invariants=[
+                            (
+                                outputs,
+                                tf.nest.map_structure(
+                                    lambda t: tf_utils.get_tensor_spec(
+                                        t, dynamic_batch=True
+                                    ).shape,
+                                    outputs,
+                                ),
+                            )
+                        ]
+                    )
+                    step_outputs = step_function(self, iterator)
+                    outputs = tf.nest.map_structure(
+                        lambda t1, t2: tf.concat([t1, t2]), outputs, step_outputs
+                    )
+                return outputs
+
+        if not self.run_eagerly:
+            predict_function = tf.function(predict_function, reduce_retracing=True)
+        self.predict_function = predict_function
+
+        return self.predict_function
 
     def _update_metrics(self, y_true, y_pred):
         y_true = bounding_box.convert_format(

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -486,9 +486,7 @@ class RetinaNet(ObjectDetectionBaseModel):
             )
             if not isinstance(data, tf.Tensor):
                 data = tf.concat(data.values, axis=0)
-            return self.decode_training_predictions(
-                data, outputs
-            )
+            return self.decode_training_predictions(data, outputs)
 
         # Special case if steps_per_execution is one.
         if (


### PR DESCRIPTION
This allows us to perform the model inference using our distributed strategy and perform decoding on the local CPU.

Decoding on distributed devices doesn't work for TPU, and this change fixes that.
Eventually, TPUs should support the necessary op for decoding in a distributed fashion.

Missing op message:
```
No registered 'CombinedNonMaxSuppression' OpKernel for XLA_TPU_JIT
```

Unfortunately, to make this work I had to copy-paste the `keras.Model` implementation of `make_predict_function`, with the only changes being:

- Accessing `jit_compile` via `self._jit_compile` because `self.jit_compile` is a property defined on a superclass
- Replacing this code:
```
data = next(iterator)
outputs = model.distribute_strategy.run(run_step, args=(data,))
outputs = reduce_per_replica(
    outputs, self.distribute_strategy, reduction="concat"
)
return outputs
```
with
```
data = next(iterator)
outputs = model.distribute_strategy.run(run_step, args=(data,))
outputs = reduce_per_replica(
    outputs, self.distribute_strategy, reduction="concat"
)
if not isinstance(data, tf.Tensor):
    data = tf.concat(data.values, axis=0)
return self.decode_training_predictions(data, outputs)
```

I think this is a bit of a hack, but let's to discuss