### PR TITLE
Fixed a small error in the RetinaNet training script

### DIFF
--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -225,10 +225,10 @@ def proc_train_fn(bounding_box_format, img_size):
         gt_classes = tf.cast(inputs["objects"]["label"], tf.float32)
         image, gt_boxes, gt_classes = resize_fn(image, gt_boxes, gt_classes)
         gt_classes = tf.expand_dims(gt_classes, axis=-1)
-        bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
         bounding_boxes = keras_cv.bounding_box.convert_format(
-            bounding_boxes, images=image, source="yxyx", target=bounding_box_format
+            gt_boxes, images=image, source="yxyx", target=bounding_box_format
         )
+        bounding_boxes = tf.concat([gt_boxes, gt_classes], axis=-1)
         return image, bounding_boxes
 
     return apply


### PR DESCRIPTION
# What does this PR do?
Since the update to `converters.py` with the new dict format, this has been failing. Updated this.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
