### PR TITLE
Fix mosaic preprocessing so it workss for one channel input

### DIFF
--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -214,7 +214,6 @@ class Mosaic(BaseImageAugmentationLayer):
         # since num_boxes is always one we squeeze axis 0
         output = tf.cast(output, self.compute_dtype)
         output = tf.squeeze(output, axis=0)
-        
         return output
 
     def _update_label(

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -211,7 +211,7 @@ class Mosaic(BaseImageAugmentationLayer):
         )
         # tf.image.crop_and_resize will always output float32, so we need to recast
         output = tf.cast(output, self.compute_dtype)
-        return tf.squeeze(output)
+        return output
 
     def _update_label(
         self, images, labels, permutation_order, mosaic_centers, index

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -210,7 +210,9 @@ class Mosaic(BaseImageAugmentationLayer):
             [input_height, input_width],
         )
         # tf.image.crop_and_resize will always output float32, so we need to recast
-        output = tf.cast(output, self.compute_dtype)
+        # tf.image.crop_and_resize outputs [num_boxes, crop_height, crop_width, depth]
+        # since num_boxes is always one we only need the first element
+        output = tf.cast(output[0], self.compute_dtype)
         return output
 
     def _update_label(

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -211,8 +211,10 @@ class Mosaic(BaseImageAugmentationLayer):
         )
         # tf.image.crop_and_resize will always output float32, so we need to recast
         # tf.image.crop_and_resize outputs [num_boxes, crop_height, crop_width, depth]
-        # since num_boxes is always one we only need the first element
-        output = tf.cast(output[0], self.compute_dtype)
+        # since num_boxes is always one we squeeze axis 0
+        output = tf.cast(output, self.compute_dtype)
+        output = tf.squeeze(output, axis=0)
+        
         return output
 
     def _update_label(


### PR DESCRIPTION
# What does this PR do?

modified _update_image so it doesn't remove channel inputs dimension with a squeeze for inputs with only one channel


Fixes [#1464](https://github.com/keras-team/keras-cv/issues/1464)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your  #PR.
