### PR TITLE
Remove support for Python 3.7 to align with keras-nightly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="keras-cv@google.com",
     license="Apache License 2.0",
     install_requires=["packaging", "absl-py", "regex"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={
         "tests": [
             "flake8",
@@ -58,8 +58,13 @@ setup(
     },
     distclass=BinaryDistribution,
     classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3 :: Only",
         "Operating System :: Unix",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",


### PR DESCRIPTION
* Keras Nightly & TensorFlow Nightly have dropped support for Python 3.7 so it can support numpy 1.23+
* Align setup.py to be similar to `keras-nlp` and `keras`