### PR TITLE
Disable mixed-precision at end of deeplab MP test

### DIFF
--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -77,6 +77,7 @@ class DeeplabTest(tf.test.TestCase):
         output = model(input_image, training=True)
 
         self.assertEquals(output["output"].dtype, tf.float32)
+        tf.keras.mixed_precision.set_global_policy("float32")
 
     def test_invalid_backbone_model(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
Fixes #1364