### PR TITLE
Refactor feature extraction for `RetinaNet`

### DIFF
--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -34,7 +34,6 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         model = keras_cv.models.RetinaNet(
             num_classes=10,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone().get_feature_extractor(),
         )
         # all metric formats must match
         model.compile(
@@ -63,7 +62,6 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         model = keras_cv.models.FasterRCNN(
             num_classes=10,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone().get_feature_extractor(),
         )
         model.compile(
             optimizer="adam",

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -15,7 +15,6 @@
 
 import os
 
-import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv.utils.python_utils import classproperty

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -146,13 +146,22 @@ class Backbone(keras.Model):
 
     @property
     def pyramid_level_inputs(self):
-        """Intermediate model outputs for transfer learning.
+        """Intermediate model outputs for feature extraction.
 
         Format is a dictionary with int as key and layer name as value.
         The int key represent the level of the feature output. A typical feature
         pyramid has five levels corresponding to scales P3, P4, P5, P6, P7 in
         the backbone. Scale Pn represents a feature map 2^n times smaller in
         width and height than the input image.
+
+        Example:
+        ```python
+        {
+            3: 'v2_stack_1_block4_out',
+            4: 'v2_stack_2_block6_out',
+            5: 'v2_stack_3_block3_out',
+        }
+        ```
         """
         return self._pyramid_level_inputs
 

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -31,7 +31,7 @@ class Backbone(keras.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._stack_level_outputs = {}
+        self._pyramid_level_outputs = {}
 
     @classmethod
     def from_config(cls, config):
@@ -146,20 +146,20 @@ class Backbone(keras.Model):
             )(cls.from_preset.__func__)
 
     @property
-    def stack_level_outputs(self):
+    def pyramid_level_outputs(self):
         """Intermediate model outputs for transfer learning.
 
         Format is a dictionary with int as key and layer name as value.
         The int key represent the level of the feature output. A typical feature
         pyramid has five levels corresponding to scales P3, P4, P5, P6, P7 in
-        the backbone. Scale Pn represents a feature map 2n times smaller in
+        the backbone. Scale Pn represents a feature map 2^n times smaller in
         width and height than the input image.
         """
-        return self._stack_level_outputs
+        return self._pyramid_level_outputs
 
-    @stack_level_outputs.setter
-    def stack_level_outputs(self, value):
-        self._stack_level_outputs = value
+    @pyramid_level_outputs.setter
+    def pyramid_level_outputs(self, value):
+        self._pyramid_level_outputs = value
 
     def get_feature_extractor(self, layer_names, output_keys=None):
         """Create a feature extractor model with augmented output.

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -31,7 +31,7 @@ class Backbone(keras.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._pyramid_level_outputs = {}
+        self._pyramid_level_inputs = {}
 
     @classmethod
     def from_config(cls, config):
@@ -146,7 +146,7 @@ class Backbone(keras.Model):
             )(cls.from_preset.__func__)
 
     @property
-    def pyramid_level_outputs(self):
+    def pyramid_level_inputs(self):
         """Intermediate model outputs for transfer learning.
 
         Format is a dictionary with int as key and layer name as value.
@@ -155,32 +155,8 @@ class Backbone(keras.Model):
         the backbone. Scale Pn represents a feature map 2^n times smaller in
         width and height than the input image.
         """
-        return self._pyramid_level_outputs
+        return self._pyramid_level_inputs
 
-    @pyramid_level_outputs.setter
-    def pyramid_level_outputs(self, value):
-        self._pyramid_level_outputs = value
-
-    def get_feature_extractor(self, layer_names, output_keys=None):
-        """Create a feature extractor model with augmented output.
-
-        This method produces a new `keras.Model` with the same input signature
-        as this instance but with the layers in `layer_names` as the output.
-        This is useful for downstream Tasks that require more output than the
-        final layer of the backbone.
-
-        Args:
-            layer_names: list of strings. Names of layers to include in the
-                output signature.
-            output_keys: optional, list of strings. Key to use for each layer in
-                the model's output dictionary
-
-        Returns:
-            `tf.keras.Model` which has dict as outputs.
-        """
-
-        if not output_keys:
-            output_keys = layer_names
-        items = zip(output_keys, layer_names)
-        outputs = {item[0]: self.get_layer(item[1]).output for item in items}
-        return tf.keras.Model(inputs=self.inputs, outputs=outputs)
+    @pyramid_level_inputs.setter
+    def pyramid_level_inputs(self, value):
+        self._pyramid_level_inputs = value

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -32,6 +32,14 @@ class Backbone(keras.Model):
         super().__init__(*args, **kwargs)
         self._pyramid_level_inputs = {}
 
+    def get_config(self):
+        # Don't chain to super here. The default `get_config()` for functional
+        # models is nested and cannot be passed to our Backbone constructors.
+        return {
+            "name": self.name,
+            "trainable": self.trainable,
+        }
+
     @classmethod
     def from_config(cls, config):
         # The default `from_config()` for functional models will return a

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -342,11 +342,10 @@ class ResNetV2Backbone(Backbone):
 
         pyramid_level_inputs = {}
         for stack_index in range(num_stacks):
-            num_blocks = stackwise_blocks[stack_index]
             x = apply_stack(
                 x,
                 filters=stackwise_filters[stack_index],
-                blocks=num_blocks,
+                blocks=stackwise_blocks[stack_index],
                 stride=stackwise_strides[stack_index],
                 dilations=stackwise_dilations[stack_index],
                 block_type=block_type,

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -202,7 +202,6 @@ def apply_stack(
     name=None,
     block_type="block",
     first_shortcut=True,
-    stack_index=1,
 ):
     """A set of stacked blocks.
 
@@ -217,15 +216,13 @@ def apply_stack(
             stack. Use "basic_block" for ResNet18 and ResNet34.
         first_shortcut: bool. Use convolution shortcut if `True` (default),
             otherwise uses identity or pooling shortcut, based on stride.
-        stack_index: int, the index of this stack in the ResNet model. Defaults
-            to 1.
 
     Returns:
         Output tensor for the stacked blocks.
     """
 
     if name is None:
-        name = f"v2_stack_{stack_index}"
+        name = "v2_stack"
 
     if block_type == "basic_block":
         block_fn = apply_basic_block
@@ -354,11 +351,9 @@ class ResNetV2Backbone(Backbone):
                 dilations=stackwise_dilations[stack_index],
                 block_type=block_type,
                 first_shortcut=(block_type == "block" or stack_index > 0),
-                stack_index=stack_index,
+                name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[
-                stack_index + 2
-            ] = f"v2_stack_{stack_index}_block{num_blocks}_out"
+            pyramid_level_inputs[stack_index + 2] = x.node.layer.name
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"
@@ -495,7 +490,6 @@ class ResNet34V2Backbone(ResNetV2Backbone):
         return {}
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet50V2Backbone(ResNetV2Backbone):
     def __new__(
         self,

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -342,7 +342,7 @@ class ResNetV2Backbone(Backbone):
         if stackwise_dilations is None:
             stackwise_dilations = [1] * num_stacks
 
-        pyramid_level_outputs = {}
+        pyramid_level_inputs = {}
         for stack_index in range(num_stacks):
             x, output_name = apply_stack(
                 x,
@@ -354,7 +354,7 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 stack_index=stack_index,
             )
-            pyramid_level_outputs[stack_index + 2] = output_name
+            pyramid_level_inputs[stack_index + 2] = output_name
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"
@@ -365,7 +365,7 @@ class ResNetV2Backbone(Backbone):
         super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         # All references to `self` below this line
-        self.pyramid_level_outputs = pyramid_level_outputs
+        self.pyramid_level_inputs = pyramid_level_inputs
         self.stackwise_filters = stackwise_filters
         self.stackwise_blocks = stackwise_blocks
         self.stackwise_strides = stackwise_strides

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -342,7 +342,7 @@ class ResNetV2Backbone(Backbone):
         if stackwise_dilations is None:
             stackwise_dilations = [1] * num_stacks
 
-        stack_level_outputs = {}
+        pyramid_level_outputs = {}
         for stack_index in range(num_stacks):
             x, output_name = apply_stack(
                 x,
@@ -354,7 +354,7 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 stack_index=stack_index,
             )
-            stack_level_outputs[stack_index + 2] = output_name
+            pyramid_level_outputs[stack_index + 2] = output_name
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"
@@ -365,9 +365,7 @@ class ResNetV2Backbone(Backbone):
         super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         # All references to `self` below this line
-        # Backbone outputs at each resolution level for transfer learning.
-        self.stack_level_outputs = stack_level_outputs
-
+        self.pyramid_level_outputs = pyramid_level_outputs
         self.stackwise_filters = stackwise_filters
         self.stackwise_blocks = stackwise_blocks
         self.stackwise_strides = stackwise_strides

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -373,19 +373,21 @@ class ResNetV2Backbone(Backbone):
         self.block_type = block_type
 
     def get_config(self):
-        return {
-            "stackwise_filters": self.stackwise_filters,
-            "stackwise_blocks": self.stackwise_blocks,
-            "stackwise_strides": self.stackwise_strides,
-            "include_rescaling": self.include_rescaling,
-            # Remove batch dimension from `input_shape`
-            "input_shape": self.input_shape[1:],
-            "stackwise_dilations": self.stackwise_dilations,
-            "input_tensor": self.input_tensor,
-            "block_type": self.block_type,
-            "name": self.name,
-            "trainable": self.trainable,
-        }
+        config = super().get_config()
+        config.update(
+            {
+                "stackwise_filters": self.stackwise_filters,
+                "stackwise_blocks": self.stackwise_blocks,
+                "stackwise_strides": self.stackwise_strides,
+                "include_rescaling": self.include_rescaling,
+                # Remove batch dimension from `input_shape`
+                "input_shape": self.input_shape[1:],
+                "stackwise_dilations": self.stackwise_dilations,
+                "input_tensor": self.input_tensor,
+                "block_type": self.block_type,
+            }
+        )
+        return config
 
     @classproperty
     def presets(cls):

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -81,7 +81,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("keras_format", "keras_v3", "model.keras"),
     )
     def test_saved_alias_model(self, save_format, filename):
-        model = ResNet18V2Backbone()
+        model = ResNet50V2Backbone()
         model_output = model(self.input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -88,7 +88,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
-        # Note that these aliases create the base case
+        # Note that these aliases serialized as the base class
         self.assertIsInstance(restored_model, ResNetV2Backbone)
 
         # Check that output matches.

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -19,7 +19,7 @@ from absl.testing import parameterized
 from tensorflow import keras
 
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
-    ResNet18V2Backbone,
+    ResNet50V2Backbone,
 )
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
@@ -41,7 +41,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         model(self.input_batch)
 
     def test_valid_call_applications_model(self):
-        model = ResNet18V2Backbone()
+        model = ResNet50V2Backbone()
         model(self.input_batch)
 
     def test_valid_call_with_rescaling(self):
@@ -96,12 +96,8 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
                 continue
             self.assertEquals(layers_1[i].name, layers_2[i].name)
 
-    def test_create_backbone_model_from_application_model(self):
-        # ResNet50 style model
-        model = ResNetV2Backbone(
-            stackwise_filters=[64, 128, 256, 512],
-            stackwise_blocks=[3, 4, 6, 3],
-            stackwise_strides=[1, 2, 2, 2],
+    def test_create_backbone_model_from_alias_model(self):
+        model = ResNet50V2Backbone(
             include_rescaling=False,
         )
         backbone_model = get_feature_extractor(

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -24,6 +24,7 @@ from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
 )
+from keras_cv.utils.train import get_feature_extractor
 
 
 class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
@@ -103,7 +104,11 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             stackwise_strides=[1, 2, 2, 2],
             include_rescaling=False,
         )
-        backbone_model = model.get_feature_extractor()
+        backbone_model = get_feature_extractor(
+            model,
+            model.pyramid_level_inputs.values(),
+            model.pyramid_level_inputs.keys(),
+        )
         inputs = tf.keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # Resnet50 backbone has 4 level of features (2 ~ 5)
@@ -122,7 +127,9 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
             input_shape=[256, 256, 3],
         )
-        backbone_model = model.get_feature_extractor(min_level=3, max_level=4)
+        levels = [3, 4]
+        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = tf.keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -25,6 +25,7 @@ from keras_cv.models.object_detection.__test_utils__ import (
     _create_bounding_box_dataset,
 )
 from keras_cv.models.object_detection.faster_rcnn import FasterRCNN
+from keras_cv.utils.train import get_feature_extractor
 
 
 class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
@@ -106,4 +107,11 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         faster_rcnn.evaluate(dataset)
 
     def _build_backbone(self):
-        return ResNet50V2Backbone().get_feature_extractor()
+        backbone = ResNet50V2Backbone()
+        extractor_levels = [2, 3, 4, 5]
+        extractor_layer_names = [
+            backbone.pyramid_level_inputs[i] for i in extractor_levels
+        ]
+        return get_feature_extractor(
+            backbone, extractor_layer_names, extractor_levels
+        )

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -19,7 +19,6 @@ from tensorflow import keras
 import keras_cv
 from keras_cv import bounding_box
 from keras_cv import layers as cv_layers
-from keras_cv.models import ResNet50V2Backbone
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.models.object_detection import predict_utils
 from keras_cv.models.object_detection.__internal__ import unpack_input

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -25,21 +25,22 @@ from keras_cv.models.object_detection.__internal__ import unpack_input
 from keras_cv.models.object_detection.retina_net.__internal__ import (
     layers as layers_lib,
 )
+from keras_cv.utils.train import get_feature_extractor
 
 BOX_VARIANCE = [0.1, 0.1, 0.2, 0.2]
 
 
 # TODO(lukewood): update docstring to include documentation on creating a custom label
 # decoder/etc.
-# TODO(lukewood): link to keras.io guide on creating custom backbone and FPN.
+# TODO(jbischof): Generalize `FeaturePyramid` class to allow for any P-levels and
+# add `feature_pyramid_levels` param.
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RetinaNet(tf.keras.Model):
     """A Keras model implementing the RetinaNet architecture.
 
     Implements the RetinaNet architecture for object detection.  The constructor
     requires `classes`, and `bounding_box_format`.  Optionally, a backbone,
-    custom label encoder, feature pyramid network, and prediction decoder may all be
-    provided.
+    custom label encoder, and prediction decoder may all be provided.
 
     Usage:
     ```python
@@ -57,10 +58,9 @@ class RetinaNet(tf.keras.Model):
         bounding_box_format: The format of bounding boxes of input dataset. Refer
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
-        backbone: an optional `tf.keras.Model` custom backbone model.
-            If `feature_pyramid` is not provided, must implement the
-            `pyramid_level_outputs` property with keys "3", "4", and "5". Defaults
-            to a `keras_cv.models.ResNet50V2Backbone`.
+        backbone: optional `keras.Model`. Must implement the `pyramid_level_inputs`
+            property with keys 3, 4, and 5 and layer names as values. If
+            `None`, defaults to `keras_cv.models.ResNet50V2Backbone()`.
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`.  If provided,
             the anchor generator will be passed to both the `label_encoder` and the
             `prediction_decoder`.  Only to be used when both `label_encoder` and
@@ -71,18 +71,14 @@ class RetinaNet(tf.keras.Model):
             and `aspect_ratios=[0.5, 1.0, 2.0]`.
         label_encoder: (Optional) a keras.Layer that accepts an image Tensor, a
             bounding box Tensor and a bounding box class Tensor to its `call()` method,
-            and returns RetinaNet training targets.  By default, a KerasCV standard LabelEncoder is created and used.
-            Results of this `call()` method are passed to the `loss` object passed into
-            `compile()` as the `y_true` argument.
+            and returns RetinaNet training targets.  By default, a KerasCV standard
+            LabelEncoder is created and used.  Results of this `call()` method
+            are passed to the `loss` object passed into `compile()` as the `y_true`
+            argument.
         prediction_decoder: (Optional)  A `keras.layer` that is responsible for
             transforming RetinaNet predictions into usable bounding box Tensors.  If
             not provided, a default is provided.  The default `prediction_decoder`
             layer uses a `MultiClassNonMaxSuppression` operation for box pruning.
-        feature_pyramid: (Optional) A `keras.Model` representing a feature pyramid
-            network (FPN).  The feature pyramid network is called on the outputs of the
-            `backbone`.  If not provided, a default feature pyramid network is produced
-            by the library. The default feature pyramid network is compatible with all
-            standard keras_cv Backbones.
         classification_head: (Optional) A `keras.Layer` that performs classification of
             the bounding boxes.  If not provided, a simple ConvNet with 1 layer will be
             used.
@@ -99,7 +95,6 @@ class RetinaNet(tf.keras.Model):
         anchor_generator=None,
         label_encoder=None,
         prediction_decoder=None,
-        feature_pyramid=None,
         classification_head=None,
         box_head=None,
         name="RetinaNet",
@@ -145,7 +140,9 @@ class RetinaNet(tf.keras.Model):
         self.classes = classes
         # TODO(jbischof): replace with preset default once this is Task subclass
         if backbone is None:
-            backbone = keras_cv.models.ResNet50V2Backbone()
+            self.backbone = keras_cv.models.ResNet50V2Backbone()
+        else:
+            self.backbone = backbone
         self._prediction_decoder = (
             prediction_decoder
             or cv_layers.MultiClassNonMaxSuppression(
@@ -155,19 +152,14 @@ class RetinaNet(tf.keras.Model):
         )
 
         # initialize trainable networks
-        if not feature_pyramid:
-            extractor_levels = [3, 4, 5]
-            extractor_layer_names = [
-                backbone.pyramid_level_outputs[i] for i in extractor_levels
-            ]
-            # TODO(bischof): consider calling this `self.feature_extractor`
-            self.backbone = backbone.get_feature_extractor(
-                extractor_layer_names, extractor_levels
-            )
-            self.feature_pyramid = layers_lib.FeaturePyramid()
-        else:
-            self.backbone = backbone
-            self.feature_pyramid = feature_pyramid
+        extractor_levels = [3, 4, 5]
+        extractor_layer_names = [
+            self.backbone.pyramid_level_inputs[i] for i in extractor_levels
+        ]
+        self.feature_extractor = get_feature_extractor(
+            self.backbone, extractor_layer_names, extractor_levels
+        )
+        self.feature_pyramid = layers_lib.FeaturePyramid()
         prior_probability = tf.constant_initializer(-np.log((1 - 0.01) / 0.01))
 
         self.classification_head = (
@@ -209,8 +201,12 @@ class RetinaNet(tf.keras.Model):
         )
 
     def _forward(self, images, training=None):
-        backbone_outputs = self.backbone(images, training=training)
-        features = self.feature_pyramid(backbone_outputs, training=training)
+        feature_extractor_outputs = self.feature_extractor(
+            images, training=training
+        )
+        features = self.feature_pyramid(
+            feature_extractor_outputs, training=training
+        )
 
         N = tf.shape(images)[0]
         cls_pred = []

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -44,7 +44,7 @@ class RetinaNet(tf.keras.Model):
 
     Usage:
     ```python
-    images = tf.random.ones(shape=(1, 512, 512, 3))
+    images = tf.ones(shape=(1, 512, 512, 3))
     labels = {
         "boxes": [
             [

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -44,7 +44,7 @@ class RetinaNet(tf.keras.Model):
 
     Usage:
     ```python
-    images = tf.random.uniform((1, 512, 512, 3))
+    images = tf.random.ones(shape=(1, 512, 512, 3))
     labels = {
         "boxes": [
             [

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -137,7 +137,7 @@ class RetinaNet(tf.keras.Model):
             )
 
         self.bounding_box_format = bounding_box_format
-        self.classes = num_classes
+        self.num_classes = num_classes
         # TODO(jbischof): replace with preset default once this is Task subclass
         if backbone is None:
             self.backbone = keras_cv.models.ResNet50V2Backbone()

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -44,11 +44,33 @@ class RetinaNet(tf.keras.Model):
 
     Usage:
     ```python
-    retina_net = keras_cv.models.RetinaNet(
+    images = tf.random.uniform((1, 512, 512, 3))
+    labels = {
+        "boxes": [
+            [
+                [0, 0, 100, 100],
+                [100, 100, 200, 200],
+                [300, 300, 400, 400],
+            ]
+        ],
+        "classes": [[1, 1, 1]],
+    }
+    model = keras_cv.models.RetinaNet(
         num_classes=20,
         bounding_box_format="xywh",
-        backbone=ResNet50V2Backbone(),
     )
+
+    # Evaluate model
+    model(images)
+
+    # Train model
+    model.compile(
+        classification_loss='focal',
+        box_loss='smoothl1',
+        optimizer=tf.optimizers.SGD(global_clipnorm=10.0),
+        jit_compile=False,
+    )
+    model.fit(images, labels)
     ```
 
     Args:

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -38,7 +38,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=20,
             bounding_box_format="xywh",
-            backbone=self.build_backbone(),
         )
         retina_net.compile(
             classification_loss="focal",
@@ -60,7 +59,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=20,
             bounding_box_format="xywh",
-            backbone=self.build_backbone(),
         )
         images = tf.random.uniform((2, 512, 512, 3))
         _ = retina_net(images)
@@ -70,7 +68,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=2,
             bounding_box_format="xywh",
-            backbone=self.build_backbone(),
         )
 
         with self.assertRaisesRegex(
@@ -91,7 +88,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=2,
             bounding_box_format="xywh",
-            backbone=self.build_backbone(),
         )
 
         retina_net.compile(
@@ -109,7 +105,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=1,
             bounding_box_format=bounding_box_format,
-            backbone=self.build_backbone(),
         )
         retina_net.backbone.trainable = False
         retina_net.compile(
@@ -140,7 +135,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=1,
             bounding_box_format=bounding_box_format,
-            backbone=self.build_backbone(),
         )
 
         retina_net.compile(
@@ -197,7 +191,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=1,
             bounding_box_format=bounding_box_format,
-            backbone=self.build_backbone(),
         )
 
         retina_net.compile(
@@ -224,7 +217,6 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             classes=20,
             bounding_box_format="xywh",
-            backbone=self.build_backbone(),
         )
 
         images, boxes = _create_bounding_box_dataset("xywh")
@@ -244,8 +236,3 @@ class RetinaNetTest(tf.test.TestCase):
 
         retina_net.fit(dataset, epochs=1)
         retina_net.evaluate(dataset)
-
-    def build_backbone(self):
-        return keras_cv.models.ResNet50(
-            include_top=False, include_rescaling=False
-        ).as_backbone()

--- a/keras_cv/utils/train.py
+++ b/keras_cv/utils/train.py
@@ -75,5 +75,5 @@ def get_feature_extractor(model, layer_names, output_keys=None):
     if not output_keys:
         output_keys = layer_names
     items = zip(output_keys, layer_names)
-    outputs = {item[0]: model.get_layer(item[1]).output for item in items}
+    outputs = {key: model.get_layer(name).output for key, name in items}
     return tf.keras.Model(inputs=model.inputs, outputs=outputs)

--- a/keras_cv/utils/train.py
+++ b/keras_cv/utils/train.py
@@ -51,3 +51,29 @@ def convert_inputs_to_tf_dataset(
     if batch_size is not None:
         dataset = dataset.batch(batch_size)
     return dataset
+
+
+def get_feature_extractor(model, layer_names, output_keys=None):
+    """Create a feature extractor model with augmented output.
+
+    This method produces a new `keras.Model` with the same input signature
+    as the source but with the layers in `layer_names` as the output.
+    This is useful for downstream tasks that require more output than the
+    final layer of the backbone.
+
+    Args:
+        model: keras.Model. The source model.
+        layer_names: list of strings. Names of layers to include in the
+            output signature.
+        output_keys: optional, list of strings. Key to use for each layer in
+            the model's output dictionary.
+
+    Returns:
+        `tf.keras.Model` which has dict as outputs.
+    """
+
+    if not output_keys:
+        output_keys = layer_names
+    items = zip(output_keys, layer_names)
+    outputs = {item[0]: model.get_layer(item[1]).output for item in items}
+    return tf.keras.Model(inputs=model.inputs, outputs=outputs)


### PR DESCRIPTION
Fixes #1447 

Feature extraction should be handled by the Task and not be visible to the user. The original docs were also vague and in parts incorrect about the contract between the `backbone` and the model. This PR attempts to improve and clarify that contract.

This PR changes the `Backbone` and `RetinaNet` implementation to provide automatic FPN construction. We no longer allow custom FPNs due to minimal user value but in a future PR should allow arbitrary P-levels to be specific by the user for use in the FPN. Custom backbones are possible as long as they implement `pyramid_level_inputs`.

```python
# Old API
model = RetinaNet(
    classes=4,
    bounding_box_format="xywh",
    backbone=ResNet50V2Backbone.as_backbone(),
)

# New API with default backbone
model = RetinaNet(
    classes=4,
    bounding_box_format="xywh",
)

# New API with explicit backbone
model = RetinaNet(
    classes=4,
    bounding_box_format="xywh",
    backbone=ResNet50V2Backbone(),
)
```
