### PR TITLE
Fix the pascal VOC loader to use the dictionary format

### DIFF
--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -16,7 +16,6 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 from keras_cv import bounding_box
-from keras_cv import layers as cv_layers
 
 
 def curry_map_function(bounding_box_format):

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -71,6 +71,7 @@ def load(
         shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
         dataset: (Optional) the PascalVOC dataset to load from.  Should be either
             `voc/2007` or `voc/2012`.
+
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing
         keys {"images": images, "bounding_boxes": bounding_boxes} where images is a

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -70,7 +70,7 @@ def load(
         shuffle_buffer: the size of the buffer to use in shuffling.
         shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
         dataset: (Optional) the PascalVOC dataset to load from.  Should be either
-            `voc/2007` or `voc/2012`.
+            'voc/2007' or 'voc/2012'. Defaults to 'voc/2007'.
 
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -69,7 +69,8 @@ def load(
         shuffle: whether or not to shuffle the dataset.  Defaults to True.
         shuffle_buffer: the size of the buffer to use in shuffling.
         shuffle_files: (Optional) whether or not to shuffle files, defaults to True.
-
+        dataset: (Optional) the PascalVOC dataset to load from.  Should be either
+            `voc/2007` or `voc/2012`.
     Returns:
         tf.data.Dataset containing PascalVOC.  Each entry is a dictionary containing
         keys {"images": images, "bounding_boxes": bounding_boxes} where images is a


### PR DESCRIPTION
also makes some other small API updates:

- remove img_size argument, this should be done by users using their own Resizing layer
- add support for 2012 split so we can replicate SOTA results