### PR TITLE
fix label smoothing in focal loss

### DIFF
--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -75,16 +75,17 @@ class FocalLoss(tf.keras.losses.Loss):
         y_pred = tf.convert_to_tensor(y_pred)
         y_true = tf.cast(y_true, y_pred.dtype)
 
-        if self.label_smoothing:
-            y_true = self._smooth_labels(y_true)
-
         if self.from_logits:
             y_pred = tf.nn.sigmoid(y_pred)
 
-        cross_entropy = K.binary_crossentropy(y_true, y_pred)
-
         alpha = tf.where(tf.equal(y_true, 1.0), self._alpha, (1.0 - self._alpha))
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
+
+        if self.label_smoothing:
+            y_true = self._smooth_labels(y_true)
+
+        cross_entropy = K.binary_crossentropy(y_true, y_pred)
+
         loss = alpha * tf.pow(1.0 - pt, self._gamma) * cross_entropy
         # In most losses you mean over the final axis to achieve a scalar
         # Focal loss however is a special case in that it is meant to focus on

--- a/keras_cv/losses/focal_test.py
+++ b/keras_cv/losses/focal_test.py
@@ -74,3 +74,14 @@ class FocalTest(tf.test.TestCase):
         self.assertAllClose(
             focal_loss_on_logits(y_true, y_logits), focal_loss(y_true, y_pred)
         )
+
+    def test_smoothing(self):
+        y_true = [0.0, 1.0, 1.0]
+        y_pred = [0.0, 1.0, 1.0]
+
+        focal_loss = FocalLoss(label_smoothing=0.0)
+        self.assertEqual(focal_loss(y_true, y_pred), 0.0)
+        focal_loss = FocalLoss(label_smoothing=0.1)
+        self.assertEqual(focal_loss(y_true, y_pred), 0.0)
+        focal_loss = FocalLoss(label_smoothing=1)
+        self.assertEqual(focal_loss(y_true, y_pred), 0.0)


### PR DESCRIPTION
# What does this PR do?

Introduced in #672, PR'd in #680 and re-opened due to seemingly going cold.
If @atuleu still wants to do this PR, feel free to ping here. Otherwise, this is a bug that should be fixed as the object detection API is being built.

Added numerical tests to verify that the loss is indeed `0.0` on a fully correct prediction, with label smoothing on, which was off in the original implementation.

Fixes #672

## Who can review?
@atuleu @LukeWood @tanzhenyu 