### PR TITLE
Revert "[Object Detection] Update retinanet predict loop to enable TPU support"

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -457,8 +457,8 @@ class RetinaNet(ObjectDetectionBaseModel):
         self._update_metrics(y_for_metrics, predictions)
         return {m.name: m.result() for m in self.metrics}
 
-    def predict(self, x, **kwargs):
-        predictions = super().predict(x, **kwargs)
+    def predict_step(self, x):
+        predictions = super().predict_step(x)
         return self.decode_training_predictions(x, predictions)
 
     def _update_metrics(self, y_true, y_pred):


### PR DESCRIPTION
Reverts keras-team/keras-cv#1017

As per our discussion, this seems to have broken `predict` for tf.data.Dataset, so we'll need to find another path forward. For the time being, I think we should roll this back.