### PR TITLE
Fix bugs in frustum-based data augmentations

### DIFF
--- a/keras_cv/layers/preprocessing3d/__init__.py
+++ b/keras_cv/layers/preprocessing3d/__init__.py
@@ -18,6 +18,9 @@ from keras_cv.layers.preprocessing3d.base_augmentation_layer_3d import (
 from keras_cv.layers.preprocessing3d.frustum_random_dropping_points import (
     FrustumRandomDroppingPoints,
 )
+from keras_cv.layers.preprocessing3d.frustum_random_point_feature_noise import (
+    FrustumRandomPointFeatureNoise,
+)
 from keras_cv.layers.preprocessing3d.global_random_dropping_points import (
     GlobalRandomDroppingPoints,
 )

--- a/keras_cv/layers/preprocessing3d/frustum_random_dropping_points.py
+++ b/keras_cv/layers/preprocessing3d/frustum_random_dropping_points.py
@@ -79,15 +79,14 @@ class FrustumRandomDroppingPoints(base_augmentation_layer_3d.BaseAugmentationLay
 
     def get_random_transformation(self, point_clouds, **kwargs):
         # Randomly select a point from the first frame as the center of the frustum.
-        num_valid_points = tf.cast(
-            tf.math.reduce_sum(point_clouds[0, :, POINTCLOUD_LABEL_INDEX]), tf.int32
-        )
+        valid_points = point_clouds[0, :, POINTCLOUD_LABEL_INDEX] > 0
+        num_valid_points = tf.math.reduce_sum(tf.cast(valid_points, tf.int32))
         randomly_select_point_index = tf.random.uniform(
             (), minval=0, maxval=num_valid_points, dtype=tf.int32
         )
-        randomly_select_frustum_center = point_clouds[
-            0, randomly_select_point_index, :POINTCLOUD_LABEL_INDEX
-        ]
+        randomly_select_frustum_center = tf.boolean_mask(
+            point_clouds[0], valid_points, axis=0
+        )[randomly_select_point_index, :POINTCLOUD_LABEL_INDEX]
         num_frames, num_points, _ = point_clouds.get_shape().as_list()
         frustum_mask = []
         for f in range(num_frames):

--- a/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise.py
+++ b/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise.py
@@ -91,10 +91,9 @@ class FrustumRandomPointFeatureNoise(
         randomly_select_point_index = tf.random.uniform(
             (), minval=0, maxval=num_valid_points, dtype=tf.int32
         )
-        randomly_select_frustum_center = point_clouds[
-            0, randomly_select_point_index, :POINTCLOUD_LABEL_INDEX
-        ]
-        tf.print(("khk", randomly_select_frustum_center))
+        randomly_select_frustum_center = tf.boolean_mask(
+            point_clouds[0], valid_points, axis=0
+        )[randomly_select_point_index, :POINTCLOUD_LABEL_INDEX]
 
         num_frames, num_points, num_features = point_clouds.get_shape().as_list()
         frustum_mask = []

--- a/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise_test.py
+++ b/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise_test.py
@@ -83,6 +83,46 @@ class FrustumRandomPointFeatureNoiseTest(tf.test.TestCase):
         # [100, 100, 2, 3, 4, 1] is not changed due to outside phi_width.
         self.assertAllClose(outputs[POINT_CLOUDS], augmented_point_clouds)
 
+    def test_augment_only_one_valid_point_point_clouds_and_bounding_boxes(self):
+        tf.keras.utils.set_random_seed(2)
+        add_layer = FrustumRandomPointFeatureNoise(
+            r_distance=10, theta_width=np.pi, phi_width=1.5 * np.pi, max_noise_level=0.5
+        )
+        point_clouds = np.array(
+            [
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [100, 100, 2, 3, 4, 1],
+                    [0, 0, 0, 0, 0, 0],
+                ]
+            ]
+            * 2
+        ).astype("float32")
+        bounding_boxes = np.random.random(size=(2, 10, 7)).astype("float32")
+        inputs = {POINT_CLOUDS: point_clouds, BOUNDING_BOXES: bounding_boxes}
+        outputs = add_layer(inputs)
+        # bounding boxes and point clouds (x, y, z, class) are not modified.
+        augmented_point_clouds = np.array(
+            [
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [100, 100, 2, 3, 4.119616, 0.619783],
+                    [0, 0, 0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [100, 100, 2, 3, 3.192014, 0.618371],
+                    [0, 0, 0, 0, 0, 0],
+                ],
+            ]
+        ).astype("float32")
+        self.assertAllClose(inputs[BOUNDING_BOXES], outputs[BOUNDING_BOXES])
+        # [100, 100, 2, 3, 4, 1] is selected as the frustum center because it is the only valid point
+        self.assertAllClose(outputs[POINT_CLOUDS], augmented_point_clouds)
+
     def test_not_augment_max_noise_level0_point_clouds_and_bounding_boxes(self):
         add_layer = FrustumRandomPointFeatureNoise(
             r_distance=0, theta_width=1, phi_width=1, max_noise_level=0.0

--- a/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise_test.py
+++ b/keras_cv/layers/preprocessing3d/frustum_random_point_feature_noise_test.py
@@ -120,7 +120,7 @@ class FrustumRandomPointFeatureNoiseTest(tf.test.TestCase):
             ]
         ).astype("float32")
         self.assertAllClose(inputs[BOUNDING_BOXES], outputs[BOUNDING_BOXES])
-        # [100, 100, 2, 3, 4, 1] is selected as the frustum center because it is the only valid point
+        # [100, 100, 2, 3, 4, 1] is selected as the frustum center because it is the only valid point.
         self.assertAllClose(outputs[POINT_CLOUDS], augmented_point_clouds)
 
     def test_not_augment_max_noise_level0_point_clouds_and_bounding_boxes(self):


### PR DESCRIPTION
Use boolean mask to select valid points, then choose a frustum center from the valid points. Previous implementation will random choose a center from all points, which include none valid points. 