### PR TITLE
[Custom ops] Update docs + build without custom ops by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Bazel Build
       if: ${{ ! matrix.use-macos-arm }}
       run: |
+        export BUILD_WITH_CUSTOM_OPS=true
         bazel build build_pip_pkg
     - name: Bazel Build (MacOS ARM)
       if: ${{ matrix.use-macos-arm}}
@@ -71,6 +72,7 @@ jobs:
         bazel build --cpu=darwin_arm64 --copt -mmacosx-version-min=12.0 --linkopt -mmacosx-version-min=12.0 build_pip_pkg
     - name: Build wheels
       run: |
+        export BUILD_WITH_CUSTOM_OPS=true
         bazel-bin/build_pip_pkg wheels
     - name: Repair wheels (manylinux)
       if: ${{ matrix.os == 'ubuntu-18.04' }}

--- a/README.md
+++ b/README.md
@@ -66,23 +66,6 @@ Thank you to all of our wonderful contributors!
   <img src="https://contrib.rocks/image?repo=keras-team/keras-cv" />
 </a>
 
-
-## Installing Custom Ops from Source
-Installing from source requires the [Bazel](https://bazel.build/) build system
-(version >= 1.0.0).
-
-```
-git clone https://github.com/keras-team/keras-cv.git
-cd keras-cv
-
-python3 build_deps/configure.py
-
-bazel build build_pip_pkg
-bazel-bin/build_pip_pkg wheels
-
-pip install wheels/keras_cv-*.whl
-```
-
 ## Pretrained Weights
 Many models in KerasCV come with pre-trained weights. With the exception of StableDiffusion,
 all of these weights are trained using Keras and KerasCV components and training scripts in this
@@ -92,6 +75,36 @@ in the training history for each task. For example, see ImageNet classification 
 history for backbone models [here](examples/training/classification/imagenet/training_history.json).
 All results are reproducible using the training scripts in this repository. Pre-trained weights
 operate on images that have been rescaled using a simple `1/255` rescaling layer.
+
+## Custom Ops
+Note that in some the 3D Object Detection layers, custom TF ops are used. The
+binaries for these ops are not shipped in our PyPi package in order to keep our
+wheels pure-Python.
+
+If you'd like to use these custom ops, you can install from source using the
+instructions below.
+
+### Installing KerasCV with Custom Ops from Source
+Installing from source requires the [Bazel](https://bazel.build/) build system
+(version >= 5.4.0).
+
+```
+git clone https://github.com/keras-team/keras-cv.git
+cd keras-cv
+
+python3 build_deps/configure.py
+
+bazel build build_pip_pkg
+export BUILD_WITH_CUSTOM_OPS=true
+bazel-bin/build_pip_pkg wheels
+
+pip install wheels/keras_cv-*.whl
+```
+
+Note that GitHub actions exist to release KerasCV with custom ops, but are
+currently disabled. You can use these [actions](https://github.com/keras-team/keras-cv/blob/master/.github/workflows/release.yml)
+in your own fork to create wheels for Linux (manylinux2014), MacOS (both x86 and ARM),
+and Windows.
 
 ## Disclaimer
 
@@ -109,7 +122,7 @@ Here is the BibTeX entry:
 ```bibtex
 @misc{wood2022kerascv,
   title={KerasCV},
-  author={Wood, Luke and Tan, Zhenyu and Ian, Stenbit and Zhu, Scott and Chollet, Fran\c{c}ois and others},
+  author={Wood, Luke and Tan, Zhenyu and Stenbit, Ian and Zhu, Scott and Chollet, Fran\c{c}ois and others},
   year={2022},
   howpublished={\url{https://github.com/keras-team/keras-cv}},
 }

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ from setuptools import find_packages
 from setuptools import setup
 from setuptools.dist import Distribution
 
-BUILD_WITH_CUSTOM_OPS = not (
+BUILD_WITH_CUSTOM_OPS = (
     "BUILD_WITH_CUSTOM_OPS" in os.environ
-    and os.environ["BUILD_WITH_CUSTOM_OPS"] == "false"
+    and os.environ["BUILD_WITH_CUSTOM_OPS"] == "true"
 )
 
 HERE = pathlib.Path(__file__).parent


### PR DESCRIPTION
Our GitHub actions can still create+publish wheels with custom ops, but now our setup.py defaults to ignoring custom ops.

This also moves discussion of custom ops to a lower spot in the README.

Fixes #1307 