### PR TITLE
[Object Detection] Fix SmoothL1 Loss Calculation

### DIFF
--- a/examples/models/object_detection/retina_net/pascal_voc/train.py
+++ b/examples/models/object_detection/retina_net/pascal_voc/train.py
@@ -392,7 +392,7 @@ coco_suite = [
 ]
 model.compile(
     classification_loss=keras_cv.losses.FocalLoss(from_logits=True, reduction="none"),
-    box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+    box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
     optimizer=optimizer,
     metrics=coco_suite,
 )

--- a/keras_cv/losses/smooth_l1.py
+++ b/keras_cv/losses/smooth_l1.py
@@ -23,12 +23,15 @@ class SmoothL1Loss(tf.keras.losses.Loss):
     contribute to the overall loss based on their squared difference, and values greater
     than `beta` contribute based on their raw difference.
 
-    As `beta` approaches 1 - the loss approaches L2 loss.
-    As `beta` approaches 0 - the loss approaches L1 loss.
+    The function is quadratic for small values, and linear for large values,
+    balancing the positives of L1 and L2 losses.
+
+    L2 loss is used on targets between [0...beta] (near zero).
+    L1 loss is used on targets between [beta...+inf] (large values).
 
     Args:
-        beta: differences between y_true and y_pred that are larger than `beta` are
-            treated as `L1` values.
+        beta: default 1.0, the threshold at which the loss behaves as L1 or L2, in
+        the range of [0..1].
     """
 
     def __init__(self, beta=1.0, **kwargs):

--- a/keras_cv/losses/smooth_l1.py
+++ b/keras_cv/losses/smooth_l1.py
@@ -19,33 +19,33 @@ import tensorflow as tf
 class SmoothL1Loss(tf.keras.losses.Loss):
     """Implements Smooth L1 loss.
 
-    SmoothL1Loss implements the SmoothL1 function, where values less than `l1_cutoff`
+    SmoothL1Loss implements the SmoothL1 function, where values less than `beta`
     contribute to the overall loss based on their squared difference, and values greater
-    than l1_cutoff contribute based on their raw difference.
+    than `beta` contribute based on their raw difference.
 
     Args:
-        l1_cutoff: differences between y_true and y_pred that are larger than `l1_cutoff` are
+        beta: differences between y_true and y_pred that are larger than `beta` are
             treated as `L1` values
     """
 
-    def __init__(self, l1_cutoff=1.0, **kwargs):
+    def __init__(self, beta=1.0, **kwargs):
         super().__init__(**kwargs)
-        self.l1_cutoff = l1_cutoff
+        self.beta = beta
 
     def call(self, y_true, y_pred):
         difference = y_true - y_pred
         absolute_difference = tf.abs(difference)
         squared_difference = difference**2
         loss = tf.where(
-            absolute_difference < self.l1_cutoff,
-            0.5 * squared_difference,
-            absolute_difference - 0.5,
+            absolute_difference < self.beta,
+            (0.5 * squared_difference) / self.beta,
+            (absolute_difference - 0.5) * self.beta,
         )
         return tf.keras.backend.mean(loss, axis=-1)
 
     def get_config(self):
         config = {
-            "l1_cutoff": self.l1_cutoff,
+            "beta": self.beta,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras_cv/losses/smooth_l1.py
+++ b/keras_cv/losses/smooth_l1.py
@@ -23,9 +23,12 @@ class SmoothL1Loss(tf.keras.losses.Loss):
     contribute to the overall loss based on their squared difference, and values greater
     than `beta` contribute based on their raw difference.
 
+    As `beta` approaches 1 - the loss approaches L2 loss.
+    As `beta` approaches 0 - the loss approaches L1 loss.
+
     Args:
         beta: differences between y_true and y_pred that are larger than `beta` are
-            treated as `L1` values
+            treated as `L1` values.
     """
 
     def __init__(self, beta=1.0, **kwargs):
@@ -39,7 +42,7 @@ class SmoothL1Loss(tf.keras.losses.Loss):
         loss = tf.where(
             absolute_difference < self.beta,
             (0.5 * squared_difference) / self.beta,
-            (absolute_difference - 0.5) * self.beta,
+            absolute_difference - 0.5 * self.beta,
         )
         return tf.keras.backend.mean(loss, axis=-1)
 

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -43,7 +43,7 @@ class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
         loss = keras_cv.losses.SmoothL1Loss(beta=0.5)
 
         result = loss(y_true, y_pred)
-        self.assertEqual(result, 0.25)
+        self.assertEqual(result, 0.75)
 
         loss = keras_cv.losses.SmoothL1Loss(beta=0.0)
 

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -48,4 +48,4 @@ class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
         loss = keras_cv.losses.SmoothL1Loss(beta=0.0)
 
         result = loss(y_true, y_pred)
-        self.assertEqual(result, 0.0)
+        self.assertEqual(result, 1.0)

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -31,3 +31,21 @@ class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
             y_pred=tf.random.uniform((20, 300)),
         )
         self.assertEqual(result.shape, target_size)
+
+    def test_beta_values(self):
+        loss = keras_cv.losses.SmoothL1Loss(beta=1.0)
+        y_pred = tf.zeros(shape=(1, 10))
+        y_true = tf.ones(shape=(1, 10))
+
+        result = loss(y_true, y_pred)
+        self.assertEqual(result, 0.5)
+
+        loss = keras_cv.losses.SmoothL1Loss(beta=0.5)
+
+        result = loss(y_true, y_pred)
+        self.assertEqual(result, 0.25)
+
+        loss = keras_cv.losses.SmoothL1Loss(beta=0.0)
+
+        result = loss(y_true, y_pred)
+        self.assertEqual(result, 0.0)

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -25,7 +25,7 @@ class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
         ("sum_over_batch_size", "sum_over_batch_size", ()),
     )
     def test_proper_output_shapes(self, reduction, target_size):
-        loss = keras_cv.losses.SmoothL1Loss(l1_cutoff=0.5, reduction=reduction)
+        loss = keras_cv.losses.SmoothL1Loss(beta=0.5, reduction=reduction)
         result = loss(
             y_true=tf.random.uniform((20, 300)),
             y_pred=tf.random.uniform((20, 300)),

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -541,7 +541,7 @@ def _parse_box_loss(loss):
 
     # case insensitive comparison
     if loss.lower() == "smoothl1":
-        return keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none")
+        return keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none")
     if loss.lower() == "huber":
         return keras.losses.Huber(reduction="none")
 

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -194,7 +194,7 @@ def _create_retina_nets(x, y, epochs=1, custom_decoder=False):
             from_logits=True,
             reduction="none",
         ),
-        box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+        box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
         optimizer="adam",
         metrics=[
             keras_cv.metrics.COCOMeanAveragePrecision(
@@ -244,7 +244,7 @@ def _create_retina_nets(x, y, epochs=1, custom_decoder=False):
             from_logits=True,
             reduction="none",
         ),
-        box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+        box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
         optimizer="adam",
         metrics=[
             keras_cv.metrics.COCOMeanAveragePrecision(

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -165,7 +165,7 @@ class RetinaNetTest(tf.test.TestCase):
                 classification_loss=keras_cv.losses.FocalLoss(
                     from_logits=False, reduction="none"
                 ),
-                box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+                box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
             )
 
     def test_no_metrics(self):
@@ -182,7 +182,7 @@ class RetinaNetTest(tf.test.TestCase):
             classification_loss=keras_cv.losses.FocalLoss(
                 from_logits=True, reduction="none"
             ),
-            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+            box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
         )
 
     def test_weights_contained_in_trainable_variables(self):
@@ -200,7 +200,7 @@ class RetinaNetTest(tf.test.TestCase):
             classification_loss=keras_cv.losses.FocalLoss(
                 from_logits=True, reduction="none"
             ),
-            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+            box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
             metrics=[],
         )
         xs, ys = _create_bounding_box_dataset(bounding_box_format)
@@ -228,7 +228,7 @@ class RetinaNetTest(tf.test.TestCase):
             classification_loss=keras_cv.losses.FocalLoss(
                 from_logits=True, reduction="none"
             ),
-            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+            box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
             metrics=[],
         )
         xs, ys = _create_bounding_box_dataset(bounding_box_format)
@@ -285,7 +285,7 @@ class RetinaNetTest(tf.test.TestCase):
             classification_loss=keras_cv.losses.FocalLoss(
                 from_logits=True, reduction="none"
             ),
-            box_loss=keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="none"),
+            box_loss=keras_cv.losses.SmoothL1Loss(beta=1.0, reduction="none"),
             metrics=[
                 keras_cv.metrics.COCOMeanAveragePrecision(
                     class_ids=range(1),


### PR DESCRIPTION
# What does this PR do?

- Updates the SmoothF1 Loss to correctly account for the `beta`.
- Renamed `f1_cutoff` to `beta` for consistency with paper terminology and refactored `f1_cutoff` usage.
- Added numerical tests for the `beta` argument.

Fixes #920

## Who can review?

Tagging original authors (@LukeWood @fchollet) and @tanzhenyu for opening the issue.