### PR TITLE
Fix RandomZoom for RaggedTensor input

### DIFF
--- a/keras_cv/layers/preprocessing/ragged_image_test.py
+++ b/keras_cv/layers/preprocessing/ragged_image_test.py
@@ -78,6 +78,11 @@ CONSISTENT_OUTPUT_TEST_CONFIGURATIONS = [
         layers.RandomTranslation,
         {"height_factor": 0.5, "width_factor": 0.5},
     ),
+    (
+        "RandomZoom",
+        layers.RandomZoom,
+        {"height_factor": 0.2, "width_factor": 0.5},
+    ),
     ("Solarization", layers.Solarization, {"value_range": (0, 255)}),
 ]
 

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -156,9 +156,17 @@ class RandomZoom(VectorizedBaseImageAugmentationLayer):
         return {"height_zooms": height_zooms, "width_zooms": width_zooms}
 
     def augment_ragged_image(self, image, transformation, **kwargs):
-        return self.augment_images(
+        image = tf.expand_dims(image, axis=0)
+        width_zooms = transformation["width_zooms"]
+        height_zooms = transformation["height_zooms"]
+        transformation = {
+            "height_zooms": tf.expand_dims(height_zooms, axis=0),
+            "width_zooms": tf.expand_dims(width_zooms, axis=0),
+        }
+        image = self.augment_images(
             images=image, transformations=transformation, **kwargs
         )
+        return tf.squeeze(image, axis=0)
 
     def augment_images(self, images, transformations, **kwargs):
         images = preprocessing_utils.ensure_tensor(images, self.compute_dtype)


### PR DESCRIPTION
# What does this PR do?

Fixes #1481 

- fix `augment_ragged_image` by applying `tf.expand_dims` and `tf.squeeze` to image and transformation
- add RandomZoom to `keras_cv/layers/preprocessing/ragged_image_test.py`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 