### PR TITLE
Use SUM_OVER_BATCH_SIZE as default OD loss reduction

### DIFF
--- a/keras_cv/models/object_detection/faster_rcnn.py
+++ b/keras_cv/models/object_detection/faster_rcnn.py
@@ -431,7 +431,8 @@ class FasterRCNN(tf.keras.Model):
         rpn_box_loss = _validate_and_get_loss(rpn_box_loss, "rpn_box_loss")
         if rpn_classification_loss == "BinaryCrossentropy":
             rpn_classification_loss = tf.keras.losses.BinaryCrossentropy(
-                from_logits=True, reduction=tf.keras.losses.Reduction.SUM
+                from_logits=True,
+                reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE,
             )
         rpn_classification_loss = _validate_and_get_loss(
             rpn_classification_loss, "rpn_cls_loss"
@@ -605,9 +606,9 @@ def _validate_and_get_loss(loss, loss_name):
         raise ValueError(
             f"FasterRCNN only accepts `tf.keras.losses.Loss` for {loss_name}, got {loss}"
         )
-    if loss.reduction != tf.keras.losses.Reduction.SUM:
+    if loss.reduction != tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE:
         logging.info(
             f"FasterRCNN only accepts `SUM` reduction, got {loss.reduction}, automatically converted."
         )
-        loss.reduction = tf.keras.losses.Reduction.SUM
+        loss.reduction = tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE
     return loss

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -487,10 +487,13 @@ def _parse_box_loss(loss):
     # case insensitive comparison
     if loss.lower() == "smoothl1":
         return keras_cv.losses.SmoothL1Loss(
-            l1_cutoff=1.0, reduction=tf.keras.losses.Reduction.SUM
+            l1_cutoff=1.0,
+            reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE,
         )
     if loss.lower() == "huber":
-        return keras.losses.Huber(reduction=tf.keras.losses.Reduction.SUM)
+        return keras.losses.Huber(
+            reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE
+        )
 
     raise ValueError(
         "Expected `box_loss` to be either a Keras Loss, "
@@ -506,7 +509,8 @@ def _parse_classification_loss(loss):
     # case insensitive comparison
     if loss.lower() == "focal":
         return keras_cv.losses.FocalLoss(
-            from_logits=True, reduction=tf.keras.losses.Reduction.SUM
+            from_logits=True,
+            reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE,
         )
 
     raise ValueError(


### PR DESCRIPTION
Currently, this results in unusually small losses.

I'm training on 2 GPUs with reduce `SUM`, I'm seeing a first epoch loss of ~3.

The initial loss I'm seeing with reduce `SUM_OVER_BATCH_SIZE` is `0.0000052`, which seems ... incorrect.

@LukeWood any ideas?