### PR TITLE
Step 1/4 [ObjectDetection]: allow PyCOCOCallback to take apply_nms

### DIFF
--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -25,6 +25,7 @@ import tensorflow_datasets as tfds
 from absl import flags
 
 import keras_cv
+from keras_cv.callbacks import PyCOCOCallback
 
 flags.DEFINE_string(
     "weights_path",
@@ -227,12 +228,18 @@ def proc_train_fn(bounding_box_format, img_size):
     return apply
 
 
+# TODO(tanzhenyu): consider remove padding while reduce function tracing.
 def pad_fn(examples):
     gt_boxes = examples.pop("gt_boxes")
     gt_classes = examples.pop("gt_classes")
+    num_det = gt_boxes.row_lengths()
     gt_boxes = gt_boxes.to_tensor(default_value=-1.0, shape=[global_batch, 32, 4])
     gt_classes = gt_classes.to_tensor(default_value=-1.0, shape=[global_batch, 32, 1])
-    return examples["images"], {"gt_boxes": gt_boxes, "gt_classes": gt_classes}
+    return examples["images"], {
+        "gt_boxes": gt_boxes,
+        "gt_classes": gt_classes,
+        "gt_num_dets": num_det,
+    }
 
 
 train_ds = train_ds.map(
@@ -275,6 +282,7 @@ callbacks = [
     tf.keras.callbacks.TensorBoard(
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
     ),
+    PyCOCOCallback(eval_ds, bounding_box_format="yxyx", apply_nms=False),
 ]
 model.compile(
     optimizer=optimizer,

--- a/examples/models/object_detection/faster_rcnn/train.py
+++ b/examples/models/object_detection/faster_rcnn/train.py
@@ -282,7 +282,7 @@ callbacks = [
     tf.keras.callbacks.TensorBoard(
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
     ),
-    PyCOCOCallback(eval_ds, bounding_box_format="yxyx", apply_nms=False),
+    PyCOCOCallback(eval_ds, bounding_box_format="yxyx", input_nms=False),
 ]
 model.compile(
     optimizer=optimizer,

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -30,6 +30,9 @@ class PyCOCOCallback(Callback):
                 "gt_classes": classes})```.
             bounding_box_format: the KerasCV bounding box format used in the
                 validation dataset (e.g. "xywh")
+            apply_nms: whether the model has already applied non-max-suppression. If False,
+                the callback will use `model.nms_decoder` to decode the model prediction,
+                otherwise the callback will use model prediction as-is. Default to True.
             cache: whether the callback should cache the dataset between iterations.
                 Note that if the validation dataset has shuffling of any kind
                 (e.g from `shuffle_files=True` in a call to TFDS.load or a call

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -67,15 +67,7 @@ class PyCOCOCallback(Callback):
                     scores_pred,
                     cls_pred,
                     valid_det,
-                ) = tf.image.combined_non_max_suppression(
-                    boxes=box_pred,
-                    scores=cls_pred[..., :-1],
-                    max_output_size_per_class=10,
-                    max_total_size=10,
-                    score_threshold=0.5,
-                    iou_threshold=0.5,
-                    clip_boxes=False,
-                )
+                ) = self.model.nms_decoder(box_pred, cls_pred)
 
         gt = [boxes for boxes in self.val_data.map(boxes_only)]
         if self.apply_nms:

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -56,3 +56,31 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         self.assertAllInSet(
             [f"val_{metric}" for metric in METRIC_NAMES], history.history.keys()
         )
+
+    def test_apply_nms_false(self):
+        model = keras_cv.models.FasterRCNN(
+            classes=10,
+            bounding_box_format="xywh",
+        )
+        model.compile(
+            optimizer="adam",
+            box_loss="Huber",
+            classification_loss="SparseCategoricalCrossentropy",
+            rpn_box_loss="Huber",
+            rpn_classification_loss="BinaryCrossentropy",
+        )
+        train_ds = _create_bounding_box_dataset(
+            bounding_box_format="yxyx", use_dictionary_box_format=True
+        )
+        eval_ds = _create_bounding_box_dataset(
+            bounding_box_format="yxyx", use_dictionary_box_format=True
+        )
+        callback = PyCOCOCallback(
+            validation_data=eval_ds,
+            bounding_box_format="yxyx",
+            apply_nms=False,
+        )
+        history = model.fit(train_ds, callbacks=[callback])
+        self.assertAllInSet(
+            [f"val_{metric}" for metric in METRIC_NAMES], history.history.keys()
+        )

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -57,7 +57,7 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             [f"val_{metric}" for metric in METRIC_NAMES], history.history.keys()
         )
 
-    def test_apply_nms_false(self):
+    def test_input_nms_false(self):
         model = keras_cv.models.FasterRCNN(
             classes=10,
             bounding_box_format="xywh",
@@ -78,7 +78,7 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         callback = PyCOCOCallback(
             validation_data=eval_ds,
             bounding_box_format="yxyx",
-            apply_nms=False,
+            input_nms=False,
         )
         history = model.fit(train_ds, callbacks=[callback])
         self.assertAllInSet(

--- a/keras_cv/models/object_detection/__test_utils__.py
+++ b/keras_cv/models/object_detection/__test_utils__.py
@@ -30,10 +30,11 @@ def _create_bounding_box_dataset(bounding_box_format, use_dictionary_box_format=
     ys = keras_cv.bounding_box.convert_format(
         ys, source="rel_xywh", target=bounding_box_format, images=xs, dtype=tf.float32
     )
+    num_dets = tf.ones([10])
 
     if use_dictionary_box_format:
         return tf.data.Dataset.from_tensor_slices(
-            (xs, {"gt_boxes": ys, "gt_classes": y_classes})
+            (xs, {"gt_boxes": ys, "gt_classes": y_classes, "gt_num_dets": num_dets})
         ).batch(5, drop_remainder=True)
     else:
         ys = tf.concat([ys, y_classes], axis=-1)

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -225,6 +225,51 @@ class RCNNHead(tf.keras.layers.Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class NMSDecoder(tf.keras.layers.Layer):
+    """A customized NMS layer wrapper."""
+
+    def __init__(
+        self,
+        iou_threshold=0.5,
+        score_threshold=0.5,
+        max_output_size_per_class=10,
+        max_total_size=10,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.iou_threshold = iou_threshold
+        self.score_threshold = score_threshold
+        self.max_output_size_per_class = max_output_size_per_class
+        self.max_total_size = max_total_size
+
+    def call(self, box_pred, scores_pred):
+        (
+            box_pred,
+            scores_pred,
+            cls_pred,
+            valid_det,
+        ) = tf.image.combined_non_max_suppression(
+            boxes=box_pred,
+            scores=scores_pred[..., :-1],
+            max_output_size_per_class=self.max_output_size_per_class,
+            max_total_size=self.max_total_size,
+            score_threshold=self.score_threshold,
+            iou_threshold=self.iou_threshold,
+            clip_boxes=False,
+        )
+        return box_pred, scores_pred, cls_pred, valid_det
+
+    def get_config(self):
+        config = {
+            "iou_threshold": self.iou_threshold,
+            "score_threshold": self.score_threshold,
+            "max_output_size_per_class": self.max_output_size_per_class,
+            "max_total_size": self.max_total_size,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 # TODO(tanzheny): add more configurations
 class FasterRCNN(tf.keras.Model):
     """A Keras model implementing the FasterRCNN architecture.
@@ -275,6 +320,9 @@ class FasterRCNN(tf.keras.Model):
             (all foreground classes + one background class). By default it uses the rcnn head
             from paper, which is 2 FC layer with 1024 dimension, 1 box regressor and 1
             softmax classifier.
+        nms_decoder: (Optional) a `keras.layers.Layer` that takes input box prediction and
+            softmaxed score prediction, and returns NMSed box prediction, NMSed softmaxed
+            score prediction, NMSed class prediction, and NMSed valid detection.
     """
 
     def __init__(
@@ -286,6 +334,7 @@ class FasterRCNN(tf.keras.Model):
         anchor_generator=None,
         rpn_head=None,
         rcnn_head=None,
+        nms_decoder=None,
         **kwargs,
     ):
         self.bounding_box_format = bounding_box_format
@@ -329,6 +378,7 @@ class FasterRCNN(tf.keras.Model):
             samples_per_image=256,
             positive_fraction=0.5,
         )
+        self.nms_decoder = nms_decoder or NMSDecoder()
 
     def _call_rpn(self, images, anchors, training=None):
         image_shape = tf.shape(images[0])

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -225,6 +225,7 @@ class RCNNHead(tf.keras.layers.Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+#TODO(tanzhenyu): provide a TPU compatible NMS decoder.
 class NMSDecoder(tf.keras.layers.Layer):
     """A customized NMS layer wrapper."""
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -225,7 +225,7 @@ class RCNNHead(tf.keras.layers.Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-#TODO(tanzhenyu): provide a TPU compatible NMS decoder.
+# TODO(tanzhenyu): provide a TPU compatible NMS decoder.
 class NMSDecoder(tf.keras.layers.Layer):
     """A customized NMS layer wrapper."""
 


### PR DESCRIPTION
The trained result for FasterRCNN got ~40.4 mAP (0.5:0.95), and ~66 mAP (0.5).

inheriting OD Base Model and overriding `predict` only gets to ~28 mAP, which is significantly lower than this PR

Step 2/4: update RetinaNet to disable nms during train and eval, and remove OD Base Model.
Step 3/4: add Batch MultiClass NMS layer that works for TPU
Step 4/4: update FasterRCNN and RetinaNet to take new NMS layer, and set apply_nms to True.
