### PR TITLE
Remove the need for a image input shape in StableDiffusion

### DIFF
--- a/keras_cv/models/stable_diffusion/__internal__/layers/attention_block.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/attention_block.py
@@ -35,12 +35,13 @@ class AttentionBlock(keras.layers.Layer):
         q, k, v = self.q(x), self.k(x), self.v(x)
 
         # Compute attention
-        _, h, w, c = q.shape
+        shape = tf.shape(q)
+        h, w, c = shape[1], shape[2], shape[3]
         q = tf.reshape(q, (-1, h * w, c))  # b, hw, c
         k = tf.transpose(k, (0, 3, 1, 2))
         k = tf.reshape(k, (-1, c, h * w))  # b, c, hw
         y = q @ k
-        y = y * (c**-0.5)
+        y = y * 1 / tf.sqrt(tf.cast(c, self.compute_dtype))
         y = keras.activations.softmax(y)
 
         # Attend to values

--- a/keras_cv/models/stable_diffusion/image_encoder.py
+++ b/keras_cv/models/stable_diffusion/image_encoder.py
@@ -28,10 +28,10 @@ from keras_cv.models.stable_diffusion.__internal__.layers.resnet_block import (
 class ImageEncoder(keras.Sequential):
     """ImageEncoder is the VAE Encoder for StableDiffusion."""
 
-    def __init__(self, img_height=512, img_width=512, download_weights=True):
+    def __init__(self, download_weights=True):
         super().__init__(
             [
-                keras.layers.Input((img_height, img_width, 3)),
+                keras.layers.Input((None, None, 3)),
                 PaddedConv2D(128, 3, padding=1),
                 ResnetBlock(128),
                 ResnetBlock(128),

--- a/keras_cv/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion.py
@@ -410,7 +410,7 @@ class StableDiffusionBase:
         ```
         """
         if self._image_encoder is None:
-            self._image_encoder = ImageEncoder(self.img_height, self.img_width)
+            self._image_encoder = ImageEncoder()
             if self.jit_compile:
                 self._image_encoder.compile(jit_compile=True)
         return self._image_encoder


### PR DESCRIPTION
This is done by changing the call to `shape` with `tf.shape()`, and changing **-0.5 to 1/tf.sqrt(c).

Slightly better UX, output dim is constant so users will not need to resize input images anymore.