### PR TITLE
Vectorized random saturation

### DIFF
--- a/benchmarks/vectorized_random_saturation.py
+++ b/benchmarks/vectorized_random_saturation.py
@@ -25,7 +25,6 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@tf.keras.utils.register_keras_serializable(package="keras_cv")
 class OldRandomSaturation(BaseImageAugmentationLayer):
     """Randomly adjusts the saturation on given images.
 

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -82,6 +82,7 @@ class RandomSaturation(VectorizedBaseImageAugmentationLayer):
         # it will be handled correctly when it is a one tensor.
         transformations = tf.convert_to_tensor(transformations)
         adjust_factors = transformations / (1 - transformations)
+        adjust_factors = tf.cast(adjust_factors, dtype=images.dtype)
 
         images = tf.image.rgb_to_hsv(images)
         s_channel = tf.multiply(

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -21,7 +21,6 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@tf.keras.utils.register_keras_serializable(package="keras_cv")
 class OldRandomSaturation(BaseImageAugmentationLayer):
     """Randomly adjusts the saturation on given images.
 

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,86 @@ import tensorflow as tf
 
 from keras_cv import core
 from keras_cv.layers import preprocessing
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
+
+
+@tf.keras.utils.register_keras_serializable(package="keras_cv")
+class OldRandomSaturation(BaseImageAugmentationLayer):
+    """Randomly adjusts the saturation on given images.
+
+    This layer will randomly increase/reduce the saturation for the input RGB
+    images. At inference time, the output will be identical to the input.
+    Call the layer with `training=True` to adjust the saturation of the input.
+
+    Args:
+        factor: A tuple of two floats, a single float or `keras_cv.FactorSampler`.
+            `factor` controls the extent to which the image saturation is impacted.
+            `factor=0.5` makes this layer perform a no-op operation. `factor=0.0` makes
+            the image to be fully grayscale. `factor=1.0` makes the image to be fully
+            saturated.
+            Values should be between `0.0` and `1.0`. If a tuple is used, a `factor`
+            is sampled between the two values for every image augmented.  If a single
+            float is used, a value between `0.0` and the passed float is sampled.
+            In order to ensure the value is always the same, please pass a tuple with
+            two identical floats: `(0.5, 0.5)`.
+        seed: Integer. Used to create a random seed.
+    """
+
+    def __init__(self, factor, seed=None, **kwargs):
+        super().__init__(seed=seed, **kwargs)
+        self.factor = preprocessing_utils.parse_factor(
+            factor,
+            min_value=0.0,
+            max_value=1.0,
+        )
+        self.seed = seed
+
+    def get_random_transformation(self, **kwargs):
+        return self.factor()
+
+    def augment_image(self, image, transformation=None, **kwargs):
+        # Convert the factor range from [0, 1] to [0, +inf]. Note that the
+        # tf.image.adjust_saturation is trying to apply the following math formula
+        # `output_saturation = input_saturation * factor`. We use the following
+        # method to the do the mapping.
+        # `y = x / (1 - x)`.
+        # This will ensure:
+        #   y = +inf when x = 1 (full saturation)
+        #   y = 1 when x = 0.5 (no augmentation)
+        #   y = 0 when x = 0 (full gray scale)
+
+        # Convert the transformation to tensor in case it is a float. When
+        # transformation is 1.0, then it will result in to divide by zero error, but
+        # it will be handled correctly when it is a one tensor.
+        transformation = tf.convert_to_tensor(transformation)
+        adjust_factor = transformation / (1 - transformation)
+        return tf.image.adjust_saturation(image, saturation_factor=adjust_factor)
+
+    def augment_bounding_boxes(self, bounding_boxes, transformation=None, **kwargs):
+        return bounding_boxes
+
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def get_config(self):
+        config = {
+            "factor": self.factor,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        if isinstance(config["factor"], dict):
+            config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        return cls(**config)
 
 
 class RandomSaturationTest(tf.test.TestCase):
@@ -93,3 +173,29 @@ class RandomSaturationTest(tf.test.TestCase):
         self.assertTrue(isinstance(config["factor"], core.UniformFactorSampler))
         self.assertEqual(config["factor"].get_config()["lower"], 0.3)
         self.assertEqual(config["factor"].get_config()["upper"], 0.8)
+
+    def test_correctness_with_tf_adjust_saturation_normalized_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        image = tf.random.uniform(shape=image_shape)
+
+        layer = preprocessing.RandomSaturation(factor=fixed_factor)
+        old_layer = OldRandomSaturation(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output, atol=1e-5, rtol=1e-5)
+
+    def test_correctness_with_tf_adjust_saturation_rgb_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        image = tf.random.uniform(shape=image_shape) * 255.0
+
+        layer = preprocessing.RandomSaturation(factor=fixed_factor)
+        old_layer = OldRandomSaturation(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output, atol=1e-3, rtol=1e-5)


### PR DESCRIPTION
# What does this PR do?

Fixes #1386 

The vectorized version can pass all tests in old `keras_cv/layers/preprocessing/random_saturation_test.py`.

Then, as discussed in #1386, I copied the old random saturation layer into `keras_cv/layers/preprocessing/random_saturation_test.py` and wrote two tests to check the consistency.

This is the result:
- Input value range [0, 1]: the vectorized version can almost always pass the test with `atol=1e-5, rtol=1e-5`. I locally set batch size 1024 to test.
- Input value range [0, 255]: the vectorized version can only pass the test by setting higher `atol` that  `atol=1e-3, rtol=1e-5`.

I think the conversion between RGB and HSV might bring the error because the doc of `tf.image.rgb_to_hsv` says: [https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_hsv](https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_hsv)
>The output is only well defined if the value in images are in [0,1].

I add a benchmark script `benchmarks/vectorized_random_saturation.py` to show the improvement.

![comparison](https://user-images.githubusercontent.com/20734616/218413141-5de47147-5686-42dd-9de1-e7887f928ae2.png)
![comparison_no_old_eager](https://user-images.githubusercontent.com/20734616/218413158-0da84589-271f-4a5a-8868-a0613c53711f.png)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood 
