### PR TITLE
[Object Detection] Remove backbone_weights from RetinaNet

### DIFF
--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -178,9 +178,6 @@ with strategy.scope():
         bounding_box_format="xywh",
         # KerasCV offers a set of pre-configured backbones
         backbone="resnet50",
-        # Each backbone comes with multiple pre-trained weights
-        # These weights match the weights available in the `keras_cv.model` class.
-        backbone_weights="imagenet",
         # include_rescaling tells the model whether your input images are in the default
         # pixel range (0, 255) or if you have already rescaled your inputs to the range
         # (0, 1).  In our case, we feed our model images with inputs in the range (0, 255).

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -33,7 +33,6 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             classes=10,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=True,
         )
         # all metric formats must match

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -25,7 +25,6 @@ from keras_cv.models.object_detection.__test_utils__ import _create_bounding_box
 class RetinaNetTest(tf.test.TestCase):
     @pytest.fixture(autouse=True)
     def cleanup_global_session(self):
-        tf.config.set_visible_devices([], "GPU")
         # Code before yield runs before the test
         tf.config.set_soft_device_placement(False)
         yield

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -66,40 +66,6 @@ class RetinaNetTest(tf.test.TestCase):
         _ = retina_net(images)
         _ = retina_net.predict(images)
 
-    def test_loss_output_shape_error_messages(self):
-        retina_net = keras_cv.models.RetinaNet(
-            classes=20,
-            bounding_box_format="xywh",
-            backbone="resnet50",
-            include_rescaling=True,
-        )
-        xs, ys = _create_bounding_box_dataset("xywh")
-
-        # all metric formats must match
-        retina_net.compile(
-            optimizer="adam",
-            box_loss=keras_cv.losses.SmoothL1Loss(reduction="none"),
-            classification_loss=keras_cv.losses.FocalLoss(
-                from_logits=True, reduction="sum"
-            ),
-        )
-
-        with self.assertRaisesRegex(
-            ValueError, "output shape of `classification_loss`"
-        ):
-            retina_net.fit(x=xs, y=ys, epochs=1)
-
-        # all metric formats must match
-        retina_net.compile(
-            optimizer="adam",
-            box_loss=keras_cv.losses.SmoothL1Loss(reduction="sum"),
-            classification_loss=keras_cv.losses.FocalLoss(
-                from_logits=True, reduction="none"
-            ),
-        )
-        with self.assertRaisesRegex(ValueError, "output shape of `box_loss`"):
-            retina_net.fit(x=xs, y=ys, epochs=1)
-
     def test_wrong_logits(self):
         retina_net = keras_cv.models.RetinaNet(
             classes=2,

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -37,7 +37,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=20,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=True,
         )
         retina_net.compile(
@@ -56,7 +55,6 @@ class RetinaNetTest(tf.test.TestCase):
                 classes=20,
                 bounding_box_format="xywh",
                 backbone="resnet50",
-                backbone_weights=None,
                 # Note no include_rescaling is provided
             )
 
@@ -71,7 +69,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=20,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=True,
         )
         images = tf.random.uniform((2, 512, 512, 3))
@@ -83,7 +80,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=20,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=True,
         )
         xs, ys = _create_bounding_box_dataset("xywh")
@@ -118,7 +114,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=2,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=False,
         )
 
@@ -139,7 +134,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=2,
             bounding_box_format="xywh",
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=False,
         )
 
@@ -157,7 +151,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=1,
             bounding_box_format=bounding_box_format,
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=False,
         )
         retina_net.backbone.trainable = False
@@ -184,7 +177,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=1,
             bounding_box_format=bounding_box_format,
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=False,
         )
 
@@ -240,7 +232,6 @@ class RetinaNetTest(tf.test.TestCase):
             classes=1,
             bounding_box_format=bounding_box_format,
             backbone="resnet50",
-            backbone_weights=None,
             include_rescaling=False,
         )
 

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -25,6 +25,7 @@ from keras_cv.models.object_detection.__test_utils__ import _create_bounding_box
 class RetinaNetTest(tf.test.TestCase):
     @pytest.fixture(autouse=True)
     def cleanup_global_session(self):
+        tf.config.set_visible_devices([], "GPU")
         # Code before yield runs before the test
         tf.config.set_soft_device_placement(False)
         yield
@@ -48,15 +49,6 @@ class RetinaNetTest(tf.test.TestCase):
         # TODO(lukewood) uncomment when using keras_cv.models.ResNet50
         # self.assertIsNotNone(retina_net.backbone.get_layer(name="rescaling"))
         # TODO(lukewood): test compile with the FocalLoss class
-
-    def test_retina_net_include_rescaling_required_with_default_backbone(self):
-        with self.assertRaises(ValueError):
-            _ = keras_cv.models.RetinaNet(
-                classes=20,
-                bounding_box_format="xywh",
-                backbone="resnet50",
-                # Note no include_rescaling is provided
-            )
 
     @pytest.mark.skipif(
         "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",


### PR DESCRIPTION
Follow-up will switch to functional subclassing.

For now, keeping the resnet50 backbone as a default. We can re-evaluate based on our resnet50 results whether this should also be removed (and if it is, we should do the same for FasterRCNN)