### PR TITLE
[3D Object Detection] Rename GlobalRandomFlipY -> GlobalRandomFlip

### DIFF
--- a/examples/training/object_detection_3d/waymo/train_pillars.py
+++ b/examples/training/object_detection_3d/waymo/train_pillars.py
@@ -71,7 +71,7 @@ print(f"train ds element spec {train_ds.element_spec}")
 
 # Augment the training data
 AUGMENTATION_LAYERS = [
-    preprocessing3d.GlobalRandomFlipY(),
+    preprocessing3d.GlobalRandomFlip(),
     preprocessing3d.GlobalRandomDroppingPoints(drop_rate=0.02),
     preprocessing3d.GlobalRandomRotation(max_rotation_angle_x=3.14),
     preprocessing3d.GlobalRandomScaling(scaling_factor_z=(0.5, 1.5)),

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -83,7 +83,7 @@ from keras_cv.layers.preprocessing_3d.frustum_random_point_feature_noise import 
 from keras_cv.layers.preprocessing_3d.global_random_dropping_points import (
     GlobalRandomDroppingPoints,
 )
-from keras_cv.layers.preprocessing_3d.global_random_flip_y import GlobalRandomFlipY
+from keras_cv.layers.preprocessing_3d.global_random_flip import GlobalRandomFlip
 from keras_cv.layers.preprocessing_3d.global_random_rotation import GlobalRandomRotation
 from keras_cv.layers.preprocessing_3d.global_random_scaling import GlobalRandomScaling
 from keras_cv.layers.preprocessing_3d.global_random_translation import (

--- a/keras_cv/layers/preprocessing_3d/__init__.py
+++ b/keras_cv/layers/preprocessing_3d/__init__.py
@@ -24,7 +24,7 @@ from keras_cv.layers.preprocessing_3d.frustum_random_point_feature_noise import 
 from keras_cv.layers.preprocessing_3d.global_random_dropping_points import (
     GlobalRandomDroppingPoints,
 )
-from keras_cv.layers.preprocessing_3d.global_random_flip_y import GlobalRandomFlipY
+from keras_cv.layers.preprocessing_3d.global_random_flip import GlobalRandomFlip
 from keras_cv.layers.preprocessing_3d.global_random_rotation import GlobalRandomRotation
 from keras_cv.layers.preprocessing_3d.global_random_scaling import GlobalRandomScaling
 from keras_cv.layers.preprocessing_3d.global_random_translation import (

--- a/keras_cv/layers/preprocessing_3d/global_random_flip.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip.py
@@ -23,10 +23,11 @@ BOUNDING_BOXES = base_augmentation_layer_3d.BOUNDING_BOXES
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
-class GlobalRandomFlipY(base_augmentation_layer_3d.BaseAugmentationLayer3D):
-    """A preprocessing layer which flips point clouds and bounding boxes with respect to the X axis during training.
+class GlobalRandomFlip(base_augmentation_layer_3d.BaseAugmentationLayer3D):
+    """A preprocessing layer which flips point clouds and bounding boxes with respect to the specified axis during training.
 
-    This layer will flip the whole scene with respect to the X axis.
+    This layer will flip the whole scene with respect to the specified axis.
+    Note that this layer currently only supports flipping over axis 1 (Y axis in the CENTER_XYZ_DXDYDZ_PHI format).
     During inference time, the output will be identical to input. Call the layer with `training=True` to flip the input.
 
     Input shape:
@@ -44,11 +45,15 @@ class GlobalRandomFlipY(base_augmentation_layer_3d.BaseAugmentationLayer3D):
 
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, axis=1, **kwargs):
+        if axis != 1:
+            raise ValueError(
+                "GlobalRandomFlip currently only supports flipping over axis 1 "
+                f"(the Y axis in CENTER_XYZ_DXDYDZ_PHI). Received axis={axis}."
+            )
+        self.axis = axis
 
-    def get_config(self):
-        return {}
+        super().__init__(**kwargs)
 
     def augment_point_clouds_bounding_boxes(
         self, point_clouds, bounding_boxes, transformation, **kwargs
@@ -93,3 +98,8 @@ class GlobalRandomFlipY(base_augmentation_layer_3d.BaseAugmentationLayer3D):
         )
 
         return (point_clouds, bounding_boxes)
+
+    def get_config(self):
+        return {
+            "axis": self.axis,
+        }

--- a/keras_cv/layers/preprocessing_3d/global_random_flip.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip.py
@@ -26,8 +26,8 @@ BOUNDING_BOXES = base_augmentation_layer_3d.BOUNDING_BOXES
 class GlobalRandomFlip(base_augmentation_layer_3d.BaseAugmentationLayer3D):
     """A preprocessing layer which flips point clouds and bounding boxes with respect to the specified axis during training.
 
-    This layer will flip the whole scene with respect to the specified axis.
-    Note that this layer currently only supports flipping over axis 1 (Y axis in the CENTER_XYZ_DXDYDZ_PHI format).
+    This layer will flip the whole scene with respect to the specified axes.
+    Note that this layer currently only supports flipping over the Y axis.
     During inference time, the output will be identical to input. Call the layer with `training=True` to flip the input.
 
     Input shape:
@@ -43,15 +43,24 @@ class GlobalRandomFlip(base_augmentation_layer_3d.BaseAugmentationLayer3D):
     Output shape:
       A dictionary of Tensors with the same shape as input Tensors.
 
+    Args:
+      flip_x: Whether or not to flip over the X axis. Defaults to False.
+      flip_y: Whether or not to flip over the Y axis. Defaults to True.
+      flip_z: Whether or not to flip over the Z axis. Defaults to False.
     """
 
-    def __init__(self, axis=1, **kwargs):
-        if axis != 1:
+    def __init__(self, flip_x=False, flip_y=True, flip_z=False, **kwargs):
+        if flip_x or flip_z:
             raise ValueError(
-                "GlobalRandomFlip currently only supports flipping over axis 1 "
-                f"(the Y axis in CENTER_XYZ_DXDYDZ_PHI). Received axis={axis}."
+                "GlobalRandomFlip currently only supports flipping over the Y "
+                f"axis. Received flip_x={flip_x}, flip_y={flip_y}, flip_z={flip_z}."
             )
-        self.axis = axis
+
+        if not (flip_x or flip_y or flip_z):
+            raise ValueError("GlobalRandomFlip must flip over at least 1 axis.")
+        self.flip_x = flip_x
+        self.flip_y = flip_y
+        self.flip_z = flip_z
 
         super().__init__(**kwargs)
 
@@ -101,5 +110,7 @@ class GlobalRandomFlip(base_augmentation_layer_3d.BaseAugmentationLayer3D):
 
     def get_config(self):
         return {
-            "axis": self.axis,
+            "flip_x": self.flip_x,
+            "flip_y": self.flip_y,
+            "flip_z": self.flip_z,
         }

--- a/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
@@ -55,3 +55,14 @@ class GlobalRandomFlipTest(tf.test.TestCase):
         inputs = {POINT_CLOUDS: point_clouds, BOUNDING_BOXES: bounding_boxes}
         outputs = add_layer(inputs)
         self.assertNotAllClose(inputs, outputs)
+
+    def test_noop_raises_error(self):
+        with self.assertRaisesRegexp(ValueError, "must flip over at least 1 axis"):
+            _ = GlobalRandomFlip(flip_x=False, flip_y=False, flip_z=False)
+
+    def test_flip_x_or_z_raises_error(self):
+        with self.assertRaisesRegexp(ValueError, "only supports flipping over the Y"):
+            _ = GlobalRandomFlip(flip_x=True, flip_y=False, flip_z=False)
+
+        with self.assertRaisesRegexp(ValueError, "only supports flipping over the Y"):
+            _ = GlobalRandomFlip(flip_x=False, flip_y=False, flip_z=True)

--- a/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
@@ -15,15 +15,15 @@ import numpy as np
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing_3d import base_augmentation_layer_3d
-from keras_cv.layers.preprocessing_3d.global_random_flip_y import GlobalRandomFlipY
+from keras_cv.layers.preprocessing_3d.global_random_flip import GlobalRandomFlip
 
 POINT_CLOUDS = base_augmentation_layer_3d.POINT_CLOUDS
 BOUNDING_BOXES = base_augmentation_layer_3d.BOUNDING_BOXES
 
 
-class GlobalFlippingYTest(tf.test.TestCase):
+class GlobalFlippingTest(tf.test.TestCase):
     def test_augment_random_point_clouds_and_bounding_boxes(self):
-        add_layer = GlobalRandomFlipY()
+        add_layer = GlobalRandomFlip()
         point_clouds = np.random.random(size=(2, 50, 10)).astype("float32")
         bounding_boxes = np.random.random(size=(2, 10, 7)).astype("float32")
         inputs = {POINT_CLOUDS: point_clouds, BOUNDING_BOXES: bounding_boxes}
@@ -31,7 +31,7 @@ class GlobalFlippingYTest(tf.test.TestCase):
         self.assertNotAllClose(inputs, outputs)
 
     def test_augment_specific_random_point_clouds_and_bounding_boxes(self):
-        add_layer = GlobalRandomFlipY()
+        add_layer = GlobalRandomFlip()
         point_clouds = np.array([[[1, 1, 2, 3, 4, 5, 6, 7, 8, 9]] * 2] * 2).astype(
             "float32"
         )
@@ -49,7 +49,7 @@ class GlobalFlippingYTest(tf.test.TestCase):
         self.assertAllClose(outputs[BOUNDING_BOXES], flipped_bounding_boxes)
 
     def test_augment_batch_point_clouds_and_bounding_boxes(self):
-        add_layer = GlobalRandomFlipY()
+        add_layer = GlobalRandomFlip()
         point_clouds = np.random.random(size=(3, 2, 50, 10)).astype("float32")
         bounding_boxes = np.random.random(size=(3, 2, 10, 7)).astype("float32")
         inputs = {POINT_CLOUDS: point_clouds, BOUNDING_BOXES: bounding_boxes}

--- a/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
@@ -21,7 +21,7 @@ POINT_CLOUDS = base_augmentation_layer_3d.POINT_CLOUDS
 BOUNDING_BOXES = base_augmentation_layer_3d.BOUNDING_BOXES
 
 
-class GlobalFlippingTest(tf.test.TestCase):
+class GlobalRandomFlipTest(tf.test.TestCase):
     def test_augment_random_point_clouds_and_bounding_boxes(self):
         add_layer = GlobalRandomFlip()
         point_clouds = np.random.random(size=(2, 50, 10)).astype("float32")

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -329,8 +329,8 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
             {"drop_rate": 0.1},
         ),
         (
-            "GlobalRandomFlipY",
-            cv_layers.GlobalRandomFlipY,
+            "GlobalRandomFlip",
+            cv_layers.GlobalRandomFlip,
             {},
         ),
         (


### PR DESCRIPTION
The layer still only supports Y-flipping, but now has a more consistent API surface compared to similar 2D layers