### PR TITLE
Add ABI warning to custom ops loader

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,6 +32,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
+        pip uninstall tensorflow
         pip install tensorflow-cpu==2.11.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Build custom ops for tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow-cpu==2.11.0
+        pip install tensorflow==2.11.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Build custom ops for tests
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.11.0
+        pip install tensorflow-cpu==2.11.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Build custom ops for tests
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,6 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip uninstall tensorflow
         pip install tensorflow-cpu==2.11.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Build custom ops for tests

--- a/keras_cv/utils/resource_loader.py
+++ b/keras_cv/utils/resource_loader.py
@@ -18,8 +18,12 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import warnings
 
 import tensorflow as tf
+
+TF_VERSION_FOR_ABI_COMPATIBILITY = "2.11"
+abi_warning_already_raised = False
 
 
 def get_project_root():
@@ -49,5 +53,29 @@ class LazySO:
     @property
     def ops(self):
         if self._ops is None:
+            self.display_warning_if_incompatible()
             self._ops = tf.load_op_library(get_path_to_datafile(self.relative_path))
         return self._ops
+
+    def display_warning_if_incompatible(self):
+        global abi_warning_already_raised
+        if abi_warning_already_raised or abi_is_compatible():
+            return
+
+        user_version = tf.__version__
+        warnings.warn(
+            f"You are currently using TensorFlow {user_version} and trying to load a KerasCV custom op."
+            "\n"
+            f"KerasCV has compiled its custom ops against TensorFlow {TF_VERSION_FOR_ABI_COMPATIBILITY}, "
+            "and there are no compatibility guarantees between the two versions. "
+            "\n"
+            "This means that you might get segfaults when loading the custom op, "
+            "or other kind of low-level errors.\n If you do, do not file an issue "
+            "on Github. This is a known limitation.",
+            UserWarning,
+        )
+        abi_warning_already_raised = True
+
+
+def abi_is_compatible():
+    return tf.__version__.startswith(TF_VERSION_FOR_ABI_COMPATIBILITY)

--- a/keras_cv/version_check_test.py
+++ b/keras_cv/version_check_test.py
@@ -13,12 +13,21 @@
 # limitations under the License.
 
 import pytest
+import tensorflow as tf
 
 from keras_cv import version_check
 
+@pytest.fixture(autouse=True)
+def cleanup_tf_version():
+    actual_tf_version = tf.__version__
+    # Tests will be run after yield
+    yield
+
+    # Cleanup
+    tf.__version__ = actual_tf_version
 
 def test_check_tf_version_error():
-    version_check.tf.__version__ = "2.8.0"
+    tf.__version__ = "2.8.0"
 
     with pytest.raises(
         RuntimeError, match="Tensorflow package version needs to be at least 2.9.0"
@@ -28,11 +37,11 @@ def test_check_tf_version_error():
 
 def test_check_tf_version_passes_rc2():
     # should pass
-    version_check.tf.__version__ = "2.9.1rc2"
+    tf.__version__ = "2.9.1rc2"
     version_check.check_tf_version()
 
 
 def test_check_tf_version_passes_nightly():
     # should pass
-    version_check.tf.__version__ = "2.10.0-dev20220419"
+    tf.__version__ = "2.10.0-dev20220419"
     version_check.check_tf_version()

--- a/keras_cv/version_check_test.py
+++ b/keras_cv/version_check_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 
 from keras_cv import version_check
 
+
 @pytest.fixture(autouse=True)
 def cleanup_tf_version():
     actual_tf_version = tf.__version__
@@ -25,6 +26,7 @@ def cleanup_tf_version():
 
     # Cleanup
     tf.__version__ = actual_tf_version
+
 
 def test_check_tf_version_error():
     tf.__version__ = "2.8.0"


### PR DESCRIPTION
This is similar to the [TFA implementation](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/utils/resource_loader.py) and will raise warnings if users have an incompatible TF version with KerasCV's custom ops