### PR TITLE
Add pretrained weights for ResNet50

### DIFF
--- a/examples/training/classification/imagenet/training_history.json
+++ b/examples/training/classification/imagenet/training_history.json
@@ -153,6 +153,25 @@
             "validation_accuracy": "0.8010"
         }
     },
+    "resnet50": {
+        "v0": {
+            "accelerators": 8,
+            "args": {
+                "batch_size": "64",
+                "initial_learning_rate": "0.0125",
+                "use_ema": "True",
+                "weight_decay": "0.0001"
+            },
+            "contributor": "ianstenbit",
+            "epochs_trained": 158,
+            "script": {
+                "name": "basic_training.py",
+                "version": "212e67fc9acb65c699b609e4cdae54552d22e6b4"
+            },
+            "tensorboard_logs": "https://tensorboard.dev/experiment/H5kM5mYOQQq82sEEtrOq7g/",
+            "validation_accuracy": "0.7550"
+        }
+    },
     "resnet50v2": {
         "v0": {
             "accelerators": 2,

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -22,6 +22,7 @@ from tensorflow.keras import backend
 from tensorflow.keras import layers
 
 from keras_cv.models import utils
+from keras_cv.models.weights import parse_weights
 
 MODEL_CONFIGS = {
     "ResNet18": {
@@ -436,7 +437,7 @@ def ResNet50(
         include_rescaling=include_rescaling,
         include_top=include_top,
         name=name,
-        weights=weights,
+        weights=parse_weights(weights, include_top, "resnet50v2"),
         input_shape=input_shape,
         input_tensor=input_tensor,
         pooling=pooling,

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -437,7 +437,7 @@ def ResNet50(
         include_rescaling=include_rescaling,
         include_top=include_top,
         name=name,
-        weights=parse_weights(weights, include_top, "resnet50v2"),
+        weights=parse_weights(weights, include_top, "resnet50"),
         input_shape=input_shape,
         input_tensor=input_tensor,
         pooling=pooling,

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -78,6 +78,10 @@ ALIASES = {
         "imagenet": "imagenet/classification-v0",
         "imagenet/classification": "imagenet/classification-v0",
     },
+    "resnet50": {
+        "imagenet": "imagenet/classification-v2",
+        "imagenet/classification": "imagenet/classification-v2",
+    },
     "resnet50v2": {
         "imagenet": "imagenet/classification-v2",
         "imagenet/classification": "imagenet/classification-v2",
@@ -147,6 +151,10 @@ WEIGHTS_CONFIG = {
     "efficientnetv2s": {
         "imagenet/classification-v0": "2259db3483a577b5473dd406d1278439bd1a704ee477ff01a118299b134bd4db",
         "imagenet/classification-v0-notop": "80555436ea49100893552614b4dce98de461fa3b6c14f8132673817d28c83654",
+    },
+    "resnet50": {
+        "imagenet/classification-v0": "1525dc1ce580239839ba6848c0f1b674dc89cb9ed73c4ed49eba355b35eac3ce",
+        "imagenet/classification-v0-notop": "dc5f6d8f929c78d0fc192afecc67b11ac2166e9d8b9ef945742368ae254c07af",
     },
     "resnet50v2": {
         "imagenet/classification-v0": "11bde945b54d1dca65101be2648048abca8a96a51a42820d87403486389790db",


### PR DESCRIPTION
These weights score 75.5% top-1 imagenet validation accuracy, which beats the Keras applications weights (74.9%)

Fixes #1193 