### PR TITLE
PR autolabel size + warning

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: labeler
+
+on: [pull_request]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '10'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '500'
+          l_label: 'size/l'
+          l_max_size: '1000'
+          xl_label: 'size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          github_api_url: 'api.github.com'
+          files_to_ignore: ''

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: labeler
 
 on: 
-- pull_request_target
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,13 @@
 name: labeler
 
-on: [pull_request]
+on: pull_request_target
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
     name: Label the PR size
     permissions:
-      issues: write
+      contents: read
       pull-requests: write
     steps:
       - uses: codelytv/pr-size-labeler@v1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,6 @@
 name: labeler
 
-on: 
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: [pull_request]
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: labeler
 
-on: pull_request_target
+on: 
+- pull_request_target
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     name: Label the PR size
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,5 +27,4 @@ jobs:
             This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.
-          github_api_url: 'api.github.com'
           files_to_ignore: ''

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'
           xs_max_size: '10'
           s_label: 'size/s'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
-          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'
           xs_max_size: '10'
           s_label: 'size/s'


### PR DESCRIPTION
# What does this PR do?
This PR autolabel the PR with a configurable size label and eventually add a message for very large PRs.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
