### PR TITLE
Faster RCNN: Replace keras.applications ResNet50 with KCV ResNet50

### DIFF
--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -29,7 +29,7 @@ from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 def _resnet50_backbone(include_rescaling=False):
     inputs = tf.keras.layers.Input(shape=(None, None, 3))
 
-    backbone = keras_cv.models.ResNet50V2(
+    backbone = keras_cv.models.resnet_v2.ResNet50V2(
         include_top=False, include_rescaling=include_rescaling, input_tensor=inputs
     )
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -15,6 +15,7 @@
 import tensorflow as tf
 from absl import logging
 
+import keras_cv
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.bounding_box.utils import _clip_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
@@ -22,14 +23,13 @@ from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
-from keras_cv.models import ResNet50V2
 from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 
 
 def _resnet50_backbone(include_rescaling=False):
     inputs = tf.keras.layers.Input(shape=(None, None, 3))
 
-    backbone = ResNet50V2(
+    backbone = keras_cv.models.ResNet50V2(
         include_top=False, include_rescaling=include_rescaling, input_tensor=inputs
     )
 

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -22,17 +22,16 @@ from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
+from keras_cv.models import ResNet50V2
 from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 
 
 def _resnet50_backbone(include_rescaling=False):
     inputs = tf.keras.layers.Input(shape=(None, None, 3))
-    x = inputs
 
-    if include_rescaling:
-        x = tf.keras.applications.resnet.preprocess_input(x)
-
-    backbone = tf.keras.applications.ResNet50(include_top=False, input_tensor=x)
+    backbone = ResNet50V2(
+        include_top=False, include_rescaling=include_rescaling, input_tensor=inputs
+    )
 
     c2_output, c3_output, c4_output, c5_output = [
         backbone.get_layer(layer_name).output
@@ -283,7 +282,7 @@ class FasterRCNN(tf.keras.Model):
 
     Usage:
     ```python
-    retina_net = keras_cv.models.FasterRCNN(
+    faster_rcnn = keras_cv.models.FasterRCNN(
         classes=20,
         bounding_box_format="xywh",
         backbone="resnet50",


### PR DESCRIPTION
# What does this PR do?

There's still a few TODOs in the Faster RCNN model, but this seemed like a quick/simple update, since `keras.applications` probably shouldn't be used in lieu of KCV's models.

## Who can review?

Tagging author: @tanzhenyu 