### PR TITLE
Remove extra models from CI tests for ViT

### DIFF
--- a/keras_cv/models/vit_test.py
+++ b/keras_cv/models/vit_test.py
@@ -22,7 +22,7 @@ from .models_test import ModelsTest
 MODEL_LIST = [
     (vit.ViTS16, 384, {"input_shape": (224, 224, 3)}),
 ]
-    
+ 
 """
 Below are other configurations that we omit from our CI but that can/should
 be tested manually when making changes to this model.

--- a/keras_cv/models/vit_test.py
+++ b/keras_cv/models/vit_test.py
@@ -36,7 +36,6 @@ be tested manually when making changes to this model.
 (vit.ViTL32, 1024, {"input_shape": (224, 224, 3)}),
 (vit.ViTH32, 1280, {"input_shape": (224, 224, 3)}),
 """
-    
 
 
 class ViTTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):

--- a/keras_cv/models/vit_test.py
+++ b/keras_cv/models/vit_test.py
@@ -20,17 +20,22 @@ from keras_cv.models import vit
 from .models_test import ModelsTest
 
 MODEL_LIST = [
-    (vit.ViTTiny16, 192, {"input_shape": (224, 224, 3)}),
     (vit.ViTS16, 384, {"input_shape": (224, 224, 3)}),
-    (vit.ViTB16, 768, {"input_shape": (224, 224, 3)}),
-    (vit.ViTL16, 1024, {"input_shape": (224, 224, 3)}),
-    (vit.ViTH16, 1280, {"input_shape": (224, 224, 3)}),
-    (vit.ViTTiny32, 192, {"input_shape": (224, 224, 3)}),
-    (vit.ViTS32, 384, {"input_shape": (224, 224, 3)}),
-    (vit.ViTB32, 768, {"input_shape": (224, 224, 3)}),
-    (vit.ViTL32, 1024, {"input_shape": (224, 224, 3)}),
-    (vit.ViTH32, 1280, {"input_shape": (224, 224, 3)}),
 ]
+    
+"""
+Below are other configurations that we omit from our CI but that can/should
+be tested manually when making changes to this model.
+(vit.ViTB16, 768, {"input_shape": (224, 224, 3)}),
+(vit.ViTL16, 1024, {"input_shape": (224, 224, 3)}),
+(vit.ViTH16, 1280, {"input_shape": (224, 224, 3)}),
+(vit.ViTTiny32, 192, {"input_shape": (224, 224, 3)}),
+(vit.ViTS32, 384, {"input_shape": (224, 224, 3)}),
+(vit.ViTB32, 768, {"input_shape": (224, 224, 3)}),
+(vit.ViTL32, 1024, {"input_shape": (224, 224, 3)}),
+(vit.ViTH32, 1280, {"input_shape": (224, 224, 3)}),
+"""
+    
 
 
 class ViTTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):

--- a/keras_cv/models/vit_test.py
+++ b/keras_cv/models/vit_test.py
@@ -26,6 +26,7 @@ MODEL_LIST = [
 """
 Below are other configurations that we omit from our CI but that can/should
 be tested manually when making changes to this model.
+(vit.ViTTiny16, 192, {"input_shape": (224, 224, 3)}),
 (vit.ViTB16, 768, {"input_shape": (224, 224, 3)}),
 (vit.ViTL16, 1024, {"input_shape": (224, 224, 3)}),
 (vit.ViTH16, 1280, {"input_shape": (224, 224, 3)}),

--- a/keras_cv/models/vit_test.py
+++ b/keras_cv/models/vit_test.py
@@ -22,7 +22,7 @@ from .models_test import ModelsTest
 MODEL_LIST = [
     (vit.ViTS16, 384, {"input_shape": (224, 224, 3)}),
 ]
- 
+
 """
 Below are other configurations that we omit from our CI but that can/should
 be tested manually when making changes to this model.


### PR DESCRIPTION
This is consistent with how we're doing CI for other models to avoid running tons of expensive and redundant tests