### PR TITLE
Make `include_rescaling` and `include_top`  required positionals

### DIFF
--- a/keras_cv/models/convnext.py
+++ b/keras_cv/models/convnext.py
@@ -386,6 +386,7 @@ def ConvNeXt(
 
 
 def ConvNeXtTiny(
+    *,
     include_rescaling,
     include_top,
     drop_path_rate,
@@ -416,6 +417,7 @@ def ConvNeXtTiny(
 
 
 def ConvNeXtSmall(
+    *,
     include_rescaling,
     include_top,
     drop_path_rate,
@@ -446,6 +448,7 @@ def ConvNeXtSmall(
 
 
 def ConvNeXtBase(
+    *,
     include_rescaling,
     include_top,
     drop_path_rate,
@@ -476,6 +479,7 @@ def ConvNeXtBase(
 
 
 def ConvNeXtLarge(
+    *,
     include_rescaling,
     include_top,
     drop_path_rate,
@@ -506,6 +510,7 @@ def ConvNeXtLarge(
 
 
 def ConvNeXtXLarge(
+    *,
     include_rescaling,
     include_top,
     drop_path_rate,

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -253,6 +253,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
 
 
 def CSPDarkNetTiny(
+    *,
     include_rescaling,
     include_top,
     use_depthwise=False,
@@ -283,6 +284,7 @@ def CSPDarkNetTiny(
 
 
 def CSPDarkNetS(
+    *,
     include_rescaling,
     include_top,
     use_depthwise=False,
@@ -313,6 +315,7 @@ def CSPDarkNetS(
 
 
 def CSPDarkNetM(
+    *,
     include_rescaling,
     include_top,
     use_depthwise=False,
@@ -343,6 +346,7 @@ def CSPDarkNetM(
 
 
 def CSPDarkNetL(
+    *,
     include_rescaling,
     include_top,
     use_depthwise=False,
@@ -373,6 +377,7 @@ def CSPDarkNetL(
 
 
 def CSPDarkNetX(
+    *,
     include_rescaling,
     include_top,
     use_depthwise=False,

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -209,6 +209,7 @@ def DarkNet(
 
 
 def DarkNet21(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -234,6 +235,7 @@ def DarkNet21(
 
 
 def DarkNet53(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -252,6 +252,7 @@ def DenseNet(
 
 
 def DenseNet121(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -277,6 +278,7 @@ def DenseNet121(
 
 
 def DenseNet169(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -302,6 +304,7 @@ def DenseNet169(
 
 
 def DenseNet201(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/efficientnet_lite.py
+++ b/keras_cv/models/efficientnet_lite.py
@@ -492,6 +492,7 @@ def EfficientNetLite(
 
 
 def EfficientNetLiteB0(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -521,6 +522,7 @@ def EfficientNetLiteB0(
 
 
 def EfficientNetLiteB1(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -550,6 +552,7 @@ def EfficientNetLiteB1(
 
 
 def EfficientNetLiteB2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -579,6 +582,7 @@ def EfficientNetLiteB2(
 
 
 def EfficientNetLiteB3(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -608,6 +612,7 @@ def EfficientNetLiteB3(
 
 
 def EfficientNetLiteB4(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/efficientnet_v1.py
+++ b/keras_cv/models/efficientnet_v1.py
@@ -506,6 +506,7 @@ def EfficientNet(
 
 
 def EfficientNetB0(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -535,6 +536,7 @@ def EfficientNetB0(
 
 
 def EfficientNetB1(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -564,6 +566,7 @@ def EfficientNetB1(
 
 
 def EfficientNetB2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -593,6 +596,7 @@ def EfficientNetB2(
 
 
 def EfficientNetB3(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -622,6 +626,7 @@ def EfficientNetB3(
 
 
 def EfficientNetB4(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -651,6 +656,7 @@ def EfficientNetB4(
 
 
 def EfficientNetB5(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -680,6 +686,7 @@ def EfficientNetB5(
 
 
 def EfficientNetB6(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -709,6 +716,7 @@ def EfficientNetB6(
 
 
 def EfficientNetB7(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/efficientnet_v2.py
+++ b/keras_cv/models/efficientnet_v2.py
@@ -823,6 +823,7 @@ def EfficientNetV2(
 
 
 def EfficientNetV2B0(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -851,6 +852,7 @@ def EfficientNetV2B0(
 
 
 def EfficientNetV2B1(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -879,6 +881,7 @@ def EfficientNetV2B1(
 
 
 def EfficientNetV2B2(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -907,6 +910,7 @@ def EfficientNetV2B2(
 
 
 def EfficientNetV2B3(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -935,6 +939,7 @@ def EfficientNetV2B3(
 
 
 def EfficientNetV2S(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -963,6 +968,7 @@ def EfficientNetV2S(
 
 
 def EfficientNetV2M(
+    *,
     include_rescaling,
     include_top,
     weights=None,
@@ -991,6 +997,7 @@ def EfficientNetV2M(
 
 
 def EfficientNetV2L(
+    *,
     include_rescaling,
     include_top,
     weights=None,

--- a/keras_cv/models/mlp_mixer.py
+++ b/keras_cv/models/mlp_mixer.py
@@ -267,6 +267,7 @@ def MLPMixer(
 
 def MLPMixerB16(
     input_shape,
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -298,6 +299,7 @@ def MLPMixerB16(
 
 def MLPMixerB32(
     input_shape,
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -328,6 +330,7 @@ def MLPMixerB32(
 
 def MLPMixerL16(
     input_shape,
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/mobilenet_v3.py
+++ b/keras_cv/models/mobilenet_v3.py
@@ -419,6 +419,7 @@ def MobileNetV3(
 
 
 def MobileNetV3Small(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -488,6 +489,7 @@ def MobileNetV3Small(
 
 
 def MobileNetV3Large(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/regnet.py
+++ b/keras_cv/models/regnet.py
@@ -799,6 +799,7 @@ def RegNet(
 
 
 def RegNetX002(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -829,6 +830,7 @@ def RegNetX002(
 
 
 def RegNetX004(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -859,6 +861,7 @@ def RegNetX004(
 
 
 def RegNetX006(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -889,6 +892,7 @@ def RegNetX006(
 
 
 def RegNetX008(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -919,6 +923,7 @@ def RegNetX008(
 
 
 def RegNetX016(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -949,6 +954,7 @@ def RegNetX016(
 
 
 def RegNetX032(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -979,6 +985,7 @@ def RegNetX032(
 
 
 def RegNetX040(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1009,6 +1016,7 @@ def RegNetX040(
 
 
 def RegNetX064(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1039,6 +1047,7 @@ def RegNetX064(
 
 
 def RegNetX080(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1069,6 +1078,7 @@ def RegNetX080(
 
 
 def RegNetX120(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1099,6 +1109,7 @@ def RegNetX120(
 
 
 def RegNetX160(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1129,6 +1140,7 @@ def RegNetX160(
 
 
 def RegNetX320(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1159,6 +1171,7 @@ def RegNetX320(
 
 
 def RegNetY002(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1189,6 +1202,7 @@ def RegNetY002(
 
 
 def RegNetY004(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1219,6 +1233,7 @@ def RegNetY004(
 
 
 def RegNetY006(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1249,6 +1264,7 @@ def RegNetY006(
 
 
 def RegNetY008(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1279,6 +1295,7 @@ def RegNetY008(
 
 
 def RegNetY016(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1309,6 +1326,7 @@ def RegNetY016(
 
 
 def RegNetY032(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1339,6 +1357,7 @@ def RegNetY032(
 
 
 def RegNetY040(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1369,6 +1388,7 @@ def RegNetY040(
 
 
 def RegNetY064(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1399,6 +1419,7 @@ def RegNetY064(
 
 
 def RegNetY080(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1429,6 +1450,7 @@ def RegNetY080(
 
 
 def RegNetY120(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1459,6 +1481,7 @@ def RegNetY120(
 
 
 def RegNetY160(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -1489,6 +1512,7 @@ def RegNetY160(
 
 
 def RegNetY320(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -364,6 +364,7 @@ def ResNet(
 
 
 def ResNet18(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -396,6 +397,7 @@ def ResNet18(
 
 
 def ResNet34(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -428,6 +430,7 @@ def ResNet34(
 
 
 def ResNet50(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -459,6 +462,7 @@ def ResNet50(
 
 
 def ResNet101(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -489,6 +493,7 @@ def ResNet101(
 
 
 def ResNet152(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -412,6 +412,7 @@ def ResNetV2(
 
 
 def ResNet18V2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -444,6 +445,7 @@ def ResNet18V2(
 
 
 def ResNet34V2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -476,6 +478,7 @@ def ResNet34V2(
 
 
 def ResNet50V2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -507,6 +510,7 @@ def ResNet50V2(
 
 
 def ResNet101V2(
+    *,
     include_rescaling,
     include_top,
     classes=None,
@@ -537,6 +541,7 @@ def ResNet101V2(
 
 
 def ResNet152V2(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/vgg16.py
+++ b/keras_cv/models/vgg16.py
@@ -26,6 +26,7 @@ from keras_cv.models import utils
 
 
 def VGG16(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -27,6 +27,7 @@ from keras_cv.models import utils
 
 
 def VGG19(
+    *,
     include_rescaling,
     include_top,
     classes=None,

--- a/keras_cv/models/vit.py
+++ b/keras_cv/models/vit.py
@@ -310,6 +310,7 @@ def ViT(
 
 
 def ViTTiny16(
+    *,
     include_rescaling,
     include_top,
     name="ViTTiny16",
@@ -347,6 +348,7 @@ def ViTTiny16(
 
 
 def ViTS16(
+    *,
     include_rescaling,
     include_top,
     name="ViTS16",
@@ -384,6 +386,7 @@ def ViTS16(
 
 
 def ViTB16(
+    *,
     include_rescaling,
     include_top,
     name="ViTB16",
@@ -421,6 +424,7 @@ def ViTB16(
 
 
 def ViTL16(
+    *,
     include_rescaling,
     include_top,
     name="ViTL16",
@@ -458,6 +462,7 @@ def ViTL16(
 
 
 def ViTH16(
+    *,
     include_rescaling,
     include_top,
     name="ViTH16",
@@ -495,6 +500,7 @@ def ViTH16(
 
 
 def ViTTiny32(
+    *,
     include_rescaling,
     include_top,
     name="ViTTiny32",
@@ -532,6 +538,7 @@ def ViTTiny32(
 
 
 def ViTS32(
+    *,
     include_rescaling,
     include_top,
     name="ViTS32",
@@ -569,6 +576,7 @@ def ViTS32(
 
 
 def ViTB32(
+    *,
     include_rescaling,
     include_top,
     name="ViTB32",
@@ -606,6 +614,7 @@ def ViTB32(
 
 
 def ViTL32(
+    *,
     include_rescaling,
     include_top,
     name="ViTL32",
@@ -643,6 +652,7 @@ def ViTL32(
 
 
 def ViTH32(
+    *,
     include_rescaling,
     include_top,
     name="ViTH32",


### PR DESCRIPTION
to quickly describe why one is better:

```
ResNet50V2(True, False)
# OR
ResNet50V2(include_rescaling=True, include_top=False)
```