### PR TITLE
[Mixed Precision Support] MixUp Layer

### DIFF
--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -36,6 +36,8 @@ class MixUp(BaseImageAugmentationLayer):
     Sample usage:
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+    # Labels must be floating-point and one-hot encoded
+    labels = tf.cast(tf.one_hot(labels, 10), tf.float32)
     mixup = keras_cv.layers.preprocessing.MixUp(10)
     augmented_images, updated_labels = mixup({'images': images, 'labels': labels})
     # output == {'images': updated_images, 'labels': updated_labels}
@@ -85,9 +87,10 @@ class MixUp(BaseImageAugmentationLayer):
         permutation_order = tf.random.shuffle(tf.range(0, batch_size), seed=self.seed)
 
         lambda_sample = self._sample_from_beta(self.alpha, self.alpha, (batch_size,))
-        lambda_sample = tf.reshape(lambda_sample, [-1, 1, 1, 1])
+        lambda_sample = tf.cast(tf.reshape(lambda_sample, [-1, 1, 1, 1]), dtype=self.compute_dtype)
 
-        mixup_images = tf.gather(images, permutation_order)
+        mixup_images = tf.cast(tf.gather(images, permutation_order), dtype=self.compute_dtype)
+
         images = lambda_sample * images + (1.0 - lambda_sample) * mixup_images
 
         return images, tf.squeeze(lambda_sample), permutation_order
@@ -96,6 +99,7 @@ class MixUp(BaseImageAugmentationLayer):
         labels_for_mixup = tf.gather(labels, permutation_order)
 
         lambda_sample = tf.reshape(lambda_sample, [-1, 1])
+
         labels = lambda_sample * labels + (1.0 - lambda_sample) * labels_for_mixup
 
         return labels

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -36,6 +36,7 @@ class MixUp(BaseImageAugmentationLayer):
     Sample usage:
     ```python
     (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+    images, labels = images[:10], labels[:10]
     # Labels must be floating-point and one-hot encoded
     labels = tf.cast(tf.one_hot(labels, 10), tf.float32)
     mixup = keras_cv.layers.preprocessing.MixUp(10)
@@ -87,9 +88,13 @@ class MixUp(BaseImageAugmentationLayer):
         permutation_order = tf.random.shuffle(tf.range(0, batch_size), seed=self.seed)
 
         lambda_sample = self._sample_from_beta(self.alpha, self.alpha, (batch_size,))
-        lambda_sample = tf.cast(tf.reshape(lambda_sample, [-1, 1, 1, 1]), dtype=self.compute_dtype)
+        lambda_sample = tf.cast(
+            tf.reshape(lambda_sample, [-1, 1, 1, 1]), dtype=self.compute_dtype
+        )
 
-        mixup_images = tf.cast(tf.gather(images, permutation_order), dtype=self.compute_dtype)
+        mixup_images = tf.cast(
+            tf.gather(images, permutation_order), dtype=self.compute_dtype
+        )
 
         images = lambda_sample * images + (1.0 - lambda_sample) * mixup_images
 

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -94,6 +94,7 @@ TEST_CONFIGURATIONS = [
     ("Solarization", layers.Solarization, {"value_range": (0, 255)}),
     ("Mosaic", layers.Mosaic, {}),
     ("CutMix", layers.CutMix, {}),
+    ("MixUp", layers.MixUp, {}),
     (
         "Resizing",
         layers.Resizing,


### PR DESCRIPTION
# What does this PR do?

A few weeks ago, most of the issues with missing support for mixed precision were fixed, but MixUp seems to have been overlooked.

```
tf.keras.mixed_precision.set_global_policy('mixed_float16')

(images, labels), _ = tf.keras.datasets.cifar10.load_data()
images = images[:10]
labels = labels[:10]
labels = tf.cast(tf.one_hot(labels, 10), tf.float32)

mixup = keras_cv.layers.preprocessing.MixUp(10)
mixup({'images': images, 'labels': labels})
```

```
...
InvalidArgumentError: Exception encountered when calling layer "mix_up" "                 f"(type MixUp).

cannot compute Mul as input #1(zero-based) was expected to be a float tensor but is a half tensor [Op:Mul]

Call arguments received by layer "mix_up" "                 f"(type MixUp):
  • inputs={'images': 'tf.Tensor(shape=(10, 32, 32, 3), dtype=float16)', 'labels': 'tf.Tensor(shape=(10, 1, 10), dtype=float16)'}
  • training=True
```

This PR also updates the example to cast the input labels into floats.
Should we add dtype support tests for all preprocessing layers?

@LukeWood @tanzhenyu 