### PR TITLE
add utility function to mask invalid detections

### DIFF
--- a/keras_cv/bounding_box/__init__.py
+++ b/keras_cv/bounding_box/__init__.py
@@ -22,10 +22,10 @@ from keras_cv.bounding_box.formats import XYWH
 from keras_cv.bounding_box.formats import XYXY
 from keras_cv.bounding_box.formats import YXYX
 from keras_cv.bounding_box.iou import compute_iou
+from keras_cv.bounding_box.mask_invalid_detections import mask_invalid_detections
 from keras_cv.bounding_box.pad_batch_to_shape import pad_batch_to_shape
 from keras_cv.bounding_box.to_dense import to_dense
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.utils import clip_to_image
 from keras_cv.bounding_box.utils import preserve_rel
 from keras_cv.bounding_box.validate_format import validate_format
-from keras_cv.bounding_box.mask_invalid_detections import mask_invalid_detections

--- a/keras_cv/bounding_box/__init__.py
+++ b/keras_cv/bounding_box/__init__.py
@@ -28,3 +28,4 @@ from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.utils import clip_to_image
 from keras_cv.bounding_box.utils import preserve_rel
 from keras_cv.bounding_box.validate_format import validate_format
+from keras_cv.bounding_box.mask_invalid_detections import mask_invalid_detections

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import tensorflow as tf
+
 from keras_cv.bounding_box.to_dense import to_dense
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
@@ -43,6 +45,7 @@ def mask_invalid_detections(bounding_boxes):
 
     boxes = bounding_boxes.get("boxes")
     classes = bounding_boxes.get("classes")
+    num_detections = bounding_boxes.get("num_detections")
 
     # Create a mask to select only the first N boxes from each batch
     mask = tf.repeat(
@@ -56,6 +59,10 @@ def mask_invalid_detections(bounding_boxes):
     mask = tf.expand_dims(mask, axis=-1)
     mask = tf.repeat(mask, repeats=boxes.shape[-1], axis=-1)
     boxes = tf.where(mask, boxes, -tf.ones_like(boxes))
+
+    result = bounding_boxes.copy()
+    result["boxes"] = boxes
+    result["classes"] = classes
 
     if info["ragged"]:
         return to_ragged(result)

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -1,0 +1,63 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.bounding_box.to_dense import to_dense
+from keras_cv.bounding_box.to_ragged import to_ragged
+from keras_cv.bounding_box.validate_format import validate_format
+
+
+def mask_invalid_detections(bounding_boxes):
+    """masks out invalid detections with -1s.
+
+    This utility is mainly used on the output of `tf.image.combined_non_max_suppression`
+    operations.  The output of `tf.image.combined_non_max_suppression` contains padding
+    values of 0 instead of -1.  KerasCV expects all bounding boxes to be padded with
+    -1s instead of 0s.  This function uses the value of `num_detections` to mask out
+    invalid boxes with -1s.
+
+    Args:
+        bounding_boxes: a dictionary complying with KerasCV bounding box format.  In
+            addition to the normal required keys, these boxes are also expected to have
+            a `num_detections` key.
+    """
+    # ensure we are complying with KerasCV bounding box format.
+    info = validate_format(bounding_boxes)
+    if "num_detections" not in bounding_boxes:
+        raise ValueError(
+            "`bounding_boxes` must have key 'num_detections' "
+            "to be used with `bounding_box.mask_invalid_detections()`."
+        )
+
+    # required to use tf.where()
+    bounding_boxes = to_dense(bounding_boxes)
+
+    boxes = bounding_boxes.get("boxes")
+    classes = bounding_boxes.get("classes")
+
+    # Create a mask to select only the first N boxes from each batch
+    mask = tf.repeat(
+        tf.expand_dims(tf.range(boxes.shape[1]), axis=0), repeats=boxes.shape[0], axis=0
+    )
+    mask = mask < num_detections[:, None]
+
+    classes = tf.where(mask, classes, -tf.ones_like(classes))
+
+    # resuse mask for boxes
+    mask = tf.expand_dims(mask, axis=-1)
+    mask = tf.repeat(mask, repeats=boxes.shape[-1], axis=-1)
+    boxes = tf.where(mask, boxes, -tf.ones_like(boxes))
+
+    if info["ragged"]:
+        return to_ragged(result)
+
+    return result

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -31,6 +31,13 @@ def mask_invalid_detections(bounding_boxes):
         bounding_boxes: a dictionary complying with KerasCV bounding box format.  In
             addition to the normal required keys, these boxes are also expected to have
             a `num_detections` key.
+
+    Returns:
+        bounding boxes with proper masking of the boxes according to `num_detections`.
+        This allows proper interop with `tf.image.combined_non_max_suppression`.
+        Returned boxes match the specification fed to the function, so if the bounding
+        box tensor uses `tf.RaggedTensor` to represent boxes the returned value will
+        also return `tf.RaggedTensor` representations.
     """
     # ensure we are complying with KerasCV bounding box format.
     info = validate_format(bounding_boxes)

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -61,7 +61,9 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
 
     # Create a mask to select only the first N boxes from each batch
     mask = tf.repeat(
-        tf.expand_dims(tf.range(boxes.shape[1]), axis=0), repeats=boxes.shape[0], axis=0
+        tf.expand_dims(tf.range(tf.shape(boxes)[1]), axis=0),
+        repeats=tf.shape(boxes)[0],
+        axis=0,
     )
     mask = mask < num_detections[:, None]
 

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import tensorflow as tf
 
-from keras_cv.bounding_box.to_dense import to_dense
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
 

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -18,20 +18,23 @@ from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
 
 
-def mask_invalid_detections(bounding_boxes):
+def mask_invalid_detections(bounding_boxes, output_ragged=False):
     """masks out invalid detections with -1s.
 
     This utility is mainly used on the output of `tf.image.combined_non_max_suppression`
-    operations.  The output of `tf.image.combined_non_max_suppression` contains padding
-    values of 0 instead of -1.  KerasCV expects all bounding boxes to be padded with
-    -1s instead of 0s.  This function uses the value of `num_detections` to mask out
+    operations.  The output of `tf.image.combined_non_max_suppression` contains all of
+    the detections, even invalid ones.  Users are expected to use `num_detections` to
+    determine how many boxes are in each image.
+
+    In contrast, KerasCV expects all bounding boxes to be padded with -1s.
+    This function uses the value of `num_detections` to mask out
     invalid boxes with -1s.
 
     Args:
         bounding_boxes: a dictionary complying with KerasCV bounding box format.  In
             addition to the normal required keys, these boxes are also expected to have
             a `num_detections` key.
-
+        output_ragged: whether or not to output RaggedTensor based bounding boxes.
     Returns:
         bounding boxes with proper masking of the boxes according to `num_detections`.
         This allows proper interop with `tf.image.combined_non_max_suppression`.
@@ -41,14 +44,17 @@ def mask_invalid_detections(bounding_boxes):
     """
     # ensure we are complying with KerasCV bounding box format.
     info = validate_format(bounding_boxes)
+    if info["ragged"]:
+        raise ValueError(
+            "`bounding_box.mask_invalid_detections()` requires inputs to be Dense "
+            "tensors.  Please call `bounding_box.to_dense(bounding_boxes)` before "
+            "passing your boxes to `bounding_box.mask_invalid_detections()`."
+        )
     if "num_detections" not in bounding_boxes:
         raise ValueError(
             "`bounding_boxes` must have key 'num_detections' "
             "to be used with `bounding_box.mask_invalid_detections()`."
         )
-
-    # required to use tf.where()
-    bounding_boxes = to_dense(bounding_boxes)
 
     boxes = bounding_boxes.get("boxes")
     classes = bounding_boxes.get("classes")
@@ -71,7 +77,7 @@ def mask_invalid_detections(bounding_boxes):
     result["boxes"] = boxes
     result["classes"] = classes
 
-    if info["ragged"]:
+    if output_ragged:
         return to_ragged(result)
 
     return result

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -39,8 +39,10 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
                 [tf.random.uniform((5, 4)), tf.random.uniform((10, 4))]
             ),
             "num_detections": tf.constant([2, 3]),
-            "classes": tf.ragged.stack([tf.random.uniform((5,)), tf.random.uniform((5,))]),
+            "classes": tf.ragged.stack([tf.random.uniform((5,)), tf.random.uniform((10,))]),
         }
 
         result = bounding_box.mask_invalid_detections(bounding_boxes)
-        self.assertTrue(isinstance(result, tf.RaggedTensor))
+        self.assertTrue(isinstance(result['boxes'], tf.RaggedTensor))
+        self.assertEqual(result['boxes'][0].shape[0], 2)
+        self.assertEqual(result['boxes'][1].shape[0], 3)

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -39,7 +39,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
                 [tf.random.uniform((5, 4)), tf.random.uniform((10, 4))]
             ),
             "num_detections": tf.constant([2, 3]),
-            "classes": tf.ragged.stack([tf.random.uniform((5)), tf.random.uniform((5))]),
+            "classes": tf.ragged.stack([tf.random.uniform((5,)), tf.random.uniform((5,))]),
         }
 
         result = bounding_box.mask_invalid_detections(bounding_boxes)

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -33,6 +33,9 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         preserved_boxes = result["boxes"][:, :2, :]
         self.assertAllClose(preserved_boxes, bounding_boxes['boxes'][:, :2, :])
 
+        boxes_from_image_3 = result["boxes"][2, :4, :]
+        self.assertAllClose(boxes_from_image_3, bounding_boxes['boxes'][2, :4, :])
+
     def test_preserves_ragged(self):
         bounding_boxes = {
             "boxes": tf.ragged.stack(

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -1,0 +1,21 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+
+
+class MaskInvalidDetectionsTest(tf.test.TestCase):
+    pass

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -58,18 +58,16 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         boxes_from_image_3 = result["boxes"][2, :4, :]
         self.assertAllClose(boxes_from_image_3, bounding_boxes["boxes"][2, :4, :])
 
-    def test_preserves_ragged(self):
+    def test_ragged_outputs(self):
         bounding_boxes = {
-            "boxes": tf.ragged.stack(
-                [tf.random.uniform((5, 4)), tf.random.uniform((10, 4))]
-            ),
+            "boxes": tf.stack([tf.random.uniform((10, 4)), tf.random.uniform((10, 4))]),
             "num_detections": tf.constant([2, 3]),
-            "classes": tf.ragged.stack(
-                [tf.random.uniform((5,)), tf.random.uniform((10,))]
-            ),
+            "classes": tf.stack([tf.random.uniform((10,)), tf.random.uniform((10,))]),
         }
 
-        result = bounding_box.mask_invalid_detections(bounding_boxes)
+        result = bounding_box.mask_invalid_detections(
+            bounding_boxes, output_ragged=True
+        )
         self.assertTrue(isinstance(result["boxes"], tf.RaggedTensor))
         self.assertEqual(result["boxes"][0].shape[0], 2)
         self.assertEqual(result["boxes"][1].shape[0], 3)

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -18,4 +18,26 @@ from keras_cv import bounding_box
 
 
 class MaskInvalidDetectionsTest(tf.test.TestCase):
-    pass
+    def test_correctly_masks_based_on_max_dets(self):
+        bounding_boxes = {
+            "boxes": tf.random.uniform((4, 100, 4)),
+            "num_detections": tf.constant([2, 3, 4, 1]),
+            "classes": tf.random.uniform((4, 100)),
+        }
+
+        result = bounding_box.mask_invalid_detections(bounding_boxes)
+
+        negative_one_boxes = result["boxes"][:, 5:, :]
+        self.assertAllClose(negative_one_boxes, -tf.ones_like(negative_one_boxes))
+
+    def test_preserves_ragged(self):
+        bounding_boxes = {
+            "boxes": tf.ragged.stack(
+                [tf.random.uniform(5, 4), tf.random.uniform(10, 4)]
+            ),
+            "num_detections": tf.constant([2, 3]),
+            "classes": tf.ragged.stack([tf.random.uniform(5), tf.random.uniform(5)]),
+        }
+
+        result = bounding_box.mask_invalid_detections(bounding_boxes)
+        self.assertTrue(isinstance(result, tf.RaggedTensor))

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -21,7 +21,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
     def test_correctly_masks_based_on_max_dets(self):
         bounding_boxes = {
             "boxes": tf.random.uniform((4, 100, 4)),
-            "num_detections": tf.constant([2, 3, 4, 1]),
+            "num_detections": tf.constant([2, 3, 4, 2]),
             "classes": tf.random.uniform((4, 100)),
         }
 
@@ -30,13 +30,16 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         negative_one_boxes = result["boxes"][:, 5:, :]
         self.assertAllClose(negative_one_boxes, -tf.ones_like(negative_one_boxes))
 
+        preserved_boxes = result["boxes"][:, :2, :]
+        self.assertAllClose(preserved_boxes, bounding_boxes['boxes'][:, :2, :])
+
     def test_preserves_ragged(self):
         bounding_boxes = {
             "boxes": tf.ragged.stack(
-                [tf.random.uniform(5, 4), tf.random.uniform(10, 4)]
+                [tf.random.uniform((5, 4)), tf.random.uniform((10, 4))]
             ),
             "num_detections": tf.constant([2, 3]),
-            "classes": tf.ragged.stack([tf.random.uniform(5), tf.random.uniform(5)]),
+            "classes": tf.ragged.stack([tf.random.uniform((5)), tf.random.uniform((5))]),
         }
 
         result = bounding_box.mask_invalid_detections(bounding_boxes)

--- a/keras_cv/layers/object_detection/nms_prediction_decoder.py
+++ b/keras_cv/layers/object_detection/nms_prediction_decoder.py
@@ -94,12 +94,14 @@ class NmsDecoder(tf.keras.layers.Layer):
             source="yxyx",
             target=self.bounding_box_format,
         )
-        return {
+        bounding_boxes = {
             "boxes": box_pred,
             "confidence": confidence_pred,
             "classes": class_pred,
             "num_detections": valid_det,
         }
+        # this is required to comply with KerasCV bounding box format.
+        return bounding_box.mask_invalid_detections(bounding_boxes)
 
     def get_config(self):
         config = {


### PR DESCRIPTION
Fixes the output of the NMS layer to comply with the KerasCV bounding box format.
Right now, the returned boxes from NMS include all boxes, not just those that pass through NMS.  This causes confusing behavior where there are many more boxes included in the result Tensor than there should be.

---

    """masks out invalid detections with -1s.

    This utility is mainly used on the output of `tf.image.combined_non_max_suppression`
    operations.  The output of `tf.image.combined_non_max_suppression` contains padding
    values of 0 instead of -1.  KerasCV expects all bounding boxes to be padded with
    -1s instead of 0s.  This function uses the value of `num_detections` to mask out
    invalid boxes with -1s.

    Args:
        bounding_boxes: a dictionary complying with KerasCV bounding box format.  In
            addition to the normal required keys, these boxes are also expected to have
            a `num_detections` key.

---

XLA testing was done to ensure TPU compat:

```
@tf.function(jit_compile=True)
def test_in_xla():
  num_detections = tf.constant([5, 4, 2, 3])
  boxes = tf.random.uniform((4, 100, 4))
  classes = tf.random.uniform((4, 100))
  mask = tf.repeat(tf.expand_dims(tf.range(boxes.shape[1]), axis=0), repeats=boxes.shape[0], axis=0)
  mask = mask < num_detections[:, None]
  mask = tf.expand_dims(mask, axis=-1)
  mask = tf.repeat(mask, boxes.shape[-1], axis=-1)
  result = tf.where(mask, boxes, -tf.ones_like(boxes))
  return result
```

---

Todo:

- [x] add unit tests