### PR TITLE
Test compilation of cv_layers.MultiClassNonMaxSuppression

### DIFF
--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -46,6 +46,7 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
+
 @unittest.expectedFailure
 class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
@@ -54,7 +55,8 @@ class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
         self.assertEqual(result["boxes"].shape, [8, 100, 4])
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
-        
+
+
 class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
     def setUp(self):
         tf.config.experimental.enable_mlir_bridge()

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -23,8 +23,8 @@ def decode_predictions_output_shapes():
     classes = 10
     predictions_shape = (8, 98208, 4 + classes)
 
-    predictions = tf.random.uniform(
-        shape=predictions_shape, minval=0.0, maxval=1.0, dtype=tf.float32
+    predictions = tf.random.stateless_uniform(
+        shape=predictions_shape, seed=(2, 3), minval=0.0, maxval=1.0, dtype=tf.float32
     )
     box_pred = predictions[..., :4]
     confidence_pred = predictions[..., 4:]
@@ -46,7 +46,6 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
-
 @unittest.expectedFailure
 class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
@@ -55,8 +54,7 @@ class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
         self.assertEqual(result["boxes"].shape, [8, 100, 4])
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
-
-
+        
 class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
     def setUp(self):
         tf.config.experimental.enable_mlir_bridge()

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -14,56 +14,59 @@
 
 import unittest
 
-import pytest
 import tensorflow as tf
 
 from keras_cv import layers as cv_layers
 
 
+def decode_predictions_output_shapes():
+    classes = 10
+    predictions_shape = (8, 98208, 4 + classes)
+
+    predictions = tf.random.uniform(
+        shape=predictions_shape, minval=0.0, maxval=1.0, dtype=tf.float32
+    )
+    box_pred = predictions[..., :4]
+    confidence_pred = predictions[..., 4:]
+
+    layer = cv_layers.MultiClassNonMaxSuppression(
+        bounding_box_format="xyxy",
+        from_logits=True,
+        max_detections=100,
+    )
+
+    result = layer(box_prediction=box_pred, confidence_prediction=confidence_pred)
+    return result
+
+
 class NmsPredictionDecoderTest(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
-        classes = 10
-        predictions_shape = (8, 98208, 4 + classes)
-
-        predictions = tf.random.uniform(
-            shape=predictions_shape, minval=0.0, maxval=1.0, dtype=tf.float32
-        )
-        box_pred = predictions[..., :4]
-        confidence_pred = predictions[..., 4:]
-
-        layer = cv_layers.MultiClassNonMaxSuppression(
-            bounding_box_format="xyxy",
-            from_logits=True,
-            max_detections=100,
-        )
-
-        result = layer(box_prediction=box_pred, confidence_prediction=confidence_pred)
-
+        result = decode_predictions_output_shapes()
         self.assertEqual(result["boxes"].shape, [8, 100, 4])
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
-    @unittest.expectedFailure
-    def test_with_xla(self):
-        # TODO if the teardown is working correctly the next line is not required
-        tf.config.experimental.disable_mlir_bridge()
-        xla_function = tf.function(
-            self.test_decode_predictions_output_shapes, jit_compile=True
-        )
-        xla_function()
 
-    @pytest.fixture()
-    def prepare_xla_mlir_bridge_compiled_function(self):
+@unittest.expectedFailure
+class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
+    def test_decode_predictions_output_shapes(self):
+        xla_function = tf.function(decode_predictions_output_shapes, jit_compile=True)
+        result = xla_function()
+        self.assertEqual(result["boxes"].shape, [8, 100, 4])
+        self.assertEqual(result["classes"].shape, [8, 100])
+        self.assertEqual(result["confidence"].shape, [8, 100])
+
+class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
+    def setUp(self):
         tf.config.experimental.enable_mlir_bridge()
-        xla_function = tf.function(
-            self.test_decode_predictions_output_shapes, jit_compile=True
-        )
-        yield xla_function
+
+    def tearDown(self):
         tf.config.experimental.disable_mlir_bridge()
 
-    @pytest.fixture(autouse=True)
-    def store_xla_mlir(self, prepare_xla_mlir_bridge_compiled_function):
-        self._xla_function = prepare_xla_mlir_bridge_compiled_function
-
-    def test_with_xla_mlir_bridge(self):
-        self._xla_function()
+    #@unittest.expectedFailure
+    def test_decode_predictions_output_shapes(self):
+        xla_function = tf.function(decode_predictions_output_shapes, jit_compile=True)
+        result = xla_function()
+        self.assertEqual(result["boxes"].shape, [8, 100, 4])
+        self.assertEqual(result["classes"].shape, [8, 100])
+        self.assertEqual(result["confidence"].shape, [8, 100])

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
 import unittest
 
+import tensorflow as tf
+
 from keras_cv import layers as cv_layers
+
 
 class NmsPredictionDecoderTest(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
@@ -40,8 +42,10 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
+
 class XlaMlirBridgeNmsPredictionDecoderTest(tf.test.TestCase):
     tf.config.experimental.enable_mlir_bridge()
+
     @tf.function(jit_compile=True)
     def test_decode_predictions_output_shapes(self):
         classes = 10
@@ -65,10 +69,11 @@ class XlaMlirBridgeNmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
+
 @unittest.expectedFailure
 class XlaNmsPredictionDecoderTest(tf.test.TestCase):
-    # TODO This is not failing as it seems if uncommented it will globally 
-    # disable the MLIR bridge. 
+    # TODO This is not failing as it seems if uncommented it will globally
+    # disable the MLIR bridge.
     # Are we compiling in the same context?
     # tf.config.experimental.disable_mlir_bridge()
     @tf.function(jit_compile=True)

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -45,7 +45,8 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
 
     @unittest.expectedFailure
     def test_with_xla(self):
-        # tf.config.experimental.disable_mlir_bridge()
+        # TODO if the teardown is working correctly the next line is not required
+        tf.config.experimental.disable_mlir_bridge()
         xla_function = tf.function(
             self.test_decode_predictions_output_shapes, jit_compile=True
         )

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -56,6 +56,7 @@ class NmsPredictionDecoderTestWithXLA(tf.test.TestCase):
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
 
+
 class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
     def setUp(self):
         tf.config.experimental.enable_mlir_bridge()
@@ -63,7 +64,7 @@ class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
     def tearDown(self):
         tf.config.experimental.disable_mlir_bridge()
 
-    #@unittest.expectedFailure
+    # @unittest.expectedFailure
     def test_decode_predictions_output_shapes(self):
         xla_function = tf.function(decode_predictions_output_shapes, jit_compile=True)
         result = xla_function()


### PR DESCRIPTION
# What does this PR do?
It will try to test `MultiClassNonMaxSuppression` compilation as a proxy TPU test. 

Fixes https://github.com/keras-team/keras-cv/issues/1269


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@tanzhenyu @LukeWood @ianstenbit 

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
