### PR TITLE
Support pure-dictionary input format for OD models

### DIFF
--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -27,6 +27,7 @@ local unittest = base.BaseTest {
       bazel-5.4.0 build keras_cv/custom_ops:all --verbose_failures
       cp bazel-bin/keras_cv/custom_ops/*.so keras_cv/custom_ops/
       export TEST_CUSTOM_OPS=true
+      export INTEGRATION=true
 
       # Run whatever is in `command` here.
       ${@:0}

--- a/keras_cv/models/object_detection/__internal__.py
+++ b/keras_cv/models/object_detection/__internal__.py
@@ -24,6 +24,13 @@ except ImportError:
     pd = None
 
 
+def unpack_input(data):
+    if type(data) is dict:
+        return data["images"], data["bounding_boxes"]
+    else:
+        return data
+
+
 def _get_tensor_types():
     if pd is None:
         return (tf.Tensor, np.ndarray)

--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -27,6 +27,7 @@ from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
 from keras_cv.models.object_detection import predict_utils
+from keras_cv.models.object_detection.__internal__ import unpack_input
 
 BOX_VARIANCE = [0.1, 0.1, 0.2, 0.2]
 
@@ -487,9 +488,8 @@ class FasterRCNN(tf.keras.Model):
         )
 
     def train_step(self, data):
-        images, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
-        if sample_weight is not None:
-            raise ValueError("`sample_weight` is currently not supported.")
+        images, y = unpack_input(data)
+
         boxes = y["boxes"]
         if len(y["classes"].shape) != 2:
             raise ValueError(
@@ -511,9 +511,8 @@ class FasterRCNN(tf.keras.Model):
         return self.compute_metrics(images, {}, {}, sample_weight={})
 
     def test_step(self, data):
-        images, y, sample_weight = tf.keras.utils.unpack_x_y_sample_weight(data)
-        if sample_weight is not None:
-            raise ValueError("`sample_weight` is currently not supported.")
+        images, y = unpack_input(data)
+
         boxes = y["boxes"]
         if len(y["classes"].shape) != 2:
             raise ValueError(

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -21,6 +21,7 @@ from keras_cv import bounding_box
 from keras_cv import layers as cv_layers
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.models.object_detection import predict_utils
+from keras_cv.models.object_detection.__internal__ import unpack_input
 from keras_cv.models.object_detection.retina_net.__internal__ import (
     layers as layers_lib,
 )
@@ -365,7 +366,8 @@ class RetinaNet(tf.keras.Model):
         )
 
     def train_step(self, data):
-        x, y = data
+        x, y = unpack_input(data)
+
         y = bounding_box.convert_format(
             y,
             source=self.bounding_box_format,
@@ -398,7 +400,8 @@ class RetinaNet(tf.keras.Model):
         return self.compute_metrics(x, {}, {}, sample_weight={})
 
     def test_step(self, data):
-        x, y = data
+        x, y = unpack_input(data)
+
         y = bounding_box.convert_format(
             y,
             source=self.bounding_box_format,

--- a/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_inference_test.py
@@ -22,11 +22,12 @@ import keras_cv
 
 
 @pytest.mark.skipif(
-    "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
-    reason="Takes a long time to run, only runs when INTEGRATION "
+    "REGRESSION" not in os.environ or os.environ["REGRESSION"] != "true",
+    reason="Takes a long time to run, only runs when REGRESSION "
     "environment variable is set.  To run the test please run: \n"
-    "`INTEGRATION=true pytest keras_cv/",
+    "`REGRESSION=true pytest keras_cv/",
 )
+# TODO(lukewood): Should we remove this test file entirely?
 class RetinaNetTest(tf.test.TestCase):
     @pytest.fixture(autouse=True)
     def cleanup_global_session(self):

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -226,5 +226,5 @@ class RetinaNetTest(tf.test.TestCase):
 
     def build_backbone(self):
         return keras_cv.models.ResNet50(
-            include_top=False, weights="imagenet", include_rescaling=False
+            include_top=False, include_rescaling=False
         ).as_backbone()

--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -88,10 +88,10 @@ class DeeplabTest(tf.test.TestCase):
             )
 
     @pytest.mark.skipif(
-        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
-        reason="Takes a long time to run, only runs when INTEGRATION "
+        "REGRESSION" not in os.environ or os.environ["REGRESSION"] != "true",
+        reason="Takes a long time to run, only runs when REGRESSION "
         "environment variable is set.  To run the test please run: \n"
-        "`INTEGRATION=true pytest keras_cv/",
+        "`REGRESSION=true pytest keras_cv/",
     )
     def test_model_train(self):
         backbone = models.ResNet50V2(


### PR DESCRIPTION
Fixes #1342

This also updates our GPU CI to actually run `INTEGRATION` tests, since our model tests are no longer so expensive that they time out the GPU tests. In order to do this, I had to add a separate `REGRESSION` control to two tests which are currently very expensive that don't belong in our CI.