### PR TITLE
ResNet and ResNetV2 - Typo fix in docstrings

### DIFF
--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -61,7 +61,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
 
     The difference in Resnet and ResNetV2 rests in the structure of their
     individual building blocks. In ResNetV2, the batch normalization and
-    ReLU activation preceed the convolution layers, as opposed to ResNetV1 where
+    ReLU activation precede the convolution layers, as opposed to ResNetV1 where
     the batch normalization and ReLU activation are applied after the
     convolution layers.
 

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -63,7 +63,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
 
     The difference in Resnet and ResNetV2 rests in the structure of their
     individual building blocks. In ResNetV2, the batch normalization and
-    ReLU activation preceed the convolution layers, as opposed to ResNetV1 where
+    ReLU activation precede the convolution layers, as opposed to ResNetV1 where
     the batch normalization and ReLU activation are applied after the
     convolution layers.
 


### PR DESCRIPTION
# What does this PR do?

"preceed" -> "precede"

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

@LukeWood @tanzhenyu 