### PR TITLE
(Step 4/5) Add KPLs to RetinaNet training script

### DIFF
--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -169,12 +169,10 @@ model.compile(
     box_loss="smoothl1",
     optimizer=optimizer,
     metrics=[
-        keras_cv.metrics.COCORecall(
-            bounding_box_format="xywh", class_ids=range(20)
-        ),
+        keras_cv.metrics.COCORecall(bounding_box_format="xywh", class_ids=range(20)),
         keras_cv.metrics.COCOMeanAveragePrecision(
             bounding_box_format="xywh", class_ids=range(20)
-        )
+        ),
     ],
 )
 

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -99,7 +99,6 @@ train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(GLOBAL_BATCH_SIZE, drop_remainder=True)
 )
 
-train_ds = train_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
 train_ds = train_ds.shuffle(8 * strategy.num_replicas_in_sync)
 train_ds = train_ds.prefetch(tf.data.AUTOTUNE)
 

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -153,22 +153,23 @@ def unpackage_inputs(data):
 train_ds = train_ds.map(unpackage_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 eval_ds = eval_ds.map(unpackage_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 
-model = keras_cv.models.RetinaNet(
-    # number of classes to be used in box classification
-    classes=20,
-    # For more info on supported bounding box formats, visit
-    # https://keras.io/api/keras_cv/bounding_box/
-    bounding_box_format="xywh",
-    # KerasCV offers a set of pre-configured backbones
-    backbone="resnet50",
-    # Each backbone comes with multiple pre-trained weights
-    # These weights match the weights available in the `keras_cv.model` class.
-    backbone_weights="imagenet",
-    # include_rescaling tells the model whether your input images are in the default
-    # pixel range (0, 255) or if you have already rescaled your inputs to the range
-    # (0, 1).  In our case, we feed our model images with inputs in the range (0, 255).
-    include_rescaling=True,
-)
+with strategy.scope():
+    model = keras_cv.models.RetinaNet(
+        # number of classes to be used in box classification
+        classes=20,
+        # For more info on supported bounding box formats, visit
+        # https://keras.io/api/keras_cv/bounding_box/
+        bounding_box_format="xywh",
+        # KerasCV offers a set of pre-configured backbones
+        backbone="resnet50",
+        # Each backbone comes with multiple pre-trained weights
+        # These weights match the weights available in the `keras_cv.model` class.
+        backbone_weights="imagenet",
+        # include_rescaling tells the model whether your input images are in the default
+        # pixel range (0, 255) or if you have already rescaled your inputs to the range
+        # (0, 1).  In our case, we feed our model images with inputs in the range (0, 255).
+        include_rescaling=True,
+    )
 # Fine-tuning a RetinaNet is as simple as setting backbone.trainable = False
 model.backbone.trainable = False
 optimizer = tf.optimizers.SGD(learning_rate=BASE_LR, global_clipnorm=10.0)

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -61,7 +61,7 @@ except ValueError:
 BATCH_SIZE = 4
 GLOBAL_BATCH_SIZE = BATCH_SIZE * strategy.num_replicas_in_sync
 BASE_LR = 0.01 * GLOBAL_BATCH_SIZE / 16
-print("Number of accelerators: ", strategy.num_replicats_in_sync)
+print("Number of accelerators: ", strategy.num_replicas_in_sync)
 print("Global Batch Size: ", GLOBAL_BATCH_SIZE)
 
 IMG_SIZE = 640

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -35,31 +35,6 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 EPOCHS = 100
 CHECKPOINT_PATH = "checkpoint/"
 
-class_ids = [
-    "Aeroplane",
-    "Bicycle",
-    "Bird",
-    "Boat",
-    "Bottle",
-    "Bus",
-    "Car",
-    "Cat",
-    "Chair",
-    "Cow",
-    "Dining Table",
-    "Dog",
-    "Horse",
-    "Motorbike",
-    "Person",
-    "Potted Plant",
-    "Sheep",
-    "Sofa",
-    "Train",
-    "Tvmonitor",
-    "Total",
-]
-class_mapping = dict(zip(range(len(class_ids)), class_ids))
-
 flags.DEFINE_string(
     "weights_name",
     "weights_{epoch:02d}.h5",
@@ -100,219 +75,25 @@ train_ds = train_ds.concatenate(
 eval_ds = tfds.load("voc/2007", split="test", with_info=False)
 
 
-# TODO (lukewood): migrate to KPL, as this is mostly a duplciate of
-# https://github.com/tensorflow/models/blob/master/official/vision/ops/preprocess_ops.py#L138
-def resize_and_crop_image(
-    image,
-    desired_size,
-    padded_size,
-    aug_scale_min=1.0,
-    aug_scale_max=1.0,
-    seed=1,
-    method=tf.image.ResizeMethod.BILINEAR,
-):
-    with tf.name_scope("resize_and_crop_image"):
-        image_size = tf.cast(tf.shape(image)[0:2], tf.float32)
-
-        random_jittering = aug_scale_min != 1.0 or aug_scale_max != 1.0
-
-        if random_jittering:
-            random_scale = tf.random.uniform(
-                [], aug_scale_min, aug_scale_max, seed=seed
-            )
-            scaled_size = tf.round(random_scale * desired_size)
-        else:
-            scaled_size = desired_size
-
-        scale = tf.minimum(
-            scaled_size[0] / image_size[0], scaled_size[1] / image_size[1]
-        )
-        scaled_size = tf.round(image_size * scale)
-
-        # Computes 2D image_scale.
-        image_scale = scaled_size / image_size
-
-        # Selects non-zero random offset (x, y) if scaled image is larger than
-        # desired_size.
-        if random_jittering:
-            max_offset = scaled_size - desired_size
-            max_offset = tf.where(
-                tf.less(max_offset, 0), tf.zeros_like(max_offset), max_offset
-            )
-            offset = max_offset * tf.random.uniform(
-                [
-                    2,
-                ],
-                0,
-                1,
-                seed=seed,
-            )
-            offset = tf.cast(offset, tf.int32)
-        else:
-            offset = tf.zeros((2,), tf.int32)
-
-        scaled_image = tf.image.resize(
-            image, tf.cast(scaled_size, tf.int32), method=method
-        )
-
-        if random_jittering:
-            scaled_image = scaled_image[
-                offset[0] : offset[0] + desired_size[0],
-                offset[1] : offset[1] + desired_size[1],
-                :,
-            ]
-
-        output_image = tf.image.pad_to_bounding_box(
-            scaled_image, 0, 0, padded_size[0], padded_size[1]
-        )
-
-        image_info = tf.stack(
-            [
-                image_size,
-                tf.constant(desired_size, dtype=tf.float32),
-                image_scale,
-                tf.cast(offset, tf.float32),
-            ]
-        )
-        return output_image, image_info
-
-
-def resize_and_crop_boxes(boxes, image_scale, output_size, offset):
-    with tf.name_scope("resize_and_crop_boxes"):
-        # Adjusts box coordinates based on image_scale and offset.
-        boxes *= tf.tile(tf.expand_dims(image_scale, axis=0), [1, 2])
-        boxes -= tf.tile(tf.expand_dims(offset, axis=0), [1, 2])
-        # Clips the boxes.
-        boxes = clip_boxes(boxes, output_size)
-        return boxes
-
-
-def clip_boxes(boxes, image_shape):
-    if boxes.shape[-1] != 4:
-        raise ValueError(
-            "boxes.shape[-1] is {:d}, but must be 4.".format(boxes.shape[-1])
-        )
-
-    with tf.name_scope("clip_boxes"):
-        if isinstance(image_shape, list) or isinstance(image_shape, tuple):
-            height, width = image_shape
-            max_length = [height, width, height, width]
-        else:
-            image_shape = tf.cast(image_shape, dtype=boxes.dtype)
-            height, width = tf.unstack(image_shape, axis=-1)
-            max_length = tf.stack([height, width, height, width], axis=-1)
-
-        clipped_boxes = tf.math.maximum(tf.math.minimum(boxes, max_length), 0.0)
-        return clipped_boxes
-
-
-def get_non_empty_box_indices(boxes):
-    # Selects indices if box height or width is 0.
-    height = boxes[:, 2] - boxes[:, 0]
-    width = boxes[:, 3] - boxes[:, 1]
-    indices = tf.where(tf.logical_and(tf.greater(height, 0), tf.greater(width, 0)))
-    return indices[:, 0]
-
-
-def resize_fn(image, gt_boxes, gt_classes):
-    image, image_info = resize_and_crop_image(
-        image, image_size[:2], image_size[:2], 0.8, 1.25
-    )
-    gt_boxes = resize_and_crop_boxes(
-        gt_boxes, image_info[2, :], image_info[1, :], image_info[3, :]
-    )
-    indices = get_non_empty_box_indices(gt_boxes)
-    gt_boxes = tf.gather(gt_boxes, indices)
-    gt_classes = tf.gather(gt_classes, indices)
-    return image, gt_boxes, gt_classes
-
-
-def flip_fn(image, boxes):
-    if tf.random.uniform([], minval=0, maxval=1, dtype=tf.float32) > 0.5:
-        image = tf.image.flip_left_right(image)
-        y1, x1, y2, x2 = tf.split(boxes, num_or_size_splits=4, axis=-1)
-        boxes = tf.concat([y1, 1.0 - x2, y2, 1.0 - x1], axis=-1)
-    return image, boxes
-
-
-def proc_train_fn(bounding_box_format, img_size):
+def unpackage_inputs(bounding_box_format):
     def apply(inputs):
         image = inputs["image"]
         image = tf.cast(image, tf.float32)
-        gt_boxes = inputs["objects"]["bbox"]
-        image, gt_boxes = flip_fn(image, gt_boxes)
-        gt_boxes = keras_cv.bounding_box.convert_format(
-            gt_boxes,
-            images=image,
-            source="rel_yxyx",
-            target="yxyx",
-        )
+        gt_boxes = tf.cast(inputs["objects"]["bbox"], tf.float32)
         gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
-        image, gt_boxes, gt_classes = resize_fn(image, gt_boxes, gt_classes)
-        gt_classes = tf.expand_dims(gt_classes, axis=-1)
-        bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
-        bounding_boxes = keras_cv.bounding_box.convert_format(
-            bounding_boxes, images=image, source="yxyx", target=bounding_box_format
-        )
-        return image, bounding_boxes
-
-    return apply
-
-
-def proc_eval_fn(bounding_box_format, target_size):
-    def apply(inputs):
-        raw_image = inputs["image"]
-        raw_image = tf.cast(raw_image, tf.float32)
-
-        img_size = tf.shape(raw_image)
-        height = img_size[0]
-        width = img_size[1]
-
-        target_height = tf.cond(
-            height > width,
-            lambda: float(IMG_SIZE),
-            lambda: tf.cast(height / width * IMG_SIZE, tf.float32),
-        )
-        target_width = tf.cond(
-            width > height,
-            lambda: float(IMG_SIZE),
-            lambda: tf.cast(width / height * IMG_SIZE, tf.float32),
-        )
-        image = tf.image.resize(
-            raw_image, (target_height, target_width), antialias=False
-        )
-
-        gt_boxes = keras_cv.bounding_box.convert_format(
-            inputs["objects"]["bbox"],
-            images=image,
-            source="rel_yxyx",
-            target="xyxy",
-        )
-        image = tf.image.pad_to_bounding_box(
-            image, 0, 0, target_size[0], target_size[1]
-        )
+        gt_classes = tf.expand_dims(gt_classes, axis=1)
         gt_boxes = keras_cv.bounding_box.convert_format(
             gt_boxes,
             images=image,
-            source="xyxy",
+            source="rel_yxyx",
             target=bounding_box_format,
         )
-        gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
-        gt_classes = tf.expand_dims(gt_classes, axis=-1)
-
         bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
-
-        return image, bounding_boxes
-
+        return {"images": image, "bounding_boxes": bounding_boxes}
     return apply
 
-
-def pad_fn(image, boxes):
-    return image, boxes.to_tensor(default_value=-1.0)
-
-
 train_ds = train_ds.map(
-    proc_train_fn("xywh", image_size), num_parallel_calls=tf.data.AUTOTUNE
+    unpackage_inputs("xywh"), num_parallel_calls=tf.data.AUTOTUNE
 )
 train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(GLOBAL_BATCH_SIZE, drop_remainder=True)
@@ -320,23 +101,43 @@ train_ds = train_ds.apply(
 
 train_ds = train_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
 train_ds = train_ds.shuffle(8 * strategy.num_replicas_in_sync)
-train_ds = train_ds.prefetch(2)
+train_ds = train_ds.prefetch(tf.data.AUTOTUNE)
 
 eval_ds = eval_ds.map(
-    proc_eval_fn(bounding_box_format="xywh", target_size=image_size),
+    unpackage_inputs("xywh"),
     num_parallel_calls=tf.data.AUTOTUNE,
 )
 eval_ds = eval_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(GLOBAL_BATCH_SIZE, drop_remainder=True)
 )
 eval_ds = eval_ds.map(pad_fn, num_parallel_calls=tf.data.AUTOTUNE)
-eval_ds = eval_ds.prefetch(2)
+eval_ds = eval_ds.prefetch(tf.data.AUTOTUNE)
 
 
 """
-Our data pipeline is now complete.  We can now move on to model creation and training.
+Our data pipeline is now complete.  We can now move on to data augmentation:
 """
+eval_resizing = layers.Resizing(
+    IMG_SIZE, IMG_SIZE, bounding_box_format="xywh", pad_to_aspect_ratio=True
+)
 
+augmenter = layers.Augmenter(
+    [
+        layers.RandomFlip(mode="horizontal", bounding_box_format="xywh"),
+        layers.JitteredResize(
+            target_size=(IMG_SIZE, IMG_SIZE),
+            scale_factor=(0.8, 1.25),
+            bounding_box_format="xywh",
+        ),
+        layers.MaybeApply(layers.MixUp(), rate=0.5, batchwise=True),
+    ]
+)
+
+train_ds = train_ds.map(augmenter, num_parallel_calls=tf.data.AUTOTUNE)
+eval_ds = eval_ds.map(
+    eval_resizing,
+    num_parallel_calls=tf.data.AUTOTUNE,
+)
 """
 ## Model creation
 
@@ -345,6 +146,10 @@ a pretrained ResNet50 backbone using weights.  In order to perform fine-tuning, 
 freeze the backbone before training.  When `include_rescaling=True` is set, inputs to
 the model are expected to be in the range `[0, 255]`.
 """
+
+def unpackage_inputs(data):
+    return data['image'], data['bounding_boxes']
+train_ds = train_ds.map(unpackage_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 
 with strategy.scope():
     model = keras_cv.models.RetinaNet(
@@ -365,8 +170,8 @@ with strategy.scope():
     )
     # Fine-tuning a RetinaNet is as simple as setting backbone.trainable = False
     model.backbone.trainable = False
-
     optimizer = tf.optimizers.SGD(learning_rate=BASE_LR, global_clipnorm=10.0)
+
 model.compile(
     classification_loss="focal",
     box_loss="smoothl1",

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -49,20 +49,10 @@ flags.DEFINE_string(
 FLAGS = flags.FLAGS
 FLAGS(sys.argv)
 
-# parameters from RetinaNet [paper](https://arxiv.org/abs/1708.02002)
-
-# Try to detect an available TPU. If none is present, default to MirroredStrategy
-try:
-    tpu = tf.distribute.cluster_resolver.TPUClusterResolver.connect()
-    strategy = tf.distribute.TPUStrategy(tpu)
-except ValueError:
-    # MirroredStrategy is best for a single machine with one or multiple GPUs
-    strategy = tf.distribute.MirroredStrategy()
-
 BATCH_SIZE = 4
-GLOBAL_BATCH_SIZE = BATCH_SIZE * strategy.num_replicas_in_sync
+GLOBAL_BATCH_SIZE = BATCH_SIZE * 1
 BASE_LR = 0.01 * GLOBAL_BATCH_SIZE / 16
-print("Number of accelerators: ", strategy.num_replicas_in_sync)
+print("Number of accelerators: ", 1)
 print("Global Batch Size: ", GLOBAL_BATCH_SIZE)
 
 IMG_SIZE = 640
@@ -91,16 +81,16 @@ def unpackage_inputs(bounding_box_format):
         )
         bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
         return {"images": image, "bounding_boxes": bounding_boxes}
+
     return apply
 
-train_ds = train_ds.map(
-    unpackage_inputs("xywh"), num_parallel_calls=tf.data.AUTOTUNE
-)
+
+train_ds = train_ds.map(unpackage_inputs("xywh"), num_parallel_calls=tf.data.AUTOTUNE)
 train_ds = train_ds.apply(
     tf.data.experimental.dense_to_ragged_batch(GLOBAL_BATCH_SIZE, drop_remainder=True)
 )
 
-train_ds = train_ds.shuffle(8 * strategy.num_replicas_in_sync)
+train_ds = train_ds.shuffle(8 * 1)
 train_ds = train_ds.prefetch(tf.data.AUTOTUNE)
 
 eval_ds = eval_ds.map(
@@ -146,42 +136,47 @@ freeze the backbone before training.  When `include_rescaling=True` is set, inpu
 the model are expected to be in the range `[0, 255]`.
 """
 
+
 def unpackage_inputs(data):
-    return data['images'], data['bounding_boxes']
+    return data["images"], data["bounding_boxes"]
+
 
 train_ds = train_ds.map(unpackage_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 eval_ds = eval_ds.map(unpackage_inputs, num_parallel_calls=tf.data.AUTOTUNE)
 
-with strategy.scope():
-    model = keras_cv.models.RetinaNet(
-        # number of classes to be used in box classification
-        classes=20,
-        # For more info on supported bounding box formats, visit
-        # https://keras.io/api/keras_cv/bounding_box/
-        bounding_box_format="xywh",
-        # KerasCV offers a set of pre-configured backbones
-        backbone="resnet50",
-        # Each backbone comes with multiple pre-trained weights
-        # These weights match the weights available in the `keras_cv.model` class.
-        backbone_weights="imagenet",
-        # include_rescaling tells the model whether your input images are in the default
-        # pixel range (0, 255) or if you have already rescaled your inputs to the range
-        # (0, 1).  In our case, we feed our model images with inputs in the range (0, 255).
-        include_rescaling=True,
-    )
-    # Fine-tuning a RetinaNet is as simple as setting backbone.trainable = False
-    model.backbone.trainable = False
-    optimizer = tf.optimizers.SGD(learning_rate=BASE_LR, global_clipnorm=10.0)
+model = keras_cv.models.RetinaNet(
+    # number of classes to be used in box classification
+    classes=20,
+    # For more info on supported bounding box formats, visit
+    # https://keras.io/api/keras_cv/bounding_box/
+    bounding_box_format="xywh",
+    # KerasCV offers a set of pre-configured backbones
+    backbone="resnet50",
+    # Each backbone comes with multiple pre-trained weights
+    # These weights match the weights available in the `keras_cv.model` class.
+    backbone_weights="imagenet",
+    # include_rescaling tells the model whether your input images are in the default
+    # pixel range (0, 255) or if you have already rescaled your inputs to the range
+    # (0, 1).  In our case, we feed our model images with inputs in the range (0, 255).
+    include_rescaling=True,
+)
+# Fine-tuning a RetinaNet is as simple as setting backbone.trainable = False
+model.backbone.trainable = False
+optimizer = tf.optimizers.SGD(learning_rate=BASE_LR, global_clipnorm=10.0)
 
 model.compile(
     classification_loss="focal",
     box_loss="smoothl1",
     optimizer=optimizer,
+    metrics=[
+        keras_cv.metrics.COCORecall(
+            bounding_box_format="xywh", class_ids=range(20)
+        ),
+        keras_cv.metrics.COCOMeanAveragePrecision(
+            bounding_box_format="xywh", class_ids=range(20)
+        )
+    ],
 )
-
-
-def convert_to_dict(images, boxes):
-    return images, {"gt_boxes": boxes[:, :, :4], "gt_classes": boxes[:, :, 4]}
 
 
 callbacks = [
@@ -189,11 +184,11 @@ callbacks = [
     keras.callbacks.ReduceLROnPlateau(patience=5),
     keras.callbacks.EarlyStopping(patience=10),
     keras.callbacks.ModelCheckpoint(CHECKPOINT_PATH, save_weights_only=True),
-    PyCOCOCallback(eval_ds.map(convert_to_dict), "xywh"),
 ]
 
 history = model.fit(
     train_ds,
+    validation_data=eval_ds.take(20),
     epochs=100,
     callbacks=callbacks,
 )

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -28,7 +28,6 @@ from tensorflow import keras
 
 import keras_cv
 from keras_cv import layers
-from keras_cv.callbacks import PyCOCOCallback
 
 low, high = resource.getrlimit(resource.RLIMIT_NOFILE)
 resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))

--- a/keras_cv/metrics/coco/__init__.py
+++ b/keras_cv/metrics/coco/__init__.py
@@ -19,6 +19,7 @@ try:
     from keras_cv.metrics.coco.pycoco_wrapper import compute_pycoco_metrics
 except ImportError:
     print(
-        "You do not have pycocotools installed, so KerasCV pycoco metrics are not available."
+        "You do not have pycocotools installed, so KerasCV pycoco metrics are not available. "
+        "Please run `pip install pycocotools`."
     )
     pass


### PR DESCRIPTION
Notes:

- The checked in version of this script doesn't work at all
- This scores the same MaP as before, >0.32 every run
- This is much more readable
- This adds back in the COCO metrics, these are really useful for monitoring training on a GPU device.  We can disable them on TPU if we want, but I'd like to keep them for prototyping until we hit our final state
- I've removed the COCO evaluator callback until we move everything to native box format

---

Action items after this PR:

- [ ] swap to native box format
- [ ] add back the COCO callback
- [ ] fix the label encoder metric in MirroredStrategy mode