### PR TITLE
Remove serialization for alias models

### DIFF
--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -434,7 +434,6 @@ ALIAS_DOCSTRING = """ResNetV2Backbone model with {num_layers} layers.
 """
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet18V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -464,7 +463,6 @@ class ResNet18V2Backbone(ResNetV2Backbone):
         return {}
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet34V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -494,7 +492,6 @@ class ResNet34V2Backbone(ResNetV2Backbone):
         return {}
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet50V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -528,7 +525,6 @@ class ResNet50V2Backbone(ResNetV2Backbone):
         return cls.presets
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet101V2Backbone(ResNetV2Backbone):
     def __new__(
         self,
@@ -558,7 +554,6 @@ class ResNet101V2Backbone(ResNetV2Backbone):
         return {}
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
 class ResNet152V2Backbone(ResNetV2Backbone):
     def __new__(
         self,


### PR DESCRIPTION
Serialization is not needed for the aliases in order for `test_saved_alias_model` to pass. Since these are thin subclasses of `ResNetV2Backbone`, calling `keras.utils.get_serialized_object` points to the base class anyway.

```python
>>> keras.utils.serialize_keras_object(keras_cv.models.ResNet50V2Backbone())
{'class_name': 'keras_cv.models>ResNetV2Backbone', 'config': {'stackwise_filters': ListWrapper([64, 128, 256, 512]), 'stackwise_blocks': ListWrapper([3, 4, 6, 3]), 'stackwise_strides': ListWrapper([1, 2, 2, 2]), 'include_rescaling': True, 'input_shape': (None, None, 3), 'stackwise_dilations': ListWrapper([1, 1, 1, 1]), 'input_tensor': None, 'block_type': 'block', 'name': 'res_net_v2_backbone', 'trainable': True}}
```