### PR TITLE
Make GPU CI tests run custom op tests

### DIFF
--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -26,7 +26,7 @@ local unittest = base.BaseTest {
       python build_deps/configure.py
       bazel build keras_cv/custom_ops:all --verbose_failures
       cp bazel-bin/keras_cv/custom_ops/*.so keras_cv/custom_ops/
-      TEST_CUSTOM_OPS=true
+      export TEST_CUSTOM_OPS=true
 
       # Run whatever is in `command` here.
       ${@:0}


### PR DESCRIPTION
Without this change, we weren't actually running custom ops tests on GPU CI