### PR TITLE
Remove closures and use subclassed functional model

### DIFF
--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -71,7 +71,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
 
     For transfer learning use cases, make sure to read the [guide to transfer
         learning & fine-tuning](https://keras.io/guides/transfer_learning/).
-    
+
     Args:
         include_rescaling: bool, whether or not to Rescale the inputs. If set
             to `True`, inputs will be passed through a `Rescaling(1/255.0)`

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -265,7 +265,7 @@ def apply_stack(
         dilation: int, the dilation rate to use for dilated convolution.
             Defaults to 1.
         block_type: string, one of "basic_block" or "block". The block type to
-            stack Use "basic_block" for ResNet18 and ResNet34.
+            stack. Use "basic_block" for ResNet18 and ResNet34.
         first_shortcut: bool. Use convolution shortcut if `True` (default),
             otherwise uses identity or pooling shortcut, based on stride.
 
@@ -340,7 +340,7 @@ class ResNetV2(keras.Model):
             `classifier_activation=None` to return the logits of the "top"
             layer.
         block_type: string, one of "basic_block" or "block". The block type to
-            stack Use "basic_block" for ResNet18 and ResNet34.
+            stack. Use "basic_block" for ResNet18 and ResNet34.
     """
 
     def __init__(

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -335,7 +335,7 @@ class ResNetV2(keras.Model):
                 be applied.
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True.
-        classifier_activation: A `str` or callable. The activation function to 
+        classifier_activation: A `str` or callable. The activation function to
             use on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top"
             layer.

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -357,7 +357,7 @@ class ResNetV2(keras.Model):
         pooling=None,
         classes=None,
         classifier_activation="softmax",
-        block_type=apply_block,
+        block_type="block",
         **kwargs,
     ):
         if weights and not tf.io.gfile.exists(weights):

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -56,6 +56,7 @@ MODEL_CONFIGS = {
 }
 
 BN_AXIS = 3
+BN_EPSILON = 1.001e-5
 
 BASE_DOCSTRING = """Instantiates the {name} architecture.
     Reference:
@@ -72,12 +73,13 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
         learning & fine-tuning](https://keras.io/guides/transfer_learning/).
     
     Args:
-        include_rescaling: whether or not to Rescale the inputs.If set to True,
-            inputs will be passed through a `Rescaling(1/255.0)` layer.
-        include_top: whether to include the fully-connected layer at the top of the
-            network.  If provided, classes must be provided.
-        classes: optional number of classes to classify images into, only to be
-            specified if `include_top` is True.
+        include_rescaling: bool, whether or not to Rescale the inputs. If set
+            to `True`, inputs will be passed through a `Rescaling(1/255.0)`
+            layer.
+        include_top: bool, whether to include the fully-connected layer at
+            the top of the network.  If provided, `classes` must be provided.
+        classes: optional int, number of classes to classify images into (only
+            to be specified if `include_top` is `True`).
         weights: one of `None` (random initialization), a pretrained weight file
             path, or a reference to pre-trained weights (e.g. 'imagenet/classification')
             (see available pre-trained weights in weights.py)
@@ -107,22 +109,26 @@ def BasicBlock(
     x, filters, kernel_size=3, stride=1, dilation=1, conv_shortcut=False, name=None
 ):
     """A basic residual block (v2).
+
     Args:
         x: input tensor.
-        filters: integer, filters of the basic layer.
-        kernel_size: default 3, kernel size of the bottleneck layer.
-        stride: default 1, stride of the first layer.
-        conv_shortcut: default False, use convolution shortcut if True,
-          otherwise identity shortcut.
-        name: string, block label.
+        filters: int, filters of the basic layer.
+        kernel_size: int, kernel size of the bottleneck layer. Defaults to 3.
+        stride: int, stride of the first layer. Defaults to 1.
+        dilation: int, the dilation rate to use for dilated convolution.
+            Defaults to 1.
+        conv_shortcut: bool, uses convolution shortcut if `True`. If `False`
+            (default), uses identity or pooling shortcut, based on stride.
+
     Returns:
       Output tensor for the residual block.
     """
+
     if name is None:
         name = f"v2_basic_block_{backend.get_uid('v2_basic_block')}"
 
     use_preactivation = layers.BatchNormalization(
-        axis=BN_AXIS, epsilon=1.001e-5, name=name + "_use_preactivation_bn"
+        axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
     use_preactivation = layers.Activation(
@@ -149,9 +155,9 @@ def BasicBlock(
         use_bias=False,
         name=name + "_1_conv",
     )(use_preactivation)
-    x = layers.BatchNormalization(axis=BN_AXIS, epsilon=1.001e-5, name=name + "_1_bn")(
-        x
-    )
+    x = layers.BatchNormalization(
+        axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
+    )(x)
     x = layers.Activation("relu", name=name + "_1_relu")(x)
 
     x = layers.Conv2D(
@@ -173,14 +179,17 @@ def Block(
     x, filters, kernel_size=3, stride=1, dilation=1, conv_shortcut=False, name=None
 ):
     """A residual block (v2).
+
     Args:
         x: input tensor.
-        filters: integer, filters of the bottleneck layer.
-        kernel_size: default 3, kernel size of the bottleneck layer.
-        stride: default 1, stride of the first layer.
-        conv_shortcut: default False, use convolution shortcut if True,
-          otherwise identity shortcut.
-        name: string, block label.
+        filters: int, filters of the basic layer.
+        kernel_size: int, kernel size of the bottleneck layer. Defaults to 3.
+        stride: int, stride of the first layer. Defaults to 1.
+        dilation: int, the dilation rate to use for dilated convolution.
+            Defaults to 1.
+        conv_shortcut: bool, uses convolution shortcut if `True`. If `False`
+            (default), uses identity or pooling shortcut, based on stride.
+
     Returns:
       Output tensor for the residual block.
     """
@@ -188,7 +197,7 @@ def Block(
         name = f"v2_block_{backend.get_uid('v2_block')}"
 
     use_preactivation = layers.BatchNormalization(
-        axis=BN_AXIS, epsilon=1.001e-5, name=name + "_use_preactivation_bn"
+        axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
     use_preactivation = layers.Activation(
@@ -213,9 +222,9 @@ def Block(
     x = layers.Conv2D(filters, 1, strides=1, use_bias=False, name=name + "_1_conv")(
         use_preactivation
     )
-    x = layers.BatchNormalization(axis=BN_AXIS, epsilon=1.001e-5, name=name + "_1_bn")(
-        x
-    )
+    x = layers.BatchNormalization(
+        axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
+    )(x)
     x = layers.Activation("relu", name=name + "_1_relu")(x)
 
     x = layers.Conv2D(
@@ -227,9 +236,9 @@ def Block(
         dilation_rate=dilation,
         name=name + "_2_conv",
     )(x)
-    x = layers.BatchNormalization(axis=BN_AXIS, epsilon=1.001e-5, name=name + "_2_bn")(
-        x
-    )
+    x = layers.BatchNormalization(
+        axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_2_bn"
+    )(x)
     x = layers.Activation("relu", name=name + "_2_relu")(x)
 
     x = layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
@@ -237,7 +246,7 @@ def Block(
     return x
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.utils.register_keras_serializable(package="keras_cv.models.resnet_v2")
 def Stack(
     x,
     filters,
@@ -250,18 +259,21 @@ def Stack(
     stack_index=1,
 ):
     """A set of stacked blocks.
+
     Args:
         x: input tensor.
-        filters: integer, filters of the layer in a block.
-        blocks: integer, blocks in the stacked blocks.
-        stride: default 2, stride of the first layer in the first block.
-        name: string, stack label.
+        filters: int, filters of the layer in a block.
+        blocks: int, blocks in the stacked blocks.
+        stride: int, stride of the first layer in the first block. Defaults to 2.
+        dilation: int, the dilation rate to use for dilated convolution. Defaults to 1.
         block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
-        first_shortcut: default True, use convolution shortcut if True,
-          otherwise identity shortcut.
+        first_shortcut: bool. Use convolution shortcut if `True` (default),
+            otherwise uses identity or pooling shortcut, based on stride.
+
     Returns:
         Output tensor for the stacked blocks.
     """
+
     if name is None:
         name = f"v2_stack_{stack_index}"
 
@@ -278,19 +290,24 @@ def Stack(
     return x
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models.resnet_v2")
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNetV2(keras.Model):
     """Instantiates the ResNetV2 architecture.
 
     Args:
-        stackwise_filters: number of filters for each stack in the model.
-        stackwise_blocks: number of blocks for each stack in the model.
-        stackwise_strides: stride for each stack in the model.
-        include_rescaling: whether or not to Rescale the inputs. If set to True,
-            inputs will be passed through a `Rescaling(1/255.0)` layer.
-            name: string, model name.
-        include_top: whether to include the fully-connected
+        stackwise_filters: list of ints, number of filters for each stack in
+            the model.
+        stackwise_blocks: list of ints, number of blocks for each stack in the
+            model.
+        stackwise_strides: list of ints, stride for each stack in the model.
+        include_rescaling: bool, whether or not to Rescale the inputs. If set
+            to `True`, inputs will be passed through a `Rescaling(1/255.0)`
+            layer.
+        include_top: bool, whether to include the fully-connected
             layer at the top of the network.
+        stackwise_dialations: list of ints, dialation for each stack in the
+            model. If `None` (default), dialation will not be used.
+        name: string, model name.
         weights: one of `None` (random initialization),
             or the path to the weights file to be loaded.
         input_shape: optional shape tuple, defaults to (None, None, 3).
@@ -314,7 +331,6 @@ class ResNetV2(keras.Model):
             `classifier_activation=None` to return the logits of the "top" layer.
         block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
             Use 'basic_block' for ResNet18 and ResNet34.
-        **kwargs: Pass-through keyword arguments to `tf.keras.Model`.
     """
 
     def __init__(
@@ -388,7 +404,9 @@ class ResNetV2(keras.Model):
             )
             stack_level_outputs[stack_index + 2] = x
 
-        x = layers.BatchNormalization(axis=BN_AXIS, epsilon=1.001e-5, name="post_bn")(x)
+        x = layers.BatchNormalization(axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn")(
+            x
+        )
         x = layers.Activation("relu", name="post_relu")(x)
 
         if include_top:

--- a/keras_cv/models/resnet_v2.py
+++ b/keras_cv/models/resnet_v2.py
@@ -105,7 +105,7 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
 
 
 @keras.utils.register_keras_serializable(package="keras_cv.models.resnet_v2")
-def BasicBlock(
+def apply_basic_block(
     x, filters, kernel_size=3, stride=1, dilation=1, conv_shortcut=False, name=None
 ):
     """A basic residual block (v2).
@@ -175,7 +175,7 @@ def BasicBlock(
 
 
 @keras.utils.register_keras_serializable(package="keras_cv.models.resnet_v2")
-def Block(
+def apply_block(
     x, filters, kernel_size=3, stride=1, dilation=1, conv_shortcut=False, name=None
 ):
     """A residual block (v2).
@@ -254,7 +254,7 @@ def Stack(
     stride=2,
     dilations=1,
     name=None,
-    block_fn=Block,
+    block_fn=apply_block,
     first_shortcut=True,
     stack_index=1,
 ):
@@ -265,8 +265,10 @@ def Stack(
         filters: int, filters of the layer in a block.
         blocks: int, blocks in the stacked blocks.
         stride: int, stride of the first layer in the first block. Defaults to 2.
-        dilation: int, the dilation rate to use for dilated convolution. Defaults to 1.
-        block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
+        dilation: int, the dilation rate to use for dilated convolution. 
+            Defaults to 1.
+        block_fn: callable, `apply_block` or `apply_basic_block`, the block 
+            function to stack.
         first_shortcut: bool. Use convolution shortcut if `True` (default),
             otherwise uses identity or pooling shortcut, based on stride.
 
@@ -329,7 +331,7 @@ class ResNetV2(keras.Model):
         classifier_activation: A `str` or callable. The activation function to use
             on the "top" layer. Ignored unless `include_top=True`. Set
             `classifier_activation=None` to return the logits of the "top" layer.
-        block_fn: callable, `Block` or `BasicBlock`, the block function to stack.
+        block_fn: callable, `apply_block` or `apply_basic_block`, the block function to stack.
             Use 'basic_block' for ResNet18 and ResNet34.
     """
 
@@ -348,7 +350,7 @@ class ResNetV2(keras.Model):
         pooling=None,
         classes=None,
         classifier_activation="softmax",
-        block_fn=Block,
+        block_fn=apply_block,
         **kwargs,
     ):
         if weights and not tf.io.gfile.exists(weights):
@@ -399,7 +401,7 @@ class ResNetV2(keras.Model):
                 stride=stackwise_strides[stack_index],
                 dilations=stackwise_dilations[stack_index],
                 block_fn=block_fn,
-                first_shortcut=block_fn == Block or stack_index > 0,
+                first_shortcut=block_fn == apply_block or stack_index > 0,
                 stack_index=stack_index,
             )
             stack_level_outputs[stack_index + 2] = x
@@ -497,7 +499,7 @@ def ResNet18V2(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        block_fn=BasicBlock,
+        block_fn=apply_basic_block,
         **kwargs,
     )
 
@@ -530,7 +532,7 @@ def ResNet34V2(
         pooling=pooling,
         classes=classes,
         classifier_activation=classifier_activation,
-        block_fn=BasicBlock,
+        block_fn=apply_basic_block,
         **kwargs,
     )
 

--- a/keras_cv/models/resnet_v2_test.py
+++ b/keras_cv/models/resnet_v2_test.py
@@ -14,6 +14,7 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
+from packaging import version
 
 from keras_cv.models import resnet_v2
 
@@ -51,17 +52,17 @@ class ResNetV2Test(ModelsTest, tf.test.TestCase, parameterized.TestCase):
         super()._test_application_variable_input_channels(app, last_dim, args)
 
     @parameterized.parameters(*MODEL_LIST)
-    def test_model_can_be_used_as_backbone(self, app, last_dim, args):
-        super()._test_model_can_be_used_as_backbone(app, last_dim, args)
-
-    @parameterized.parameters(*MODEL_LIST)
-    def test_model_serialization(self, app, last_dim, args):
+    def test_model_serialization_tf(self, app, last_dim, args):
         super()._test_model_serialization(
             app, last_dim, args, save_format="tf", filename="model"
         )
-        super()._test_model_serialization(
-            app, last_dim, args, save_format="keras_v3", filename="model.keras"
-        )
+
+    @parameterized.parameters(*MODEL_LIST)
+    def test_model_serialization_keras_format(self, app, last_dim, args):
+        if version.parse(tf.__version__) >= version.parse("2.12.0-dev0"):
+            super()._test_model_serialization(
+                app, last_dim, args, save_format="keras_v3", filename="model.keras"
+            )
 
     def test_model_backbone_layer_names_stability(self):
         model = resnet_v2.ResNet50V2(


### PR DESCRIPTION
This is a pilot to remove closures and use subclassed functional models in our implementations. This is part of our effort to standardize the KerasCV and KerasNLP APIs.

An earlier draft (#1390) attempted to replace the closures with `keras.layers.Layer`, but it proved too heavyweight. We use plain python functions here instead.

This change should not affect the underlying graph. This [Colab](https://colab.research.google.com/gist/ianstenbit/ff87f2e908f034043f0c425359b79a75/numerical-comparison-of-models.ipynb) verifies that existing pretrained checkpoints can be loaded.

## Why this design?
* A subclassed `keras.Model` is needed to add a `from_preset` constructor for loading preset architectures and weights. In the long term this and other methods/properties will be maintained in a new `Backbone` base class.
* We initialize a functional `keras.Model` in the `__init__` to maintain the convenience of the `Functional` API.
* When using a subclassed `keras.Model` it is not possible to track weights in a closure-style submodel. Therefore we need to switch to regular python functions. See @LukeWood's analysis ([link](https://lukewood.xyz/blog/subclass-model-pitfall)).