### PR TITLE
Improve quickstart user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,25 @@ To learn more about the future project direction, please check the [roadmap](.gi
 - [Roadmap](.github/ROADMAP.md)
 - [API Design Guidelines](.github/API_DESIGN.md)
 
+## Installation
+
+To install the latest official release:
+
+```
+pip install keras-cv tensorflow --upgrade
+```
+
+To install the latest unreleased changes to the library, we recommend using
+pip to install directly from the master branch on github:
+
+```
+pip install git+https://github.com/keras-team/keras-cv.git tensorflow --upgrade
+```
+
 ## Quickstart
 
-Create a preprocessing pipeline:
-
 ```python
+# Create a preprocessing pipeline
 import keras_cv
 import tensorflow as tf
 from tensorflow import keras
@@ -55,19 +69,13 @@ def augment_data(images, labels):
   inputs = {"images": images, "labels": labels}
   outputs = augmenter(inputs)
   return outputs['images'], outputs['labels']
-```
 
-Augment a `tf.data.Dataset`:
-
-```python
+# Augment a `tf.data.Dataset`
 dataset = tfds.load('rock_paper_scissors', as_supervised=True, split='train')
 dataset = dataset.batch(64)
 dataset = dataset.map(augment_data, num_parallel_calls=tf.data.AUTOTUNE)
-```
 
-Create a model:
-
-```python
+# Create a model
 densenet = keras_cv.models.DenseNet121(
   include_rescaling=True,
   include_top=True,
@@ -78,11 +86,8 @@ densenet.compile(
   optimizer='adam',
   metrics=['accuracy']
 )
-```
 
-Train your model:
-
-```python
+# Train your model
 densenet.fit(dataset)
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ pip install git+https://github.com/keras-team/keras-cv.git tensorflow --upgrade
 ## Quickstart
 
 ```python
-# Create a preprocessing pipeline
 import keras_cv
 import tensorflow as tf
 from tensorflow import keras
 import tensorflow_datasets as tfds
 
+# Create a preprocessing pipeline
 augmenter = keras_cv.layers.Augmenter(
     layers=[
         keras_cv.layers.RandomFlip(),


### PR DESCRIPTION
The quickstart is currently a bit awkward to use because you need the latest version of TF for the code to run and it is divided into many code blocks. Furthermore it seems to OOM on smaller GPUs (<30GB RAM).

Changes:
* Add installation guide
* Consolidate into one code block
* Reduce batch size to 16
* Add validation set
* Add prefetch

This version runs smoothly on the free version of colab (16GB RAM GPU).