### PR TITLE
Add: support for negative prompts

### DIFF
--- a/keras_cv/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion.py
@@ -391,6 +391,7 @@ class StableDiffusionBase:
         return unconditional_context
 
     def _expand_tensor(self, text_embedding, batch_size):
+        """Extends a tensor by repeating it to fit the shape of the given batch size."""
         text_embedding = tf.squeeze(text_embedding)
         if text_embedding.shape.rank == 2:
             text_embedding = tf.repeat(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #1206. Tested with Stable Diffusion 1.x and 2.x. 

Added a colab so you can try it as well [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1xxIi1FG9MuuGsw20IsgphezLOjRiReh7?usp=sharing)

## Examples 

### Stable Diffusion 1.x

#### A photo of the peak of a mountain
![1](https://user-images.githubusercontent.com/37347167/210157121-1eb59d4e-95e8-43ed-8936-c567f84ff6d2.png)
`negative prompt`: snow
![2](https://user-images.githubusercontent.com/37347167/210157133-357d1b86-649c-4535-8c4f-859e2fca3a58.png)

### Stable Diffusion 2.x

#### A Bouquet of Roses
![5](https://user-images.githubusercontent.com/37347167/210157152-5e04ddc3-d31e-4896-9d03-267cd9e90a6d.png)
`negative prompt`: red roses
![6](https://user-images.githubusercontent.com/37347167/210157165-af3c3ef1-0033-4ef2-8a60-a2b9827a282f.png)

#### A renaissance painting of `famous-people` in the 15th Century
`negative prompt`: oversaturated, ugly, 3d, render, cartoon, grain, low-res, poorly drawn face, out of frame, poorly drawn hands, blurry, bad art.
![pop](https://user-images.githubusercontent.com/37347167/210157264-a196189a-7e1d-4a2c-8181-d6103201a1fc.svg)
**[Prompt source](https://twitter.com/abhi1thakur/status/1608039769522720768?s=20&t=0nsG7q9WIGfXCu9PKrQGrw)**

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
