### PR TITLE
Add serialization and fix typos for ResNetV2

### DIFF
--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -277,8 +277,8 @@ class ResNetV2Backbone(Backbone):
         include_rescaling: bool, whether or not to Rescale the inputs. If set
             to `True`, inputs will be passed through a `Rescaling(1/255.0)`
             layer.
-        stackwise_dialations: list of ints, dialation for each stack in the
-            model. If `None` (default), dialation will not be used.
+        stackwise_dilations: list of ints, dilation for each stack in the
+            model. If `None` (default), dilation will not be used.
         input_shape: optional shape tuple, defaults to (None, None, 3).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
@@ -434,6 +434,7 @@ ALIAS_DOCSTRING = """ResNetV2Backbone model with {num_layers} layers.
 """
 
 
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet18V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -463,6 +464,7 @@ class ResNet18V2Backbone(ResNetV2Backbone):
         return {}
 
 
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet34V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -492,6 +494,7 @@ class ResNet34V2Backbone(ResNetV2Backbone):
         return {}
 
 
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet50V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -525,6 +528,7 @@ class ResNet50V2Backbone(ResNetV2Backbone):
         return cls.presets
 
 
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet101V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -554,6 +558,7 @@ class ResNet101V2Backbone(ResNetV2Backbone):
         return {}
 
 
+@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet152V2Backbone(ResNetV2Backbone):
     def __new__(
         self,

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -39,7 +39,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    def test_valid_call_applications_model(self):
+    def test_valid_call_alias_model(self):
         model = ResNet18V2Backbone()
         model(self.input_batch)
 
@@ -69,6 +69,25 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
+        self.assertIsInstance(restored_model, ResNetV2Backbone)
+
+        # Check that output matches.
+        restored_output = restored_model(self.input_batch)
+        self.assertAllClose(model_output, restored_output)
+
+    @parameterized.named_parameters(
+        ("tf_format", "tf", "model"),
+        ("keras_format", "keras_v3", "model.keras"),
+    )
+    def test_saved_alias_model(self, save_format, filename):
+        model = ResNet18V2Backbone()
+        model_output = model(self.input_batch)
+        save_path = os.path.join(self.get_temp_dir(), filename)
+        model.save(save_path, save_format=save_format)
+        restored_model = keras.models.load_model(save_path)
+
+        # Check we got the real object back.
+        # Note that these aliases create the base case
         self.assertIsInstance(restored_model, ResNetV2Backbone)
 
         # Check that output matches.


### PR DESCRIPTION
Forgot to register alias models and misspelled `dilation`.