### PR TITLE
[Refactor RetinaNet] Step 6 Unify FasterRCNN to decode during predict.

### DIFF
--- a/examples/training/object_detection/pascal_voc/faster_rcnn.py
+++ b/examples/training/object_detection/pascal_voc/faster_rcnn.py
@@ -232,13 +232,11 @@ def proc_train_fn(bounding_box_format, img_size):
 def pad_fn(examples):
     gt_boxes = examples.pop("gt_boxes")
     gt_classes = examples.pop("gt_classes")
-    num_det = gt_boxes.row_lengths()
     gt_boxes = gt_boxes.to_tensor(default_value=-1.0, shape=[global_batch, 32, 4])
     gt_classes = gt_classes.to_tensor(default_value=-1.0, shape=[global_batch, 32, 1])
     return examples["images"], {
-        "gt_boxes": gt_boxes,
-        "gt_classes": gt_classes,
-        "gt_num_dets": num_det,
+        "boxes": gt_boxes,
+        "classes": gt_classes,
     }
 
 
@@ -282,7 +280,7 @@ callbacks = [
     tf.keras.callbacks.TensorBoard(
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
     ),
-    PyCOCOCallback(eval_ds, bounding_box_format="yxyx", input_nms=False),
+    PyCOCOCallback(eval_ds, bounding_box_format="yxyx"),
 ]
 model.compile(
     optimizer=optimizer,

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -19,9 +19,7 @@ from keras_cv.metrics.coco import compute_pycoco_metrics
 
 
 class PyCOCOCallback(Callback):
-    def __init__(
-        self, validation_data, bounding_box_format, input_nms=True, cache=True, **kwargs
-    ):
+    def __init__(self, validation_data, bounding_box_format, cache=True, **kwargs):
         """Creates a callback to evaluate PyCOCO metrics on a validation dataset.
 
         Args:
@@ -30,9 +28,6 @@ class PyCOCOCallback(Callback):
                 "classes": classes})```.
             bounding_box_format: the KerasCV bounding box format used in the
                 validation dataset (e.g. "xywh")
-            input_nms: whether the model has already applied non-max-suppression. If False,
-                the callback will use `model.nms_decoder` to decode the model prediction,
-                otherwise the callback will use model prediction as-is. Default to True.
             cache: whether the callback should cache the dataset between iterations.
                 Note that if the validation dataset has shuffling of any kind
                 (e.g from `shuffle_files=True` in a call to TFDS.load or a call
@@ -47,7 +42,6 @@ class PyCOCOCallback(Callback):
             # We cache the dataset to preserve a consistent iteration order.
             self.val_data = self.val_data.cache()
         self.bounding_box_format = bounding_box_format
-        self.input_nms = input_nms
         super().__init__(**kwargs)
 
     def on_epoch_end(self, epoch, logs=None):
@@ -61,30 +55,29 @@ class PyCOCOCallback(Callback):
 
         images_only_ds = self.val_data.map(images_only)
         y_pred = self.model.predict(images_only_ds)
-        if not self.input_nms:
-            box_pred, cls_pred = y_pred
-            box_pred = tf.expand_dims(box_pred, axis=-2)
-            with tf.device("cpu:0"):
-                (
-                    box_pred,
-                    scores_pred,
-                    cls_pred,
-                    valid_det,
-                ) = self.model.nms_decoder(box_pred, cls_pred)
+        # a temporary if / else until unify decoder output
+        if isinstance(y_pred, (tuple, list)):
+            assert len(y_pred) == 4, f"y_pred size {len(y_pred)} is not 4"
+            box_pred, scores_pred, cls_pred, valid_det = y_pred
+            box_pred = tf.convert_to_tensor(box_pred)
+            cls_pred = tf.convert_to_tensor(cls_pred)
+            scores_pred = tf.convert_to_tensor(scores_pred)
+            valid_det = tf.convert_to_tensor(valid_det)
+        else:
+            valid_det = y_pred.row_lengths()
+            y_pred = y_pred.to_tensor(-1)
+            box_pred = y_pred[:, :, :4]
+            cls_pred = y_pred[:, :, 4]
+            scores_pred = y_pred[:, :, 5]
 
         gt = [boxes for boxes in self.val_data.map(boxes_only)]
-        if self.input_nms:
-            gt_boxes = tf.concat(
-                [tf.RaggedTensor.from_tensor(boxes["boxes"]) for boxes in gt], axis=0
-            )
-            gt_classes = tf.concat(
-                [tf.RaggedTensor.from_tensor(boxes["classes"]) for boxes in gt],
-                axis=0,
-            )
-        else:
-            gt_boxes = tf.concat([boxes["gt_boxes"] for boxes in gt], axis=0)
-            gt_classes = tf.concat([boxes["gt_classes"] for boxes in gt], axis=0)
-            gt_num_dets = tf.concat([boxes["gt_num_dets"] for boxes in gt], axis=0)
+        gt_boxes = tf.concat(
+            [tf.RaggedTensor.from_tensor(boxes["boxes"]) for boxes in gt], axis=0
+        )
+        gt_classes = tf.concat(
+            [tf.RaggedTensor.from_tensor(boxes["classes"]) for boxes in gt],
+            axis=0,
+        )
 
         first_image_batch = next(iter(images_only_ds))
         height = first_image_batch.shape[1]
@@ -104,38 +97,20 @@ class PyCOCOCallback(Callback):
         ground_truth["height"] = [tf.tile(tf.constant([height]), [total_images])]
         ground_truth["width"] = [tf.tile(tf.constant([width]), [total_images])]
 
-        if self.input_nms:
-            ground_truth["num_detections"] = [gt_boxes.row_lengths(axis=1)]
-            ground_truth["boxes"] = [gt_boxes.to_tensor(-1)]
-            ground_truth["classes"] = [gt_classes.to_tensor(-1)]
-            y_pred = bounding_box.convert_format(
-                y_pred, source=self.bounding_box_format, target="yxyx"
-            )
-        else:
-            ground_truth["num_detections"] = [gt_num_dets]
-            ground_truth["boxes"] = [gt_boxes]
-            ground_truth["classes"] = [gt_classes]
-
-            box_pred = bounding_box.convert_format(
-                box_pred, source=self.bounding_box_format, target="yxyx"
-            )
+        ground_truth["num_detections"] = [gt_boxes.row_lengths(axis=1)]
+        ground_truth["boxes"] = [gt_boxes.to_tensor(-1)]
+        ground_truth["classes"] = [gt_classes.to_tensor(-1)]
+        box_pred = bounding_box.convert_format(
+            box_pred, source=self.bounding_box_format, target="yxyx"
+        )
 
         predictions = {}
-        if self.input_nms:
-            predictions["num_detections"] = [y_pred.row_lengths()]
-            y_pred = y_pred.to_tensor(-1)
-        else:
-            predictions["num_detections"] = [valid_det]
 
         predictions["source_id"] = [source_ids]
-        if self.input_nms:
-            predictions["detection_boxes"] = [y_pred[:, :, :4]]
-            predictions["detection_classes"] = [y_pred[:, :, 4]]
-            predictions["detection_scores"] = [y_pred[:, :, 5]]
-        else:
-            predictions["detection_boxes"] = [box_pred]
-            predictions["detection_classes"] = [cls_pred]
-            predictions["detection_scores"] = [scores_pred]
+        predictions["detection_boxes"] = [box_pred]
+        predictions["detection_classes"] = [cls_pred]
+        predictions["detection_scores"] = [scores_pred]
+        predictions["num_detections"] = [valid_det]
 
         metrics = compute_pycoco_metrics(ground_truth, predictions)
         # Mark these as validation metrics by prepending a val_ prefix

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -50,15 +50,6 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             bounding_box_format="xyxy", use_dictionary_box_format=True
         )
 
-        def convert_dict_fn(x, y):
-            converted_y = {}
-            converted_y["boxes"] = y.pop("gt_boxes")
-            converted_y["classes"] = y.pop("gt_classes")
-            return x, converted_y
-
-        train_ds = train_ds.map(convert_dict_fn)
-        val_ds = val_ds.map(convert_dict_fn)
-
         callback = PyCOCOCallback(validation_data=val_ds, bounding_box_format="xyxy")
         history = model.fit(train_ds, callbacks=[callback])
 
@@ -66,7 +57,7 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             [f"val_{metric}" for metric in METRIC_NAMES], history.history.keys()
         )
 
-    def test_input_nms_false(self):
+    def test_model_fit_rcnn(self):
         model = keras_cv.models.FasterRCNN(
             classes=10,
             bounding_box_format="xywh",
@@ -90,7 +81,6 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         callback = PyCOCOCallback(
             validation_data=eval_ds,
             bounding_box_format="yxyx",
-            input_nms=False,
         )
         history = model.fit(train_ds, callbacks=[callback])
         self.assertAllInSet(

--- a/keras_cv/models/object_detection/__test_utils__.py
+++ b/keras_cv/models/object_detection/__test_utils__.py
@@ -34,7 +34,7 @@ def _create_bounding_box_dataset(bounding_box_format, use_dictionary_box_format=
 
     if use_dictionary_box_format:
         return tf.data.Dataset.from_tensor_slices(
-            (xs, {"gt_boxes": ys, "gt_classes": y_classes, "gt_num_dets": num_dets})
+            (xs, {"boxes": ys, "classes": y_classes, "gt_num_dets": num_dets})
         ).batch(5, drop_remainder=True)
     else:
         return xs, {"boxes": ys, "classes": y_classes}

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -388,7 +388,9 @@ class FasterRCNN(tf.keras.Model):
             samples_per_image=256,
             positive_fraction=0.5,
         )
-        self._prediction_decoder = NMSDecoder(bounding_box_format=bounding_box_format)
+        self._prediction_decoder = prediction_decoder or NMSDecoder(
+            bounding_box_format=bounding_box_format
+        )
 
     def _call_rpn(self, images, anchors, training=None):
         image_shape = tf.shape(images[0])
@@ -576,8 +578,6 @@ class FasterRCNN(tf.keras.Model):
     def prediction_decoder(self, prediction_decoder):
         self._prediction_decoder = prediction_decoder
         self.make_predict_function(force=True)
-        self.make_test_function(force=True)
-        self.make_train_function(force=True)
 
     def decode_predictions(self, predictions, images):
         # no-op if default decoder is used.

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -15,6 +15,7 @@
 import tensorflow as tf
 from absl import logging
 
+from keras_cv import bounding_box
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.bounding_box.utils import _clip_boxes
 from keras_cv.layers.object_detection.anchor_generator import AnchorGenerator
@@ -22,6 +23,7 @@ from keras_cv.layers.object_detection.roi_align import _ROIAligner
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
+from keras_cv.models.object_detection import predict_utils
 from keras_cv.ops.box_matcher import ArgmaxBoxMatcher
 
 
@@ -229,11 +231,13 @@ class RCNNHead(tf.keras.layers.Layer):
 
 
 # TODO(tanzhenyu): provide a TPU compatible NMS decoder.
+# TODO(tanzhenyu): Unify the NMS decoder used for detection models.
 class NMSDecoder(tf.keras.layers.Layer):
     """A customized NMS layer wrapper."""
 
     def __init__(
         self,
+        bounding_box_format,
         iou_threshold=0.5,
         score_threshold=0.5,
         max_output_size_per_class=10,
@@ -241,12 +245,14 @@ class NMSDecoder(tf.keras.layers.Layer):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.bounding_box_format = bounding_box_format
         self.iou_threshold = iou_threshold
         self.score_threshold = score_threshold
         self.max_output_size_per_class = max_output_size_per_class
         self.max_total_size = max_total_size
 
     def call(self, box_pred, scores_pred):
+        box_pred = tf.expand_dims(box_pred, axis=-2)
         (
             box_pred,
             scores_pred,
@@ -324,7 +330,7 @@ class FasterRCNN(tf.keras.Model):
             (all foreground classes + one background class). By default it uses the rcnn head
             from paper, which is 2 FC layer with 1024 dimension, 1 box regressor and 1
             softmax classifier.
-        nms_decoder: (Optional) a `keras.layers.Layer` that takes input box prediction and
+        prediction_decoder: (Optional) a `keras.layers.Layer` that takes input box prediction and
             softmaxed score prediction, and returns NMSed box prediction, NMSed softmaxed
             score prediction, NMSed class prediction, and NMSed valid detection.
     """
@@ -338,7 +344,7 @@ class FasterRCNN(tf.keras.Model):
         anchor_generator=None,
         rpn_head=None,
         rcnn_head=None,
-        nms_decoder=None,
+        prediction_decoder=None,
         **kwargs,
     ):
         self.bounding_box_format = bounding_box_format
@@ -382,7 +388,7 @@ class FasterRCNN(tf.keras.Model):
             samples_per_image=256,
             positive_fraction=0.5,
         )
-        self.nms_decoder = nms_decoder or NMSDecoder()
+        self._prediction_decoder = NMSDecoder(bounding_box_format=bounding_box_format)
 
     def _call_rpn(self, images, anchors, training=None):
         image_shape = tf.shape(images[0])
@@ -536,8 +542,8 @@ class FasterRCNN(tf.keras.Model):
         images, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
         if sample_weight is not None:
             raise ValueError("`sample_weight` is currently not supported.")
-        gt_boxes = y["gt_boxes"]
-        gt_classes = y["gt_classes"]
+        gt_boxes = y["boxes"]
+        gt_classes = y["classes"]
         with tf.GradientTape() as tape:
             total_loss = self.compute_loss(images, gt_boxes, gt_classes, training=True)
             reg_losses = []
@@ -554,10 +560,44 @@ class FasterRCNN(tf.keras.Model):
         images, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
         if sample_weight is not None:
             raise ValueError("`sample_weight` is currently not supported.")
-        gt_boxes = y["gt_boxes"]
-        gt_classes = y["gt_classes"]
+        gt_boxes = y["boxes"]
+        gt_classes = y["classes"]
         self.compute_loss(images, gt_boxes, gt_classes, training=False)
         return self.compute_metrics(images, {}, {}, sample_weight={})
+
+    def make_predict_function(self, force=False):
+        return predict_utils.make_predict_function(self, force=force)
+
+    @property
+    def prediction_decoder(self):
+        return self._prediction_decoder
+
+    @prediction_decoder.setter
+    def prediction_decoder(self, prediction_decoder):
+        self._prediction_decoder = prediction_decoder
+        self.make_predict_function(force=True)
+        self.make_test_function(force=True)
+        self.make_train_function(force=True)
+
+    def decode_predictions(self, predictions, images):
+        # no-op if default decoder is used.
+        box_pred, scores_pred = predictions
+        box_pred = bounding_box.convert_format(
+            box_pred,
+            source=self.bounding_box_format,
+            target=self.prediction_decoder.bounding_box_format,
+            images=images,
+        )
+        box_pred, scores_pred, cls_pred, valid_det = self.prediction_decoder(
+            box_pred, scores_pred
+        )
+        box_pred = bounding_box.convert_format(
+            box_pred,
+            source=self.prediction_decoder.bounding_box_format,
+            target=self.bounding_box_format,
+            images=images,
+        )
+        return box_pred, scores_pred, cls_pred, valid_det
 
 
 def _validate_and_get_loss(loss, loss_name):

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -198,8 +198,6 @@ class RetinaNet(tf.keras.Model):
     def prediction_decoder(self, prediction_decoder):
         self._prediction_decoder = prediction_decoder
         self.make_predict_function(force=True)
-        self.make_test_function(force=True)
-        self.make_train_function(force=True)
 
     @staticmethod
     def default_anchor_generator(bounding_box_format):


### PR DESCRIPTION
The PyCOCOCallback no longer need to take `input_nms`.
