### PR TITLE
Added vectorized Auto Contrast implementation.

### DIFF
--- a/benchmarks/vectorized_auto_contrast.py
+++ b/benchmarks/vectorized_auto_contrast.py
@@ -1,0 +1,161 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import matplotlib.pyplot as plt
+import tensorflow as tf
+import tensorflow.keras as keras
+
+from keras_cv.layers import AutoContrast
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing
+
+
+class OldAutoContrast(BaseImageAugmentationLayer):
+    """Performs the AutoContrast operation on an image.
+
+    Auto contrast stretches the values of an image across the entire available
+    `value_range`.  This makes differences between pixels more obvious.  An example of
+    this is if an image only has values `[0, 1]` out of the range `[0, 255]`, auto
+    contrast will change the `1` values to be `255`.
+
+    Args:
+        value_range: the range of values the incoming images will have.
+            Represented as a two number tuple written [low, high].
+            This is typically either `[0, 1]` or `[0, 255]` depending
+            on how your preprocessing pipeline is setup.
+    """
+
+    def __init__(
+        self,
+        value_range,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.value_range = value_range
+
+    def augment_image(self, image, transformation=None, **kwargs):
+        original_image = image
+        image = preprocessing.transform_value_range(
+            image,
+            original_range=self.value_range,
+            target_range=(0, 255),
+            dtype=self.compute_dtype,
+        )
+
+        low = tf.reduce_min(tf.reduce_min(image, axis=0), axis=0)
+        high = tf.reduce_max(tf.reduce_max(image, axis=0), axis=0)
+        scale = 255.0 / (high - low)
+        offset = -low * scale
+
+        image = image * scale[None, None] + offset[None, None]
+        result = tf.clip_by_value(image, 0.0, 255.0)
+        result = preprocessing.transform_value_range(
+            result,
+            original_range=(0, 255),
+            target_range=self.value_range,
+            dtype=self.compute_dtype,
+        )
+        # don't process NaN channels
+        result = tf.where(tf.math.is_nan(result), original_image, result)
+        return result
+
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"value_range": self.value_range})
+        return config
+
+
+if __name__ == "__main__":
+    (x_train, _), _ = keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(float)
+
+    images = []
+    num_images = [1000, 2000, 5000, 10000]
+    results = {}
+
+    for aug in [AutoContrast, OldAutoContrast]:
+        c = aug.__name__
+
+        layer = aug(value_range=(0, 255))
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            layer(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = layer(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1 - t0}")
+
+        results[c] = runtimes
+
+        c = aug.__name__ + " Graph Mode"
+
+        layer = aug(value_range=(0, 255))
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1 - t0}")
+
+        results[c] = runtimes
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.show()
+
+    # So we can actually see more relevant margins
+    del results["OldAutoContrast"]
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.show()

--- a/keras_cv/layers/preprocessing/auto_contrast_test.py
+++ b/keras_cv/layers/preprocessing/auto_contrast_test.py
@@ -14,7 +14,73 @@
 
 import tensorflow as tf
 
+from keras_cv.layers import BaseImageAugmentationLayer
 from keras_cv.layers import preprocessing
+from keras_cv.utils import preprocessing as utils_preprocessing
+
+
+class OldAutoContrast(BaseImageAugmentationLayer):
+    """Performs the AutoContrast operation on an image.
+
+    Auto contrast stretches the values of an image across the entire available
+    `value_range`.  This makes differences between pixels more obvious.  An example of
+    this is if an image only has values `[0, 1]` out of the range `[0, 255]`, auto
+    contrast will change the `1` values to be `255`.
+
+    Args:
+        value_range: the range of values the incoming images will have.
+            Represented as a two number tuple written [low, high].
+            This is typically either `[0, 1]` or `[0, 255]` depending
+            on how your preprocessing pipeline is setup.
+    """
+
+    def __init__(
+        self,
+        value_range,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.value_range = value_range
+
+    def augment_image(self, image, transformation=None, **kwargs):
+        original_image = image
+        image = utils_preprocessing.transform_value_range(
+            image,
+            original_range=self.value_range,
+            target_range=(0, 255),
+            dtype=self.compute_dtype,
+        )
+
+        low = tf.reduce_min(tf.reduce_min(image, axis=0), axis=0)
+        high = tf.reduce_max(tf.reduce_max(image, axis=0), axis=0)
+        scale = 255.0 / (high - low)
+        offset = -low * scale
+
+        image = image * scale[None, None] + offset[None, None]
+        result = tf.clip_by_value(image, 0.0, 255.0)
+        result = utils_preprocessing.transform_value_range(
+            result,
+            original_range=(0, 255),
+            target_range=self.value_range,
+            dtype=self.compute_dtype,
+        )
+        # don't process NaN channels
+        result = tf.where(tf.math.is_nan(result), original_image, result)
+        return result
+
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"value_range": self.value_range})
+        return config
 
 
 class AutoContrastTest(tf.test.TestCase):
@@ -90,3 +156,11 @@ class AutoContrastTest(tf.test.TestCase):
 
         self.assertTrue(tf.math.reduce_any(ys[0] == 0.0))
         self.assertTrue(tf.math.reduce_any(ys[0] == 1.0))
+
+    def test_is_consistent_with_non_vectorized_implementation(self):
+        images = tf.random.uniform((16, 32, 32, 3))
+
+        old_output = OldAutoContrast(value_range=(0, 1))(images)
+        output = preprocessing.AutoContrast(value_range=(0, 1))(images)
+
+        self.assertAllClose(old_output, output)


### PR DESCRIPTION
# What does this PR do?
Modifies `AutoContrast` to use `Vectorized` base image layer.

Fixes #1382 

Following #1392 I also added the benchmark and numerical check (compare old and new).
Benchmark results:
![autocontrast_benchmark_2](https://user-images.githubusercontent.com/58402418/218660120-ed2b2bac-b312-4c30-9daf-1f002cccd43f.png)

![autocontrast_benchmark_1](https://user-images.githubusercontent.com/58402418/218660107-a6022354-b5e5-4de2-86ff-758ba3cd74e5.png)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 