### PR TITLE
Added missing name to DarknetConvBlock variables.

### DIFF
--- a/keras_cv/models/__internal__/darknet_utils.py
+++ b/keras_cv/models/__internal__/darknet_utils.py
@@ -54,8 +54,9 @@ def DarknetConvBlock(
             strides,
             padding="same",
             use_bias=use_bias,
+            name=name + "_conv",
         ),
-        layers.BatchNormalization(),
+        layers.BatchNormalization(name=name + "_bn"),
     ]
 
     if activation == "silu":


### PR DESCRIPTION
Fixes #1297 

I thought that changing variable names will break existing weights but it looks like they load ok - tested for DarkNet53.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @quantumalaviya 