### PR TITLE
Add `tensorflow` to `test` requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             "black[jupyter]",
             "pytest",
             "pycocotools",
+            "tensorflow",
         ],
         "examples": ["tensorflow_datasets", "matplotlib"],
     },


### PR DESCRIPTION
Current contributor setup instructions ((link)[https://github.com/jbischof/keras-cv/blob/master/.github/CONTRIBUTING.md#setup-environment]) do not work for running `pytest` in a fresh environment because `tensorflow` is not required. Making this an explicit requirement.