### PR TITLE
Update group_normalization.py

### DIFF
--- a/keras_cv/models/stable_diffusion/__internal__/layers/group_normalization.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/group_normalization.py
@@ -84,7 +84,7 @@ class GroupNormalization(tf.keras.layers.Layer):
         return gamma, beta
 
     def _create_broadcast_shape(self, input_shape):
-        broadcast_shape = [1] * len(input_shape)
+        broadcast_shape = [1] * input_shape.shape.rank
         broadcast_shape[self.axis] = input_shape[self.axis] // self.groups
         broadcast_shape.insert(self.axis, self.groups)
         return broadcast_shape


### PR DESCRIPTION
opening a pull request to fix the len while saving the model as suggested by @freedomtan

reference context: https://github.com/keras-team/keras-cv/issues/1033
specific issue: https://github.com/keras-team/keras-cv/issues/1034

[/usr/local/lib/python3.7/dist-packages/keras_cv/models/generative/stable_diffusion/__internal__/layers/group_normalization.py](https://localhost:8080/#) in _create_broadcast_shape(self, input_shape)
     85 
     86     def _create_broadcast_shape(self, input_shape):
---> 87      broadcast_shape = [1] * len(input_shape) 
     88         broadcast_shape[self.axis] = input_shape[self.axis] // self.groups

TypeError: Exception encountered when calling layer 'group_normalization_60' (type GroupNormalization).

len is not well defined for a symbolic Tensor (Shape:0). Please call `x.shape` rather than `len(x)` for shape information.

Call arguments received by layer 'group_normalization_60' (type GroupNormalization):
  • args=('tf.Tensor(shape=(None, 64, 64, 320), dtype=float32)',)
  • kwargs=<class 'inspect._empty'>

# What does this PR do?
changes from len(input) to input.shape.rank

Fixes # (issue)
https://github.com/keras-team/keras-cv/issues/1034

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
    The issue discussed with @LukeWood. This is just a minor patch.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?


