### PR TITLE
Fixes weight loading for gs://

### DIFF
--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -15,7 +15,7 @@ from keras.utils import data_utils
 
 
 def parse_weights(weights, include_top, model_type):
-    if not weights or tf.io.gfile.exists(weights):
+    if not weights:
         return weights
     if weights.startswith("gs://"):
         weights = weights.replace("gs://", "https://storage.googleapis.com/")
@@ -23,6 +23,8 @@ def parse_weights(weights, include_top, model_type):
             origin=weights,
             cache_subdir="models",
         )
+    if tf.io.gfile.exists(weights):
+        return weights
     if weights in ALIASES[model_type]:
         weights = ALIASES[model_type][weights]
     if weights in WEIGHTS_CONFIG[model_type]:


### PR DESCRIPTION
tf.io.exists has a discrepency with the behavior of load_weights().  This causes an error when trying to load gs:// weights in some cases.