### PR TITLE
Add ConvMixer Models

### DIFF
--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.models.convmixer import ConvMixer_512_16
+from keras_cv.models.convmixer import ConvMixer_768_32
+from keras_cv.models.convmixer import ConvMixer_1024_16
+from keras_cv.models.convmixer import ConvMixer_1536_20
+from keras_cv.models.convmixer import ConvMixer_1536_24
 from keras_cv.models.convnext import ConvNeXtBase
 from keras_cv.models.convnext import ConvNeXtLarge
 from keras_cv.models.convnext import ConvNeXtSmall
@@ -102,8 +107,3 @@ from keras_cv.models.vit import ViTS16
 from keras_cv.models.vit import ViTS32
 from keras_cv.models.vit import ViTTiny16
 from keras_cv.models.vit import ViTTiny32
-from keras_cv.models.convmixer import ConvMixer_1024_16
-from keras_cv.models.convmixer import ConvMixer_1536_20
-from keras_cv.models.convmixer import ConvMixer_1536_24
-from keras_cv.models.convmixer import ConvMixer_512_16
-from keras_cv.models.convmixer import ConvMixer_768_32

--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -102,3 +102,8 @@ from keras_cv.models.vit import ViTS16
 from keras_cv.models.vit import ViTS32
 from keras_cv.models.vit import ViTTiny16
 from keras_cv.models.vit import ViTTiny32
+from keras_cv.models.convmixer import ConvMixer_1024_16
+from keras_cv.models.convmixer import ConvMixer_1536_20
+from keras_cv.models.convmixer import ConvMixer_1536_24
+from keras_cv.models.convmixer import ConvMixer_512_16
+from keras_cv.models.convmixer import ConvMixer_768_32

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -55,7 +55,7 @@ MODEL_CONFIGS = {
 
 
 def CovnMixer_Layer(inputs, dim, kernel_size):
-    """CovnMixer Layer.
+    """CovnMixer Layer module.
     Args:
         inputs: Input tensor.
         dim: integer, filters of the layer in a block.
@@ -76,7 +76,7 @@ def CovnMixer_Layer(inputs, dim, kernel_size):
 
 
 def patch_embed(inputs, dim, patch_size):
-    """Extract Patch Embedding.
+    """Implementation for Extracting Patch Embeddings.
     Args:
         inputs: Input tensor.
         patch_size: integer, Size of patches.
@@ -138,8 +138,6 @@ def ConvMixer(
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.
-        block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
-            Use 'basic_block' for ResNet18 and ResNet34.
         **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
     Returns:
       A `keras.Model` instance.

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -74,6 +74,7 @@ def CovnMixer_Layer(dim, kernel_size):
         x = tf.keras.layers.Conv2D(dim, kernel_size=1)(x)
         x = tf.nn.gelu(x)
         x = tf.keras.layers.BatchNormalization()(x)
+        return xs
 
     return apply
 
@@ -93,6 +94,7 @@ def patch_embed(dim, patch_size):
         )(x)
         x = tf.nn.gelu(x)
         x = tf.keras.layers.BatchNormalization()(x)
+        return x
 
     return apply
 

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -195,3 +195,162 @@ def ConvMixer(
         model.load_weights(weights)
 
     return model
+
+
+def ConvMixer_1536_20(
+    include_rescaling,
+    include_top,
+    classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    input_tensor=None,
+    pooling=None,
+    classifier_activation="softmax",
+    name="ConvMixer_1536_20",
+    **kwargs,
+):
+    """Instantiates the ResNet34 architecture."""
+
+    return ConvMixer(
+        dim=MODEL_CONFIGS["ConvMixer_1536_20"]["dim"],
+        depth=MODEL_CONFIGS["ConvMixer_1536_20"]["depth"],
+        patch_size=MODEL_CONFIGS["ConvMixer_1536_20"]["patch_size"],
+        kernel_size=MODEL_CONFIGS["ConvMixer_1536_20"]["kernel_size"],
+        include_rescaling=include_rescaling,
+        include_top=include_top,
+        name=name,
+        weights=weights,
+        input_shape=input_shape,
+        input_tensor=input_tensor,
+        pooling=pooling,
+        classes=classes,
+        classifier_activation=classifier_activation,
+        **kwargs,
+    )
+
+def ConvMixer_1536_24(
+    include_rescaling,
+    include_top,
+    classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    input_tensor=None,
+    pooling=None,
+    classifier_activation="softmax",
+    name="ConvMixer_1536_24",
+    **kwargs,
+):
+    """Instantiates the ResNet34 architecture."""
+
+    return ConvMixer(
+        dim=MODEL_CONFIGS["ConvMixer_1536_24"]["dim"],
+        depth=MODEL_CONFIGS["ConvMixer_1536_24"]["depth"],
+        patch_size=MODEL_CONFIGS["ConvMixer_1536_24"]["patch_size"],
+        kernel_size=MODEL_CONFIGS["ConvMixer_1536_24"]["kernel_size"],
+        include_rescaling=include_rescaling,
+        include_top=include_top,
+        name=name,
+        weights=weights,
+        input_shape=input_shape,
+        input_tensor=input_tensor,
+        pooling=pooling,
+        classes=classes,
+        classifier_activation=classifier_activation,
+        **kwargs,
+    )
+
+
+def ConvMixer_768_32(
+    include_rescaling,
+    include_top,
+    classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    input_tensor=None,
+    pooling=None,
+    classifier_activation="softmax",
+    name="ConvMixer_768_32",
+    **kwargs,
+):
+    """Instantiates the ResNet34 architecture."""
+
+    return ConvMixer(
+        dim=MODEL_CONFIGS["ConvMixer_768_32"]["dim"],
+        depth=MODEL_CONFIGS["ConvMixer_768_32"]["depth"],
+        patch_size=MODEL_CONFIGS["ConvMixer_768_32"]["patch_size"],
+        kernel_size=MODEL_CONFIGS["ConvMixer_768_32"]["kernel_size"],
+        include_rescaling=include_rescaling,
+        include_top=include_top,
+        name=name,
+        weights=weights,
+        input_shape=input_shape,
+        input_tensor=input_tensor,
+        pooling=pooling,
+        classes=classes,
+        classifier_activation=classifier_activation,
+        **kwargs,
+    )
+
+
+def ConvMixer_1024_16(
+    include_rescaling,
+    include_top,
+    classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    input_tensor=None,
+    pooling=None,
+    classifier_activation="softmax",
+    name="ConvMixer_1024_16",
+    **kwargs,
+):
+    """Instantiates the ResNet34 architecture."""
+
+    return ConvMixer(
+        dim=MODEL_CONFIGS["ConvMixer_1024_16"]["dim"],
+        depth=MODEL_CONFIGS["ConvMixer_1024_16"]["depth"],
+        patch_size=MODEL_CONFIGS["ConvMixer_1024_16"]["patch_size"],
+        kernel_size=MODEL_CONFIGS["ConvMixer_1024_16"]["kernel_size"],
+        include_rescaling=include_rescaling,
+        include_top=include_top,
+        name=name,
+        weights=weights,
+        input_shape=input_shape,
+        input_tensor=input_tensor,
+        pooling=pooling,
+        classes=classes,
+        classifier_activation=classifier_activation,
+        **kwargs,
+    )
+
+
+def ConvMixer_512_16(
+    include_rescaling,
+    include_top,
+    classes=None,
+    weights=None,
+    input_shape=(None, None, 3),
+    input_tensor=None,
+    pooling=None,
+    classifier_activation="softmax",
+    name="ConvMixer_512_16",
+    **kwargs,
+):
+    """Instantiates the ResNet34 architecture."""
+
+    return ConvMixer(
+        dim=MODEL_CONFIGS["ConvMixer_512_16"]["dim"],
+        depth=MODEL_CONFIGS["ConvMixer_512_16"]["depth"],
+        patch_size=MODEL_CONFIGS["ConvMixer_512_16"]["patch_size"],
+        kernel_size=MODEL_CONFIGS["ConvMixer_512_16"]["kernel_size"],
+        include_rescaling=include_rescaling,
+        include_top=include_top,
+        name=name,
+        weights=weights,
+        input_shape=input_shape,
+        input_tensor=input_tensor,
+        pooling=pooling,
+        classes=classes,
+        classifier_activation=classifier_activation,
+        **kwargs,
+    )

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -79,3 +79,19 @@ def CovnMixer_Layer(inputs, dim, kernel_size):
     x = tf.nn.gelu(x)
     x = tf.keras.layers.BatchNormalization()(x)
     return x
+
+
+def patch_embed(inputs, dim, patch_size):
+    """Extract Patch Embedding.
+    Args:
+        inputs: Input tensor.
+        patch_size: integer, Size of patches.
+    Returns:
+        Output tensor for the patch embed.
+    """
+    x = tf.keras.layers.Conv2D(filters=dim, kernel_size=patch_size, strides=patch_size)(
+        inputs
+    )
+    x = tf.nn.gelu(x)
+    x = tf.keras.layers.BatchNormalization()(x)
+    return x

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -20,7 +20,7 @@ References:
 """
 
 import tensorflow as tf
-from tensorflow.keras import backend
+from tensorflow import keras
 from tensorflow.keras import layers
 
 from keras_cv.models import utils
@@ -66,14 +66,14 @@ def CovnMixer_Layer(dim, kernel_size):
 
     def apply(x):
         residual = x
-        x = tf.keras.layers.DepthwiseConv2D(kernel_size=kernel_size, padding="same")(x)
+        x = layers.DepthwiseConv2D(kernel_size=kernel_size, padding="same")(x)
         x = tf.nn.gelu(x)
-        x = tf.keras.layers.BatchNormalization()(x)
-        x = tf.keras.layers.Add()([x, residual])
+        x = layers.BatchNormalization()(x)
+        x = layers.Add()([x, residual])
 
-        x = tf.keras.layers.Conv2D(dim, kernel_size=1)(x)
+        x = layers.Conv2D(dim, kernel_size=1)(x)
         x = tf.nn.gelu(x)
-        x = tf.keras.layers.BatchNormalization()(x)
+        x = layers.BatchNormalization()(x)
         return x
 
     return apply
@@ -89,11 +89,11 @@ def patch_embed(dim, patch_size):
     """
 
     def apply(x):
-        x = tf.keras.layers.Conv2D(
+        x = layers.Conv2D(
             filters=dim, kernel_size=patch_size, strides=patch_size
         )(x)
         x = tf.nn.gelu(x)
-        x = tf.keras.layers.BatchNormalization()(x)
+        x = layers.BatchNormalization()(x)
         return x
 
     return apply
@@ -190,7 +190,7 @@ def ConvMixer(
         elif pooling == "max":
             x = layers.GlobalMaxPooling2D(name="max_pool")(x)
 
-    model = tf.keras.Model(inputs, x, name=name)
+    model = keras.Model(inputs, x, name=name)
     if weights is not None:
         model.load_weights(weights)
 

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -74,7 +74,7 @@ def CovnMixer_Layer(dim, kernel_size):
         x = tf.keras.layers.Conv2D(dim, kernel_size=1)(x)
         x = tf.nn.gelu(x)
         x = tf.keras.layers.BatchNormalization()(x)
-        return xs
+        return x
 
     return apply
 

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -24,3 +24,36 @@ from tensorflow.keras import backend
 from tensorflow.keras import layers
 
 from keras_cv.models import utils
+
+MODEL_CONFIGS = {
+    "ConvMixer_1536_20": {
+        "dim": 1536,
+        "depth": 20,
+        "patch_size": 7,
+        "kernel_size": 9
+    },
+    "ConvMixer_1536_24": {
+        "dim": 1536,
+        "depth": 24,
+        "patch_size": 14,
+        "kernel_size": 9,
+    },
+    "ConvMixer_768_32": {
+        "dim": 768,
+        "depth": 32,
+        "patch_size": 7,
+        "kernel_size": 7,
+    },
+    "ConvMixer_1024_16": {
+        "dim": 1024,
+        "depth": 16,
+        "patch_size": 7,
+        "kernel_size": 9,
+    },
+    "ConvMixer_512_16": {
+        "dim": 512,
+        "depth": 16,
+        "patch_size": 7,
+        "kernel_size": 8,
+    },
+}

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -1,0 +1,20 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import tensorflow as tf
+from tensorflow.keras import backend
+from tensorflow.keras import layers
+
+from keras_cv.models import utils

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 
+"""ConvMixer models for Keras.
+
+References:
+- [Patches Are All You Need?](https://arxiv.org/abs/2201.09792)
+"""
+
 import tensorflow as tf
 from tensorflow.keras import backend
 from tensorflow.keras import layers

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -57,3 +57,25 @@ MODEL_CONFIGS = {
         "kernel_size": 8,
     },
 }
+
+def CovnMixer_Layer(inputs, dim, kernel_size):
+    """CovnMixer Layer.
+    Args:
+        inputs: Input tensor.
+        dim: integer, filters of the layer in a block.
+        kernel_size: integer, kernel size of the Conv2d layers.
+    Returns:
+        Output tensor for the CovnMixer Layer.
+    """
+    residual = inputs
+    x = tf.keras.layers.DepthwiseConv2D(kernel_size = kernel_size, padding="same")(
+        inputs
+    )
+    x = tf.nn.gelu(x)
+    x = tf.keras.layers.BatchNormalization()(x)
+    x = tf.keras.layers.Add()([x, residual])
+
+    x = tf.keras.layers.Conv2D(dim, kernel_size=1)(x)
+    x = tf.nn.gelu(x)
+    x = tf.keras.layers.BatchNormalization()(x)
+    return x

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -89,9 +89,7 @@ def patch_embed(dim, patch_size):
     """
 
     def apply(x):
-        x = layers.Conv2D(
-            filters=dim, kernel_size=patch_size, strides=patch_size
-        )(x)
+        x = layers.Conv2D(filters=dim, kernel_size=patch_size, strides=patch_size)(x)
         x = tf.nn.gelu(x)
         x = layers.BatchNormalization()(x)
         return x

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -26,12 +26,7 @@ from tensorflow.keras import layers
 from keras_cv.models import utils
 
 MODEL_CONFIGS = {
-    "ConvMixer_1536_20": {
-        "dim": 1536,
-        "depth": 20,
-        "patch_size": 7,
-        "kernel_size": 9
-    },
+    "ConvMixer_1536_20": {"dim": 1536, "depth": 20, "patch_size": 7, "kernel_size": 9},
     "ConvMixer_1536_24": {
         "dim": 1536,
         "depth": 24,
@@ -58,6 +53,7 @@ MODEL_CONFIGS = {
     },
 }
 
+
 def CovnMixer_Layer(inputs, dim, kernel_size):
     """CovnMixer Layer.
     Args:
@@ -68,9 +64,7 @@ def CovnMixer_Layer(inputs, dim, kernel_size):
         Output tensor for the CovnMixer Layer.
     """
     residual = inputs
-    x = tf.keras.layers.DepthwiseConv2D(kernel_size = kernel_size, padding="same")(
-        inputs
-    )
+    x = tf.keras.layers.DepthwiseConv2D(kernel_size=kernel_size, padding="same")(inputs)
     x = tf.nn.gelu(x)
     x = tf.keras.layers.BatchNormalization()(x)
     x = tf.keras.layers.Add()([x, residual])
@@ -117,7 +111,7 @@ def ConvMixer(
         dim: number of filters.
         depth: number of CovnMixer Layer.
         patch_size: Size of the patches.
-        kernel_size: kernel size for conv2d layers. 
+        kernel_size: kernel size for conv2d layers.
         include_rescaling: whether or not to Rescale the inputs. If set to True,
             inputs will be passed through a `Rescaling(1/255.0)` layer.
             name: string, model name.
@@ -227,6 +221,7 @@ def ConvMixer_1536_20(
         classifier_activation=classifier_activation,
         **kwargs,
     )
+
 
 def ConvMixer_1536_24(
     include_rescaling,

--- a/keras_cv/models/convmixer_test.py
+++ b/keras_cv/models/convmixer_test.py
@@ -28,7 +28,7 @@ MODEL_LIST = [
 ]
 
 
-class ConvNeXtTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+class ConvMixerTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(*MODEL_LIST)
     def test_application_base(self, app, _, args):
         super()._test_application_base(app, _, args)

--- a/keras_cv/models/convmixer_test.py
+++ b/keras_cv/models/convmixer_test.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.models import convmixer
+
+from .models_test import ModelsTest
+
+MODEL_LIST = [
+    (
+        convmixer.ConvMixer_1024_16,
+        1024,
+        {},
+    ),
+]
+
+
+class ConvNeXtTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_base(self, app, _, args):
+        super()._test_application_base(app, _, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_with_rescaling(self, app, last_dim, args):
+        super()._test_application_with_rescaling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_pooling(self, app, last_dim, args):
+        super()._test_application_pooling(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_application_variable_input_channels(self, app, last_dim, args):
+        super()._test_application_variable_input_channels(app, last_dim, args)
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
+        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
+
+
+if __name__ == "__main__":
+    tf.test.main()


### PR DESCRIPTION
# What does this PR do?
 Based on this discussion : https://github.com/keras-team/keras-cv/discussions/52#discussioncomment-2053458

Paper : https://arxiv.org/abs/2201.09792

ConvMixer is Similar to MLP-Mixer. MLP-Mixer separates mixing of spatial and channel dimensions, by applying an MLP across spatial dimension and then an MLP across the channel dimension (spatial MLP replaces the ViT attention and channel MLP is the FFN of ViT).

ConvMixer, an extremely simple model that is similar in spirit to the ViT and the even-more-basic MLP-Mixer in that it operates directly on patches as input, separates the mixing of spatial and channel dimensions, and maintains equal size and resolution throughout the network. In contrast, however, the ConvMixer uses only standard convolutions to achieve the mixing steps. Despite its simplicity, ConvMixer outperforms the ViT, MLP-Mixer

![Capture](https://user-images.githubusercontent.com/88665786/212589213-4335b368-346c-4683-92b9-4c94880d408b.PNG)

@tanzhenyu @LukeWood @bhack @ianstenbit 
