### PR TITLE
Preparation for switch in Keras serialization format

### DIFF
--- a/keras_cv/core/factor_sampler/constant_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/constant_factor_sampler.py
@@ -42,3 +42,7 @@ class ConstantFactorSampler(FactorSampler):
 
     def get_config(self):
         return {"value": self.value}
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)

--- a/keras_cv/core/factor_sampler/normal_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/normal_factor_sampler.py
@@ -71,3 +71,7 @@ class NormalFactorSampler(FactorSampler):
             "max_value": self.max_value,
             "seed": self.seed,
         }
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)

--- a/keras_cv/core/factor_sampler/uniform_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/uniform_factor_sampler.py
@@ -52,3 +52,7 @@ class UniformFactorSampler(FactorSampler):
             "upper": self.upper,
             "seed": self.seed,
         }
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/augmenter.py
+++ b/keras_cv/layers/preprocessing/augmenter.py
@@ -35,3 +35,8 @@ class Augmenter(tf.keras.layers.Layer):
         config = super().get_config()
         config.update({"layers": self.layers})
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        config["layers"] = tf.keras.utils.deserialize_keras_object(config["layers"])
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/augmenter.py
+++ b/keras_cv/layers/preprocessing/augmenter.py
@@ -38,5 +38,6 @@ class Augmenter(tf.keras.layers.Layer):
 
     @classmethod
     def from_config(cls, config):
-        config["layers"] = tf.keras.utils.deserialize_keras_object(config["layers"])
+        if config["layers"] and isinstance(config["layers"][0], dict):
+            config["layers"] = tf.keras.utils.deserialize_keras_object(config["layers"])
         return cls(**config)

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -114,3 +114,10 @@ class RandomAugmentationPipeline(BaseImageAugmentationLayer):
             }
         )
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        layers = config.pop("layers", None)
+        if layers:
+            config["layers"] = tf.keras.utils.deserialize_keras_object(layers)
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -119,5 +119,7 @@ class RandomAugmentationPipeline(BaseImageAugmentationLayer):
     def from_config(cls, config):
         layers = config.pop("layers", None)
         if layers:
-            config["layers"] = tf.keras.utils.deserialize_keras_object(layers)
+            if isinstance(layers[0], dict):
+                layers = tf.keras.utils.deserialize_keras_object(layers)
+            config["layers"] = layers
         return cls(**config)

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -78,5 +78,6 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        if isinstance(config["factor"], dict):
+            config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
         return cls(**config)

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -75,3 +75,8 @@ class RandomColorDegeneration(BaseImageAugmentationLayer):
         config = super().get_config()
         config.update({"factor": self.factor, "seed": self.seed})
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -272,12 +272,14 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["crop_area_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["crop_area_factor"]
-        )
-        config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["aspect_ratio_factor"]
-        )
+        if isinstance(config["crop_area_factor"], dict):
+            config["crop_area_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["crop_area_factor"]
+            )
+        if isinstance(config["aspect_ratio_factor"], dict):
+            config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["aspect_ratio_factor"]
+            )
         return cls(**config)
 
     def _crop_and_resize(self, image, transformation, method=None):

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -270,6 +270,16 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
         )
         return config
 
+    @classmethod
+    def from_config(cls, config):
+        config["crop_area_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["crop_area_factor"]
+        )
+        config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["aspect_ratio_factor"]
+        )
+        return cls(**config)
+
     def _crop_and_resize(self, image, transformation, method=None):
         image = tf.expand_dims(image, axis=0)
         boxes = transformation

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -87,3 +87,8 @@ class RandomSaturation(BaseImageAugmentationLayer):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -90,5 +90,6 @@ class RandomSaturation(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        if isinstance(config["factor"], dict):
+            config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
         return cls(**config)

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
@@ -228,12 +228,14 @@ class RandomlyZoomedCrop(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["zoom_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["zoom_factor"]
-        )
-        config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["aspect_ratio_factor"]
-        )
+        if isinstance(config["zoom_factor"], dict):
+            config["zoom_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["zoom_factor"]
+            )
+        if isinstance(config["aspect_ratio_factor"], dict):
+            config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["aspect_ratio_factor"]
+            )
         return cls(**config)
 
     def _crop_and_resize(self, image, transformation, method=None):

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
@@ -226,6 +226,16 @@ class RandomlyZoomedCrop(BaseImageAugmentationLayer):
         )
         return config
 
+    @classmethod
+    def from_config(cls, config):
+        config["zoom_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["zoom_factor"]
+        )
+        config["aspect_ratio_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["aspect_ratio_factor"]
+        )
+        return cls(**config)
+
     def _crop_and_resize(self, image, transformation, method=None):
         image = tf.expand_dims(image, axis=0)
         boxes = transformation

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -114,7 +114,8 @@ class RepeatedAugmentation(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["augmenters"] = tf.keras.utils.deserialize_keras_object(
-            config["augmenters"]
-        )
+        if config["augmenters"] and isinstance(config["augmenters"][0], dict):
+            config["augmenters"] = tf.keras.utils.deserialize_keras_object(
+                config["augmenters"]
+            )
         return cls(**config)

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -111,3 +111,10 @@ class RepeatedAugmentation(BaseImageAugmentationLayer):
         config = super().get_config()
         config.update({"augmenters": self.augmenters, "shuffle": self.shuffle})
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        config["augmenters"] = tf.keras.utils.deserialize_keras_object(
+            config["augmenters"]
+        )
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -130,3 +130,13 @@ class Solarization(BaseImageAugmentationLayer):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        config["threshold_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["threshold_factor"]
+        )
+        config["addition_factor"] = tf.keras.utils.deserialize_keras_object(
+            config["addition_factor"]
+        )
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -133,10 +133,12 @@ class Solarization(BaseImageAugmentationLayer):
 
     @classmethod
     def from_config(cls, config):
-        config["threshold_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["threshold_factor"]
-        )
-        config["addition_factor"] = tf.keras.utils.deserialize_keras_object(
-            config["addition_factor"]
-        )
+        if isinstance(config["threshold_factor"], dict):
+            config["threshold_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["threshold_factor"]
+            )
+        if isinstance(config["addition_factor"], dict):
+            config["addition_factor"] = tf.keras.utils.deserialize_keras_object(
+                config["addition_factor"]
+            )
         return cls(**config)

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -108,10 +108,12 @@ class SqueezeAndExcite2D(layers.Layer):
 
     @classmethod
     def from_config(cls, config):
-        config["squeeze_activation"] = tf.keras.utils.deserialize_keras_object(
-            config["squeeze_activation"]
-        )
-        config["excite_activation"] = tf.keras.utils.deserialize_keras_object(
-            config["excite_activation"]
-        )
+        if isinstance(config["squeeze_activation"], dict):
+            config["squeeze_activation"] = tf.keras.utils.deserialize_keras_object(
+                config["squeeze_activation"]
+            )
+        if isinstance(config["excite_activation"], dict):
+            config["excite_activation"] = tf.keras.utils.deserialize_keras_object(
+                config["excite_activation"]
+            )
         return cls(**config)

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -105,3 +105,13 @@ class SqueezeAndExcite2D(layers.Layer):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        config["squeeze_activation"] = tf.keras.utils.deserialize_keras_object(
+            config["squeeze_activation"]
+        )
+        config["excite_activation"] = tf.keras.utils.deserialize_keras_object(
+            config["excite_activation"]
+        )
+        return cls(**config)

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -128,6 +128,4 @@ class TransformerEncoder(layers.Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
-        activation = config.pop("activation")
-        activation = tf.keras.activations.deserialize(activation)
-        return cls(activation=activation, **config)
+        return cls(**config)

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -113,6 +113,9 @@ class TransformerEncoder(layers.Layer):
 
     def get_config(self):
         config = super().get_config()
+        activation = self.activation
+        if not isinstance(activation, (str, dict)):
+            activation = tf.keras.activations.serialize(activation)
         config.update(
             {
                 "project_dim": self.project_dim,
@@ -120,7 +123,7 @@ class TransformerEncoder(layers.Layer):
                 "num_heads": self.num_heads,
                 "attention_dropout": self.attention_dropout,
                 "mlp_dropout": self.mlp_dropout,
-                "activation": self.activation,
+                "activation": activation,
                 "layer_norm_epsilon": self.layer_norm_epsilon,
             }
         )
@@ -128,4 +131,7 @@ class TransformerEncoder(layers.Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
-        return cls(**config)
+        activation = config.pop("activation")
+        if isinstance(activation, (str, dict)):
+            activation = tf.keras.activations.deserialize(activation)
+        return cls(activation=activation, **config)

--- a/keras_cv/models/csp_darknet_test.py
+++ b/keras_cv/models/csp_darknet_test.py
@@ -29,6 +29,8 @@ MODEL_LIST = [
 class CSPDarkNetTest(ModelsTest, tf.test.TestCase, parameterized.TestCase):
     @parameterized.parameters(*MODEL_LIST)
     def test_application_base(self, app, _, args):
+        if hasattr(tf.keras.__internal__, "enable_unsafe_deserialization"):
+            tf.keras.__internal__.enable_unsafe_deserialization()
         super()._test_application_base(app, _, args)
 
     @parameterized.parameters(*MODEL_LIST)

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -129,6 +129,7 @@ def parse_factor(param, min_value=0.0, max_value=1.0, param_name="factor", seed=
     if isinstance(param, dict):
         # For all classes missing a `from_config` implementation.
         # (RandomHue, RandomShear, etc.)
+        # To be removed with addition of `keras.__internal__` namespace support
         param = tf.keras.utils.deserialize_keras_object(param)
 
     if isinstance(param, core.FactorSampler):

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -126,6 +126,11 @@ def blend(image1: tf.Tensor, image2: tf.Tensor, factor: float) -> tf.Tensor:
 
 
 def parse_factor(param, min_value=0.0, max_value=1.0, param_name="factor", seed=None):
+    if isinstance(param, dict):
+        # For all classes missing a `from_config` implementation.
+        # (RandomHue, RandomShear, etc.)
+        param = tf.keras.utils.deserialize_keras_object(param)
+
     if isinstance(param, core.FactorSampler):
         return param
 


### PR DESCRIPTION
This PR refactors the deserialization of KerasCV layers in preparation for an upcoming switch in the serialization format of Keras objects. It adds `from_config` methods where necessary for deserialization and additionally enables the deserialization of lambdas where necessary.

Many of these changes are temporary until the addition of `keras.__internal__` namespace API support in the new serialization.