### PR TITLE
Add vectorized RandomBrightness, RandomContrast, RandomHue and RandomColorJitter

### DIFF
--- a/benchmarks/vectorized_random_brightness.py
+++ b/benchmarks/vectorized_random_brightness.py
@@ -1,0 +1,233 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from keras_cv.layers import RandomBrightness
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
+
+
+class OldRandomBrightness(BaseImageAugmentationLayer):
+    """A preprocessing layer which randomly adjusts brightness during training.
+    This layer will randomly increase/reduce the brightness for the input RGB
+    images.
+
+    At inference time, the output will be identical to the input.
+    Call the layer with `training=True` to adjust the brightness of the input.
+
+    Note that different brightness adjustment factors
+    will be apply to each the images in the batch.
+
+    Args:
+      factor: Float or a list/tuple of 2 floats between -1.0 and 1.0. The
+        factor is used to determine the lower bound and upper bound of the
+        brightness adjustment. A float value will be chosen randomly between
+        the limits. When -1.0 is chosen, the output image will be black, and
+        when 1.0 is chosen, the image will be fully white. When only one float
+        is provided, eg, 0.2, then -0.2 will be used for lower bound and 0.2
+        will be used for upper bound.
+      value_range: Optional list/tuple of 2 floats for the lower and upper limit
+        of the values of the input data. Defaults to [0.0, 255.0]. Can be
+        changed to e.g. [0.0, 1.0] if the image input has been scaled before
+        this layer.  The brightness adjustment will be scaled to this range, and
+        the output values will be clipped to this range.
+      seed: optional integer, for fixed RNG behavior.
+    Inputs: 3D (HWC) or 4D (NHWC) tensor, with float or int dtype. Input pixel
+      values can be of any range (e.g. `[0., 1.)` or `[0, 255]`)
+    Output: 3D (HWC) or 4D (NHWC) tensor with brightness adjusted based on the
+      `factor`. By default, the layer will output floats. The output value will
+      be clipped to the range `[0, 255]`, the valid range of RGB colors, and
+      rescaled based on the `value_range` if needed.
+    ```
+    """
+
+    def __init__(self, factor, value_range=(0, 255), seed=None, **kwargs):
+        super().__init__(seed=seed, force_generator=True, **kwargs)
+        if isinstance(factor, float) or isinstance(factor, int):
+            factor = (-factor, factor)
+        self.factor = preprocessing_utils.parse_factor(
+            factor, min_value=-1, max_value=1
+        )
+        self.value_range = value_range
+        self.seed = seed
+
+    def augment_image(self, image, transformation, **kwargs):
+        return self._brightness_adjust(image, transformation)
+
+    def augment_label(self, label, transformation, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def augment_bounding_boxes(self, bounding_boxes, transformation=None, **kwargs):
+        return bounding_boxes
+
+    def get_random_transformation(self, **kwargs):
+        rgb_delta_shape = (1, 1, 1)
+        random_rgb_delta = self.factor(shape=rgb_delta_shape)
+        random_rgb_delta = random_rgb_delta * (
+            self.value_range[1] - self.value_range[0]
+        )
+        return random_rgb_delta
+
+    def _brightness_adjust(self, image, rgb_delta):
+        rank = image.shape.rank
+        if rank != 3:
+            raise ValueError(
+                "Expected the input image to be rank 3. Got "
+                f"inputs.shape = {image.shape}"
+            )
+        rgb_delta = tf.cast(rgb_delta, image.dtype)
+        image += rgb_delta
+        return tf.clip_by_value(image, self.value_range[0], self.value_range[1])
+
+    def get_config(self):
+        config = {
+            "factor": self.factor,
+            "value_range": self.value_range,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class RandomBrightnessTest(tf.test.TestCase):
+    def test_consistency_with_old_impl_rescaled_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        image = tf.random.uniform(shape=image_shape)
+
+        layer = RandomBrightness(factor=fixed_factor)
+        old_layer = OldRandomBrightness(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output)
+
+    def test_consistency_with_old_impl_rgb_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        image = tf.random.uniform(shape=image_shape) * 255.0
+
+        layer = RandomBrightness(factor=fixed_factor)
+        old_layer = OldRandomBrightness(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output)
+
+
+if __name__ == "__main__":
+    # Run benchmark
+    (x_train, _), _ = tf.keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(np.float32)
+
+    num_images = [1000, 2000, 5000, 10000]
+    results = {}
+    aug_candidates = [RandomBrightness, OldRandomBrightness]
+    aug_args = {"factor": (0.5)}
+
+    for aug in aug_candidates:
+        # Eager Mode
+        c = aug.__name__
+        layer = aug(**aug_args)
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            layer(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = layer(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # Graph Mode
+        c = aug.__name__ + " Graph Mode"
+        layer = aug(**aug_args)
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # XLA Mode
+        c = aug.__name__ + " XLA Mode"
+        layer = aug(**aug_args)
+
+        @tf.function(jit_compile=True)
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison.png")
+
+    # So we can actually see more relevant margins
+    del results[aug_candidates[1].__name__]
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison_no_old_eager.png")
+
+    # Run unit tests
+    tf.test.main()

--- a/benchmarks/vectorized_random_contrast.py
+++ b/benchmarks/vectorized_random_contrast.py
@@ -1,0 +1,223 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from keras_cv.layers import RandomContrast
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
+
+
+class OldRandomContrast(BaseImageAugmentationLayer):
+    """RandomContrast randomly adjusts contrast during training.
+
+    This layer will randomly adjust the contrast of an image or images by a
+    random factor. Contrast is adjusted independently for each channel of each
+    image during training.
+
+    For each channel, this layer computes the mean of the image pixels in the
+    channel and then adjusts each component `x` of each pixel to
+    `(x - mean) * contrast_factor + mean`.
+
+    Input pixel values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and
+    in integer or floating point dtype. By default, the layer will output
+    floats. The output value will be clipped to the range `[0, 255]`, the valid
+    range of RGB colors.
+
+    Input shape:
+      3D (unbatched) or 4D (batched) tensor with shape:
+      `(..., height, width, channels)`, in `"channels_last"` format.
+    Output shape:
+      3D (unbatched) or 4D (batched) tensor with shape:
+      `(..., height, width, channels)`, in `"channels_last"` format.
+
+    Args:
+      factor: a positive float represented as fraction of value, or a tuple of
+        size 2 representing lower and upper bound. When represented as a single
+        float, lower = upper. The contrast factor will be randomly picked
+        between `[1.0 - lower, 1.0 + upper]`. For any pixel x in the channel,
+        the output will be `(x - mean) * factor + mean` where `mean` is the mean
+        value of the channel.
+      seed: Integer. Used to create a random seed.
+    """
+
+    def __init__(self, factor, seed=None, **kwargs):
+        super().__init__(seed=seed, force_generator=True, **kwargs)
+        if isinstance(factor, (tuple, list)):
+            min = 1 - factor[0]
+            max = 1 + factor[1]
+        else:
+            min = 1 - factor
+            max = 1 + factor
+        self.factor_input = factor
+        self.factor = preprocessing_utils.parse_factor(
+            (min, max), min_value=-1, max_value=2
+        )
+        self.seed = seed
+
+    def get_random_transformation(self, **kwargs):
+        return self.factor()
+
+    def augment_image(self, image, transformation, **kwargs):
+        contrast_factor = transformation
+        output = tf.image.adjust_contrast(image, contrast_factor=contrast_factor)
+        output = tf.clip_by_value(output, 0, 255)
+        output.set_shape(image.shape)
+        return output
+
+    def augment_label(self, label, transformation, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def augment_bounding_boxes(self, bounding_boxes, transformation=None, **kwargs):
+        return bounding_boxes
+
+    def get_config(self):
+        config = {
+            "factor": self.factor_input,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class RandomContrastTest(tf.test.TestCase):
+    def test_consistency_with_old_impl_rescaled_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.3, -0.3)  # makes lower and upper the same
+        image = tf.random.uniform(shape=image_shape)
+
+        layer = RandomContrast(factor=fixed_factor)
+        old_layer = OldRandomContrast(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output)
+
+    def test_consistency_with_old_impl_rgb_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.3, -0.3)  # makes lower and upper the same
+        image = tf.random.uniform(shape=image_shape) * 255.0
+
+        layer = RandomContrast(factor=fixed_factor)
+        old_layer = OldRandomContrast(factor=fixed_factor)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output, atol=1e-5, rtol=1e-5)
+
+
+if __name__ == "__main__":
+    # Run benchmark
+    (x_train, _), _ = tf.keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(np.float32)
+
+    num_images = [1000, 2000, 5000, 10000]
+    results = {}
+    aug_candidates = [RandomContrast, OldRandomContrast]
+    aug_args = {"factor": (0.5)}
+
+    for aug in aug_candidates:
+        # Eager Mode
+        c = aug.__name__
+        layer = aug(**aug_args)
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            layer(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = layer(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # Graph Mode
+        c = aug.__name__ + " Graph Mode"
+        layer = aug(**aug_args)
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # XLA Mode
+        c = aug.__name__ + " XLA Mode"
+        layer = aug(**aug_args)
+
+        @tf.function(jit_compile=True)
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison.png")
+
+    # So we can actually see more relevant margins
+    del results[aug_candidates[1].__name__]
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison_no_old_eager.png")
+
+    # Run unit tests
+    tf.test.main()

--- a/benchmarks/vectorized_random_hue.py
+++ b/benchmarks/vectorized_random_hue.py
@@ -1,0 +1,206 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+from keras_cv.layers import RandomHue
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
+
+
+class OldRandomHue(BaseImageAugmentationLayer):
+    """Randomly adjusts the hue on given images.
+
+    This layer will randomly increase/reduce the hue for the input RGB
+    images. At inference time, the output will be identical to the input.
+    Call the layer with `training=True` to adjust the brightness of the input.
+
+    The image hue is adjusted by converting the image(s) to HSV and rotating the
+    hue channel (H) by delta. The image is then converted back to RGB.
+
+    Args:
+        factor: A tuple of two floats, a single float or `keras_cv.FactorSampler`.
+            `factor` controls the extent to which the image hue is impacted.
+            `factor=0.0` makes this layer perform a no-op operation, while a value of
+            1.0 performs the most aggressive contrast adjustment available.  If a tuple
+            is used, a `factor` is sampled between the two values for every image
+            augmented.  If a single float is used, a value between `0.0` and the passed
+            float is sampled.  In order to ensure the value is always the same, please
+            pass a tuple with two identical floats: `(0.5, 0.5)`.
+        value_range:  the range of values the incoming images will have.
+            Represented as a two number tuple written [low, high].
+            This is typically either `[0, 1]` or `[0, 255]` depending
+            on how your preprocessing pipeline is setup.
+        seed: Integer. Used to create a random seed.
+
+    """
+
+    def __init__(self, factor, value_range, seed=None, **kwargs):
+        super().__init__(seed=seed, **kwargs)
+        self.factor = preprocessing_utils.parse_factor(
+            factor,
+        )
+        self.value_range = value_range
+        self.seed = seed
+
+    def get_random_transformation(self, **kwargs):
+        invert = preprocessing_utils.random_inversion(self._random_generator)
+        # We must scale self.factor() to the range [-0.5, 0.5].  This is because the
+        # tf.image operation performs rotation on the hue saturation value orientation.
+        # This can be thought of as an angle in the range [-180, 180]
+        return invert * self.factor() * 0.5
+
+    def augment_image(self, image, transformation=None, **kwargs):
+        image = preprocessing_utils.transform_value_range(
+            image, self.value_range, (0, 1), dtype=self.compute_dtype
+        )
+
+        # tf.image.adjust_hue expects floats to be in range [0, 1]
+        image = tf.image.adjust_hue(image, delta=transformation)
+        # RandomHue is one of the rare KPLs that needs to clip
+        image = tf.clip_by_value(image, 0, 1)
+        image = preprocessing_utils.transform_value_range(
+            image, (0, 1), self.value_range, dtype=self.compute_dtype
+        )
+        return image
+
+    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+        return bounding_boxes
+
+    def augment_label(self, label, transformation=None, **kwargs):
+        return label
+
+    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
+        return segmentation_mask
+
+    def get_config(self):
+        config = {
+            "factor": self.factor,
+            "value_range": self.value_range,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class RandomHueTest(tf.test.TestCase):
+    def test_consistency_with_old_impl_rescaled_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        fixed_seed = 2023
+        image = tf.random.uniform(shape=image_shape)
+
+        layer = RandomHue(fixed_factor, (0, 1), fixed_seed)
+        old_layer = OldRandomHue(fixed_factor, (0, 1), fixed_seed)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output)
+
+    def test_consistency_with_old_impl_rgb_range(self):
+        image_shape = (16, 32, 32, 3)
+        fixed_factor = (0.8, 0.8)
+        fixed_seed = 2023
+        image = tf.random.uniform(shape=image_shape) * 255.0
+
+        layer = RandomHue(fixed_factor, (0, 255), fixed_seed)
+        old_layer = OldRandomHue(fixed_factor, (0, 255), fixed_seed)
+
+        output = layer(image)
+        old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output, atol=1e-3, rtol=1e-5)
+
+
+if __name__ == "__main__":
+    # Run benchmark
+    (x_train, _), _ = tf.keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(np.float32)
+
+    num_images = [1000, 2000, 5000, 10000]
+    results = {}
+    aug_candidates = [RandomHue, OldRandomHue]
+    aug_args = {"factor": (0.5), "value_range": (0, 255)}
+
+    for aug in aug_candidates:
+        # Eager Mode
+        c = aug.__name__
+        layer = aug(**aug_args)
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            layer(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = layer(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # Graph Mode
+        c = aug.__name__ + " Graph Mode"
+        layer = aug(**aug_args)
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            apply_aug(x_train[:n_images])
+
+            t0 = time.time()
+            r1 = apply_aug(x_train[:n_images])
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # XLA Mode
+        # OldRandomHue fails to run jit_compile=True
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison.png")
+
+    # So we can actually see more relevant margins
+    del results[aug_candidates[1].__name__]
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison_no_old_eager.png")
+
+    # Run unit tests
+    tf.test.main()

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,14 @@
 # limitations under the License.
 import tensorflow as tf
 
-from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
-    BaseImageAugmentationLayer,
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    VectorizedBaseImageAugmentationLayer,
 )
-from keras_cv.utils import preprocessing
+from keras_cv.utils import preprocessing as preprocessing_utils
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")
-class RandomHue(BaseImageAugmentationLayer):
+class RandomHue(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the hue on given images.
 
     This layer will randomly increase/reduce the hue for the input RGB
@@ -45,45 +45,65 @@ class RandomHue(BaseImageAugmentationLayer):
             on how your preprocessing pipeline is setup.
         seed: Integer. Used to create a random seed.
 
+    Usage:
+    ```python
+    (images, labels), _ = tf.keras.datasets.cifar10.load_data()
+    random_hue = keras_cv.layers.preprocessing.RandomHue()
+    augmented_images = random_hue(images)
+    ```
     """
 
     def __init__(self, factor, value_range, seed=None, **kwargs):
         super().__init__(seed=seed, **kwargs)
-        self.factor = preprocessing.parse_factor(
+        self.factor = preprocessing_utils.parse_factor(
             factor,
         )
         self.value_range = value_range
         self.seed = seed
 
-    def get_random_transformation(self, **kwargs):
-        invert = preprocessing.random_inversion(self._random_generator)
+    def get_random_transformation_batch(self, batch_size, **kwargs):
+        invert = self._random_generator.random_uniform((batch_size,), 0, 1, tf.float32)
+        invert = tf.where(invert > 0.5, -tf.ones_like(invert), tf.ones_like(invert))
         # We must scale self.factor() to the range [-0.5, 0.5].  This is because the
         # tf.image operation performs rotation on the hue saturation value orientation.
         # This can be thought of as an angle in the range [-180, 180]
-        return invert * self.factor() * 0.5
+        return invert * self.factor(shape=(batch_size,)) * 0.5
 
-    def augment_image(self, image, transformation=None, **kwargs):
-        image = preprocessing.transform_value_range(
-            image, self.value_range, (0, 1), dtype=self.compute_dtype
+    def augment_ragged_image(self, image, transformation, **kwargs):
+        return self.augment_images(
+            images=image, transformations=transformation, **kwargs
         )
+
+    def augment_images(self, images, transformations, **kwargs):
+        images = preprocessing_utils.transform_value_range(
+            images, self.value_range, (0, 1), dtype=self.compute_dtype
+        )
+        adjust_factors = tf.cast(transformations, images.dtype)
+        # broadcast
+        adjust_factors = adjust_factors[..., tf.newaxis, tf.newaxis]
 
         # tf.image.adjust_hue expects floats to be in range [0, 1]
-        image = tf.image.adjust_hue(image, delta=transformation)
+        images = tf.image.rgb_to_hsv(images)
+        h_channel = images[..., 0] + adjust_factors
+        h_channel = tf.where(h_channel > 1.0, h_channel - 1.0, h_channel)
+        h_channel = tf.where(h_channel < 0.0, h_channel + 1.0, h_channel)
+        images = tf.stack([h_channel, images[..., 1], images[..., 2]], axis=-1)
+        images = tf.image.hsv_to_rgb(images)
         # RandomHue is one of the rare KPLs that needs to clip
-        image = tf.clip_by_value(image, 0, 1)
-        image = preprocessing.transform_value_range(
-            image, (0, 1), self.value_range, dtype=self.compute_dtype
+        images = tf.clip_by_value(images, 0, 1)
+        images = preprocessing_utils.transform_value_range(
+            images, (0, 1), self.value_range, dtype=self.compute_dtype
         )
-        return image
+        return images
 
-    def augment_bounding_boxes(self, bounding_boxes, **kwargs):
+    def augment_labels(self, labels, transformations, **kwargs):
+        return labels
+
+    def augment_segmentation_masks(self, segmentation_masks, transformations, **kwargs):
+        return segmentation_masks
+
+    def augment_bounding_boxes(self, bounding_boxes, transformations, **kwargs):
         return bounding_boxes
-
-    def augment_label(self, label, transformation=None, **kwargs):
-        return label
-
-    def augment_segmentation_mask(self, segmentation_mask, transformation, **kwargs):
-        return segmentation_mask
 
     def get_config(self):
         config = {
@@ -93,3 +113,9 @@ class RandomHue(BaseImageAugmentationLayer):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        if isinstance(config["factor"], dict):
+            config["factor"] = tf.keras.utils.deserialize_keras_object(config["factor"])
+        return cls(**config)

--- a/keras_cv/layers/preprocessing/random_hue_test.py
+++ b/keras_cv/layers/preprocessing/random_hue_test.py
@@ -48,8 +48,12 @@ class RandomHueTest(tf.test.TestCase, parameterized.TestCase):
         channel_min = tf.math.reduce_min(output, axis=-1)
         # Make sure the max and min channel are the same between input and output
         # In the meantime, and channel will swap between each other.
-        self.assertAllClose(channel_max, tf.math.reduce_max(image, axis=-1))
-        self.assertAllClose(channel_min, tf.math.reduce_min(image, axis=-1))
+        self.assertAllClose(
+            channel_max, tf.math.reduce_max(image, axis=-1), atol=1e-5, rtol=1e-5
+        )
+        self.assertAllClose(
+            channel_min, tf.math.reduce_min(image, axis=-1), atol=1e-5, rtol=1e-5
+        )
 
     @parameterized.named_parameters(
         ("025", 0.25), ("05", 0.5), ("075", 0.75), ("100", 1.0)


### PR DESCRIPTION
# What does this PR do?

Fixes #1405 
Fixes #1376 

Following #1392 but I moved A/B testing into benchmarks suggested by @ianstenbit 's comment at https://github.com/keras-team/keras-cv/pull/1392#discussion_r1107523531, also I added XLA Mode `jit_compile=True` for benchmarks suggested by @bhack 

For unit tests, only `keras_cv/layers/preprocessing/random_hue_test.py` failed at `test_adjust_full_opposite_hue` and could be resolved by relaxing constraints `atol=1e-5, rtol=1e-5`

For numerical check (used `image_shape = (1024, 32, 32, 3)` locally):
- `./benchmarks/vectorized_random_brightness.py` passes without any constraint relaxing
- `./benchmarks/vectorized_random_contrast.py` passes with `atol=1e-5, rtol=1e-5` at rgb value range
- `./benchmarks/vectorized_random_hue.py` passes with `atol=1e-3, rtol=1e-5` at rgb value range

`./benchmarks/vectorized_random_color_jitter.py` has no numerical check because it is composited by above layers

Some notes:
- `OldRandomBrightness` got similar performance with Graph/XLA Mode, other vectorized layers got significant boost
- `RandomHue` failed to run XLA mode
- The benchmark of `RandomColorJitter` was done after I vectorizing all sub-layers

This is results from benchmarks:

#### RandomBrightness
<details>

![comparison](https://user-images.githubusercontent.com/20734616/219316033-68cb182d-848d-4285-adfd-7e76ce0fb39d.png)
![comparison_no_old_eager](https://user-images.githubusercontent.com/20734616/219316063-ea92e5c4-1d72-4bba-8e47-8ea023f5c7d1.png)
</details>

#### RandomContrast
<details>

![comparison](https://user-images.githubusercontent.com/20734616/219316314-4b5cdb62-62d7-43aa-be38-aa3f58b6c8ff.png)
![comparison_no_old_eager](https://user-images.githubusercontent.com/20734616/219316358-d38c18fa-64a5-4d32-875b-acb80917e05c.png)
</details>

#### RandomHue (no XLA Mode)
<details>

![comparison](https://user-images.githubusercontent.com/20734616/219316579-b4381921-45a5-4133-b93b-e95424033506.png)
![comparison_no_old_eager](https://user-images.githubusercontent.com/20734616/219316601-1f4a0f96-a0c9-4af0-a676-dae09e99b971.png)
</details>

#### RandomColorJitter
<details>

![comparison](https://user-images.githubusercontent.com/20734616/219316710-5635223d-3f91-4744-b65b-0df0b1133439.png)
![comparison_no_old_eager](https://user-images.githubusercontent.com/20734616/219316752-a68a658b-9b34-44a1-a599-22a8c69b0441.png)
</details>

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 
