### PR TITLE
Update csp_darknet.py

### DIFF
--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -18,6 +18,11 @@ from keras_cv.models.convnext import ConvNeXtSmall
 from keras_cv.models.convnext import ConvNeXtTiny
 from keras_cv.models.convnext import ConvNeXtXLarge
 from keras_cv.models.csp_darknet import CSPDarkNet
+from keras_cv.models.csp_darknet import CSPDarkNetTiny
+from keras_cv.models.csp_darknet import CSPDarkNetSmall
+from keras_cv.models.csp_darknet import CSPDarkNetMedium
+from keras_cv.models.csp_darknet import CSPDarkNetLarge
+from keras_cv.models.csp_darknet import CSPDarkNetXLarge
 from keras_cv.models.darknet import DarkNet21
 from keras_cv.models.darknet import DarkNet53
 from keras_cv.models.densenet import DenseNet121

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -36,8 +36,20 @@ from keras_cv.models.weights import parse_weights
 def CSPDarkNet(
     include_rescaling,
     include_top,
-    depth_multiplier=1.0,
-    width_multiplier=1.0,
+    depth_multiplier = {
+    "tiny": 0.33,
+    "s": 0.33,
+    "m": 0.67,
+    "l": 1.00,
+    "x": 1.33,
+},
+    width_multiplier = {
+    "tiny": 0.375,
+    "s": 0.50,
+    "m": 0.75,
+    "l": 1.00,
+    "x": 1.25,
+},
     use_depthwise=False,
     classes=None,
     weights=None,

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -36,20 +36,8 @@ from keras_cv.models.weights import parse_weights
 def CSPDarkNet(
     include_rescaling,
     include_top,
-    depth_multiplier = {
-    "tiny": 0.33,
-    "s": 0.33,
-    "m": 0.67,
-    "l": 1.00,
-    "x": 1.33,
-},
-    width_multiplier = {
-    "tiny": 0.375,
-    "s": 0.50,
-    "m": 0.75,
-    "l": 1.00,
-    "x": 1.25,
-},
+    depth_multiplier=1.0,
+    width_multiplier=1.0,
     use_depthwise=False,
     classes=None,
     weights=None,

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -32,6 +32,21 @@ from keras_cv.models.__internal__.darknet_utils import Focus
 from keras_cv.models.__internal__.darknet_utils import SpatialPyramidPoolingBottleneck
 from keras_cv.models.weights import parse_weights
 
+DEPTH_MULTIPLIERS = {
+    "tiny": 0.33,
+    "s": 0.33,
+    "m": 0.67,
+    "l": 1.00,
+    "x": 1.33,
+}
+
+WIDTH_MULTIPLIERS = {
+    "tiny": 0.375,
+    "s": 0.50,
+    "m": 0.75,
+    "l": 1.00,
+    "x": 1.25,
+}
 
 def CSPDarkNet(
     include_rescaling,


### PR DESCRIPTION
<!-- Remove if not applicable -->

Fixes # (issue)

CSPDarkNet has weights only for when depth and width multiplier are 1.0 #1171


cc. @LukeWood and @tanzhenyu , @quantumalaviya 
