### PR TITLE
[Object Detection] Updates to FasterRCNN

### DIFF
--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -64,7 +64,7 @@ eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 with strategy.scope():
     model = keras_cv.models.FasterRCNN(
-        classes=20, bounding_box_format="yxyx", include_rescaling=True
+        classes=20, bounding_box_format="yxyx", include_rescaling=False
     )
 
 

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -63,7 +63,9 @@ train_ds = train_ds.concatenate(
 eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 with strategy.scope():
-    model = keras_cv.models.FasterRCNN(classes=20, bounding_box_format="yxyx")
+    model = keras_cv.models.FasterRCNN(
+        classes=20, bounding_box_format="yxyx", include_rescaling=True
+    )
 
 
 # TODO (tanzhenyu): migrate to KPL, as this is mostly a duplicate of

--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -18,6 +18,7 @@ from keras_cv import version_check
 version_check.check_tf_version()
 # isort:on
 
+from keras_cv import callbacks
 from keras_cv import datasets
 from keras_cv import layers
 from keras_cv import losses

--- a/keras_cv/layers/object_detection/nms_prediction_decoder.py
+++ b/keras_cv/layers/object_detection/nms_prediction_decoder.py
@@ -98,7 +98,7 @@ class NmsPredictionDecoder(tf.keras.layers.Layer):
                 `bounding_box_format` specified in the constructor.
             anchor_boxes: (optional) dense tensor of shape [batch, anchor_boxes, 4].
                 When specified, use these custom anchor boxes instead of using
-                the anchor generator.
+                the anchor generator. These should always be in the format "xywh".
         """
         if isinstance(images, tf.RaggedTensor):
             raise ValueError(

--- a/keras_cv/layers/object_detection/nms_prediction_decoder.py
+++ b/keras_cv/layers/object_detection/nms_prediction_decoder.py
@@ -115,7 +115,7 @@ class NmsPredictionDecoder(tf.keras.layers.Layer):
                 target="xywh",
                 images=images[0],
             )
-            anchor_boxes = anchor_boxes[None, ...]
+            anchor_boxes = anchor_boxes[tf.newaxis, ...]
         predictions = bounding_box.convert_format(
             predictions, source=self.bounding_box_format, target="xywh", images=images
         )

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -281,9 +281,11 @@ class FasterRCNN(ObjectDetectionBaseModel):
             from paper, which is 2 FC layer with 1024 dimension, 1 box regressor and 1
             softmax classifier.
         prediction_decoder: (Optional)  A `keras.layer` that is responsible for
-            transforming RetinaNet predictions into usable bounding box Tensors.  If
+            transforming box predictions into usable bounding box Tensors.  If
             not provided, a default is provided.  The default `prediction_decoder`
-            layer uses a `NonMaxSuppression` operation for box pruning.
+            layer uses a `NonMaxSuppression` operation for box pruning. The model
+            outputs box predictions relative to anchor boxes which are decoded and
+            pruned by the decoder.
     """
 
     def __init__(

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -387,6 +387,9 @@ class FasterRCNN(ObjectDetectionBaseModel):
         if training:
             return box_pred, cls_pred
 
+        rois = bounding_box.convert_format(
+            rois, source="center_yxhw", target=self.bounding_box_format
+        )
         # Return anchor boxes of interest during evaluation
         return box_pred, cls_pred, rois
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -533,6 +533,8 @@ class FasterRCNN(ObjectDetectionBaseModel):
             target=self.prediction_decoder.bounding_box_format,
             images=images,
         )
+        # The prediction decoder expects anchor boxes in xywh
+        rois = bounding_box.convert_format(rois, "yxyx", "xywh", images=images)
         pred_for_inference = self.prediction_decoder(
             images, pred_for_inference, anchor_boxes=rois
         )

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import tensorflow as tf
 from absl import logging
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -290,14 +290,18 @@ class FasterRCNN(ObjectDetectionBaseModel):
         self,
         classes,
         bounding_box_format,
+        include_rescaling,
         backbone=None,
-        include_rescaling=False,
         anchor_generator=None,
         rpn_head=None,
         rcnn_head=None,
         prediction_decoder=None,
         **kwargs,
     ):
+        if bounding_box_format != "yxyx":
+            raise ValueError(
+                "FasterRCNN currently only supports `bounding_box_format='yxyx'`"
+            )
         self.bounding_box_format = bounding_box_format
         super().__init__(
             bounding_box_format=bounding_box_format, label_encoder=None, **kwargs

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -387,9 +387,6 @@ class FasterRCNN(ObjectDetectionBaseModel):
         if training:
             return box_pred, cls_pred
 
-        rois = bounding_box.convert_format(
-            rois, source="center_yxhw", target=self.bounding_box_format
-        )
         # Return anchor boxes of interest during evaluation
         return box_pred, cls_pred, rois
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -259,8 +259,8 @@ class FasterRCNN(ObjectDetectionBaseModel):
         bounding_box_format: The format of bounding boxes of model output. Refer
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
-        backbone: Either `"resnet50"` or a custom backbone model. For now, only a backbone
-            with per level dict output is supported. Default to ResNet50 with FPN, which
+        backbone: (optional) a custom backbone model. For now, only a backbone
+            with per level dict output is supported. Defaults to ResNet50 with FPN, which
             uses the last conv block from stage 2 to stage 6 and add a max pooling at
             stage 7.
         include_rescaling: Required if provided backbone is a pre-configured model.

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -19,7 +19,9 @@ from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 
 class FasterRCNNTest(tf.test.TestCase):
     def test_faster_rcnn_infer(self):
-        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="xyxy", include_rescaling=True
+        )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=False)
         # 1000 proposals in inference
@@ -27,21 +29,27 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_faster_rcnn_predict(self):
-        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="xyxy", include_rescaling=True
+        )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model.predict(images, batch_size=2)
         # Ouputs a ragged tensor of predicted boxes
         self.assertAllEqual([2, None, 6], outputs.shape)
 
     def test_faster_rcnn_train(self):
-        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="xyxy", include_rescaling=True
+        )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=True)
         self.assertAllEqual([2, 1000, 81], outputs[1].shape)
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_invalid_compile(self):
-        model = FasterRCNN(classes=80, bounding_box_format="yxyx")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="yxyx", include_rescaling=True
+        )
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")
         with self.assertRaisesRegex(ValueError, "only accepts"):

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -19,6 +19,7 @@ from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 
 class FasterRCNNTest(tf.test.TestCase):
     def test_faster_rcnn_infer(self):
+        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="xyxy")
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=False)
@@ -26,7 +27,16 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 81], outputs[1].shape)
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
+    def test_faster_rcnn_predict(self):
+        tf.config.set_visible_devices([], "GPU")
+        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        images = tf.random.normal([2, 512, 512, 3])
+        outputs = model.predict(images, batch_size=2)
+        # Ouputs a ragged tensor of predicted boxes
+        self.assertAllEqual([2, None, 6], outputs.shape)
+
     def test_faster_rcnn_train(self):
+        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="xyxy")
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=True)
@@ -34,6 +44,7 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_invalid_compile(self):
+        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="yxyx")
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -19,7 +19,6 @@ from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 
 class FasterRCNNTest(tf.test.TestCase):
     def test_faster_rcnn_infer(self):
-        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="xyxy")
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=False)
@@ -28,7 +27,6 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_faster_rcnn_predict(self):
-        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="xyxy")
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model.predict(images, batch_size=2)
@@ -36,7 +34,6 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, None, 6], outputs.shape)
 
     def test_faster_rcnn_train(self):
-        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="xyxy")
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=True)
@@ -44,7 +41,6 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_invalid_compile(self):
-        tf.config.set_visible_devices([], "GPU")
         model = FasterRCNN(classes=80, bounding_box_format="yxyx")
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -20,7 +20,7 @@ from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 class FasterRCNNTest(tf.test.TestCase):
     def test_faster_rcnn_infer(self):
         model = FasterRCNN(
-            classes=80, bounding_box_format="xyxy", include_rescaling=True
+            classes=80, bounding_box_format="yxyx", include_rescaling=True
         )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=False)
@@ -30,7 +30,7 @@ class FasterRCNNTest(tf.test.TestCase):
 
     def test_faster_rcnn_predict(self):
         model = FasterRCNN(
-            classes=80, bounding_box_format="xyxy", include_rescaling=True
+            classes=80, bounding_box_format="yxyx", include_rescaling=True
         )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model.predict(images, batch_size=2)
@@ -39,7 +39,7 @@ class FasterRCNNTest(tf.test.TestCase):
 
     def test_faster_rcnn_train(self):
         model = FasterRCNN(
-            classes=80, bounding_box_format="xyxy", include_rescaling=True
+            classes=80, bounding_box_format="yxyx", include_rescaling=True
         )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=True)

--- a/keras_cv/models/object_detection/object_detection_base_model.py
+++ b/keras_cv/models/object_detection/object_detection_base_model.py
@@ -23,6 +23,10 @@ from keras_cv.models.object_detection.__internal__ import convert_inputs_to_tf_d
 from keras_cv.models.object_detection.__internal__ import train_validation_split
 
 
+# TODO(ianstenbit): consider removing this class hierarchy and making OD
+# models subclass keras.Model directly. Main criteria for this move are:
+# - TPU box decoding works without our custom make_predict_function
+# - OD API is stable
 class ObjectDetectionBaseModel(keras.Model):
     """ObjectDetectionBaseModel performs asynchonous label encoding.
 


### PR DESCRIPTION
Main changes are:

- Make FasterRCNN a subclass of BaseObjectDetectionModel
- Add prediction decoding to the output of FasterRCNN.predict (required some changes to the NmsDecoder)
- Add TPU support for evaluation (including decoding)

Here's a [colab](https://colab.sandbox.google.com/drive/10hNe093WPyVx2wfFJD7AVzlvgwu2rh0-?resourcekey=0-Pa59dGS-88kQc3YspTOoUw#scrollTo=4sPJM_SMyChC) of FasterRCNN on TPU training against VOC/2007 and using our coco metrics callback. Resulting TensorBoard history pending