### PR TITLE
Replace closures with layers and models in resnetv2

### DIFF
--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -107,9 +107,10 @@ class BasicBlock(keras.layers.Layer):
 
     Args:
         filters: integer, filters of the basic layer.
-        kernel_size: default 3, kernel size of the bottleneck layer.
-        stride: default 1, stride of the first layer.
-        conv_shortcut: default False, use convolution shortcut if True,
+        kernel_size: integer, kernel size of the bottleneck layer. Defaults to 3.
+        stride: integer, stride of the first layer. Defaults to 1.
+        dilation: integer, the dilation rate to use for dilated convolution. Defaults to 1.
+        conv_shortcut: bool, uses convolution shortcut if `True`. Defaults to `False`.
           otherwise identity shortcut.
 
     Returns:
@@ -205,12 +206,12 @@ class Block(keras.layers.Layer):
     """A residual block (v2).
 
     Args:
-        filters: integer, filters of the bottleneck layer.
-        kernel_size: default 3, kernel size of the bottleneck layer.
-        stride: default 1, stride of the first layer.
-        conv_shortcut: default False, use convolution shortcut if True,
+        filters: integer, filters of the basic layer.
+        kernel_size: integer, kernel size of the bottleneck layer. Defaults to 3.
+        stride: integer, stride of the first layer. Defaults to 1.
+        dilation: integer, the dilation rate to use for dilated convolution. Defaults to 1.
+        conv_shortcut: bool, uses convolution shortcut if `True`. Defaults to `False`.
           otherwise identity shortcut.
-        name: string, block label.
 
     Returns:
       Output tensor for the residual block.
@@ -319,7 +320,8 @@ class Stack(keras.layers.Layer):
     Args:
         filters: integer, filters of the layer in a block.
         blocks: integer, blocks in the stacked blocks.
-        stride: default 2, stride of the first layer in the first block.
+        stride: integer, stride of the first layer in the first block. Defaults to 2.
+        dilation: integer, the dilation rate to use for dilated convolution. Defaults to 1.
         block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
         first_shortcut: default True, use convolution shortcut if True,
           otherwise identity shortcut.
@@ -333,7 +335,7 @@ class Stack(keras.layers.Layer):
         filters,
         blocks,
         stride=2,
-        dilations=1,
+        dilation=1,
         block_fn=Block,
         first_shortcut=True,
         stack_index=1,
@@ -344,7 +346,7 @@ class Stack(keras.layers.Layer):
         self.filters = filters
         self.blocks = blocks
         self.stride = stride
-        self.dilations = dilations
+        self.dilation = dilation
         self.block_fn = block_fn
         self.first_shortcut = first_shortcut
         self.stack_index = stack_index
@@ -354,13 +356,13 @@ class Stack(keras.layers.Layer):
             filters, conv_shortcut=first_shortcut, name=self.name + "_block1"
         )
         self.middle_blocks = [
-            block_fn(filters, dilation=dilations, name=self.name + "_block" + str(i))
+            block_fn(filters, dilation=dilation, name=self.name + "_block" + str(i))
             for i in range(2, blocks)
         ]
         self.last_block = block_fn(
             filters,
             stride=stride,
-            dilation=dilations,
+            dilation=dilation,
             name=self.name + "_block" + str(blocks),
         )
 
@@ -377,7 +379,7 @@ class Stack(keras.layers.Layer):
                 "filters": self.filters,
                 "blocks": self.blocks,
                 "stride": self.stride,
-                "dilations": self.dilations,
+                "dilation": self.dilation,
                 "block_fn": keras.utils.get_registered_name(self.block_fn),
                 "first_shortcut": self.first_shortcut,
                 "stack_index": self.stack_index,
@@ -493,7 +495,7 @@ def ResNetV2(
             filters=stackwise_filters[stack_index],
             blocks=stackwise_blocks[stack_index],
             stride=stackwise_strides[stack_index],
-            dilations=stackwise_dilations[stack_index],
+            dilation=stackwise_dilations[stack_index],
             block_fn=block_fn,
             first_shortcut=block_fn == Block or stack_index > 0,
             stack_index=stack_index,

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -542,7 +542,7 @@ class ResNetV2(keras.Model):
         self.pooling = pooling
         self.classes = classes
         self.classifier_activation = classifier_activation
-        self.block_fn = Block
+        self.block_fn = block_fn
 
     def get_config(self):
         return {
@@ -551,7 +551,7 @@ class ResNetV2(keras.Model):
             "stackwise_strides": self.stackwise_strides,
             "include_rescaling": self.include_rescaling,
             "include_top": self.include_top,
-            "input_shape": self.input_shape,
+            "input_shape": self.input_shape[1:],
             "stackwise_dilations": self.stackwise_dilations,
             "input_tensor": self.input_tensor,
             "pooling": self.pooling,

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -378,12 +378,18 @@ class Stack(keras.layers.Layer):
                 "blocks": self.blocks,
                 "stride": self.stride,
                 "dilations": self.dilations,
-                "block_fn": self.block_fn,
+                "block_fn": keras.utils.get_registered_name(self.block_fn),
                 "first_shortcut": self.first_shortcut,
                 "stack_index": self.stack_index,
             }
         )
         return config
+
+    @classmethod
+    def from_config(cls, config):
+        block_class_name = config["block_fn"]
+        config["block_fn"] = keras.utils.get_registered_object(block_class_name)
+        return super().from_config(config)
 
 
 def ResNetV2(

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -429,7 +429,7 @@ class ResNetV2(keras.Model):
             `classifier_activation=None` to return the logits of the "top" layer.
         block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
             Use 'basic_block' for ResNet18 and ResNet34.
-        **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
+        **kwargs: Pass-through keyword arguments to `keras.Model`.
 
     Returns:
       A `keras.Model` instance.
@@ -504,7 +504,9 @@ class ResNetV2(keras.Model):
             )(x)
             stack_level_outputs[stack_index + 2] = x
 
-        x = layers.BatchNormalization(axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn")(x)
+        x = layers.BatchNormalization(axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn")(
+            x
+        )
         x = layers.Activation("relu", name="post_relu")(x)
 
         if include_top:
@@ -518,7 +520,7 @@ class ResNetV2(keras.Model):
             elif pooling == "max":
                 x = layers.GlobalMaxPooling2D(name="max_pool")(x)
 
-        super().__init__(inputs, x, **kwargs)
+        super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         # All references to `self` below this line.
         if weights is not None:
@@ -543,23 +545,21 @@ class ResNetV2(keras.Model):
         self.block_fn = Block
 
     def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                "stackwise_filters": self.stackwise_filters,
-                "stackwise_blocks": self.stackwise_blocks,
-                "stackwise_strides": self.stackwise_strides,
-                "include_rescaling": self.include_rescaling,
-                "include_top": self.include_top,
-                "stackwise_dilations": self.stackwise_dilations,
-                "input_tensor": self.input_tensor,
-                "pooling": self.pooling,
-                "classes": self.classes,
-                "classifier_activation": self.classifier_activation,
-                "block_fn": keras.utils.get_registered_name(self.block_fn),
-            }
-        )
-        return config
+        return {
+            "stackwise_filters": self.stackwise_filters,
+            "stackwise_blocks": self.stackwise_blocks,
+            "stackwise_strides": self.stackwise_strides,
+            "include_rescaling": self.include_rescaling,
+            "include_top": self.include_top,
+            "stackwise_dilations": self.stackwise_dilations,
+            "input_tensor": self.input_tensor,
+            "pooling": self.pooling,
+            "classes": self.classes,
+            "classifier_activation": self.classifier_activation,
+            "block_fn": keras.utils.get_registered_name(self.block_fn),
+            "name": self.name,
+            "trainable": self.trainable,
+        }
 
     @classmethod
     def from_config(cls, config):

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -551,6 +551,7 @@ class ResNetV2(keras.Model):
             "stackwise_strides": self.stackwise_strides,
             "include_rescaling": self.include_rescaling,
             "include_top": self.include_top,
+            "input_shape": self.input_shape,
             "stackwise_dilations": self.stackwise_dilations,
             "input_tensor": self.input_tensor,
             "pooling": self.pooling,
@@ -565,7 +566,7 @@ class ResNetV2(keras.Model):
     def from_config(cls, config):
         block_class_name = config["block_fn"]
         config["block_fn"] = keras.utils.get_registered_object(block_class_name)
-        return super().from_config(config)
+        return cls(**config)
 
 
 def ResNet18V2(

--- a/keras_cv/models/resnet_v2_test.py
+++ b/keras_cv/models/resnet_v2_test.py
@@ -14,6 +14,7 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
+from packaging import version
 
 from keras_cv.models import resnet_v2
 
@@ -55,13 +56,17 @@ class ResNetV2Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
         super()._test_model_can_be_used_as_backbone(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_model_serialization(self, app, last_dim, args):
+    def test_model_serialization_tf(self, app, last_dim, args):
         super()._test_model_serialization(
             app, last_dim, args, save_format="tf", filename="model"
         )
-        super()._test_model_serialization(
-            app, last_dim, args, save_format="keras_v3", filename="model.keras"
-        )
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_serialization_keras_format(self, app, last_dim, args):
+        if version.parse(tf.__version__) >= version.parse("2.12.0-dev0"):
+            super()._test_model_serialization(
+                app, last_dim, args, save_format="keras_v3", filename="model.keras"
+            )
 
     def test_model_backbone_layer_names_stability(self):
         model = resnet_v2.ResNet50V2(


### PR DESCRIPTION
WIP. NOT READY TO MERGE

This is a pilot to update our implementations as `Layers` and `Models` rather than a closure. This is part of our effort to standardize the KerasCV and KerasNLP APIs.

## Why this design?
* A subclassed `keras.Model` is needed to add a `from_preset` constructor for loading preset architectures and weights. In the long term this and other methods/properties will be maintained in a new `Backbone` base class.
* We initialize a functional `keras.Model` in the `__init__` to maintain the convenience of the `Functional` API.
* When using a subclassed `keras.Model` it is not possible to track weights in a closure-style submodel. Therefore we need to switch to `keras.layers.Layer` blocks. See @LukeWood's analysis ([link](https://lukewood.xyz/blog/subclass-model-pitfall)).

This should also improve the readability of `model.summary()`.

Steps:
* [x] Rewrite `BasicBlock` as `Layer`
* [x] Rewrite `Block` as `Layer`
* [x] Rewrite `Stack` as `Layer`
* [x] Rewrite `ResnetV2` as `Model`
* [ ] Convert weight files if incompatible