### PR TITLE
[Object Detection] Update backbone structure for FasterRCNN

### DIFF
--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -61,6 +61,9 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         model = keras_cv.models.FasterRCNN(
             classes=10,
             bounding_box_format="xywh",
+            backbone=keras_cv.models.ResNet50V2(
+                include_top=False, include_rescaling=True, weights=None
+            ).as_backbone(),
         )
         model.compile(
             optimizer="adam",

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -44,7 +44,7 @@ def _resnet50_backbone(include_rescaling=False):
         ]
     ]
     return tf.keras.Model(
-        inputs=inputs, outputs=[c2_output, c3_output, c4_output, c5_output]
+        inputs=inputs, outputs={2: c2_output, 3: c3_output, 4: c4_output, 5: c5_output}
     )
 
 
@@ -67,7 +67,10 @@ class FeaturePyramid(tf.keras.layers.Layer):
         self.upsample_2x = tf.keras.layers.UpSampling2D(2)
 
     def call(self, inputs, training=None):
-        c2_output, c3_output, c4_output, c5_output = inputs
+        c2_output = inputs[2]
+        c3_output = inputs[3]
+        c4_output = inputs[4]
+        c5_output = inputs[5]
 
         c6_output = self.conv_c6_pool(c5_output)
         p6_output = c6_output

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -14,12 +14,15 @@
 
 import tensorflow as tf
 
+from keras_cv.models import ResNet50V2
 from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
 
 
 class FasterRCNNTest(tf.test.TestCase):
     def test_faster_rcnn_infer(self):
-        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="xyxy", backbone=self._build_backbone()
+        )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=False)
         # 1000 proposals in inference
@@ -27,14 +30,18 @@ class FasterRCNNTest(tf.test.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_faster_rcnn_train(self):
-        model = FasterRCNN(classes=80, bounding_box_format="xyxy")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="xyxy", backbone=self._build_backbone()
+        )
         images = tf.random.normal([2, 512, 512, 3])
         outputs = model(images, training=True)
         self.assertAllEqual([2, 1000, 81], outputs[1].shape)
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     def test_invalid_compile(self):
-        model = FasterRCNN(classes=80, bounding_box_format="yxyx")
+        model = FasterRCNN(
+            classes=80, bounding_box_format="yxyx", backbone=self._build_backbone()
+        )
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")
         with self.assertRaisesRegex(ValueError, "only accepts"):
@@ -43,3 +50,6 @@ class FasterRCNNTest(tf.test.TestCase):
                     from_logits=False
                 )
             )
+
+    def _build_backbone(self):
+        return ResNet50V2(include_top=False, include_rescaling=True).as_backbone()


### PR DESCRIPTION
This makes FasterRCNN's internal backbone consistent with our ResNet50V2.as_backbone() API

(This also lets us avoid downloading weights in tests that use FasterRCNN)