### PR TITLE
resolve inconsistency between lint.sh and setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,8 @@ filterwarnings =
     ignore::PendingDeprecationWarning
     ignore::FutureWarning
 [flake8]
-max-line-length = 80
-max-doc-length = 200
+# Allow --max-line-length=200 to support long links in docstrings
+max-line-length = 200
 per-file-ignores =
     ./keras_cv/__init__.py:E402, F401
     ./examples/**/*:E402

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -23,8 +23,7 @@ then
 fi
 [ $# -eq 0  ] && echo "no issues with isort"
 
-# Allow --max-line-length=200 to support long links in docstrings
-flake8 --max-line-length=200 $files
+flake8 $files
 if ! [ $? -eq 0 ]
 then
   echo "Please fix the code style issue."


### PR DESCRIPTION
`setup.cfg` says 80 chars per line, but `lint.sh` says 200 chars per line. This PR resolves this inconsistency.

The inconsistency between `lint.sh` and `setup.cfg` is causing the IDEs to print false lint warnings, because IDEs use `setup.cfg` only.

Now 80 char line length is only ensured by `black`.
There are a lot of over length strings, docstrings, and comments.

Ideally, we should still ensure 80 char line length and use `# noqa: E501` after the docstrings like the following.
```py
class SomeClass:
    """My docstring.

    This is a line with over length.
    """  # noqa: E501
```