### PR TITLE
Improve the devcontainer settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,2 @@
-ARG VERSION
-
-FROM tensorflow/tensorflow:${VERSION}
-
-RUN apt-get update && apt-get install -y \
-  locales \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN pip install \
-  black[jupyter] \
-  flake8 \
-  isort \
-  pytest \
-  regex \
-  tensorflow_datasets \
-  pycocotools
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+COPY setup.sh /setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-python.isort",
+				"ms-python.flake8",
 				"ms-python.black-formatter"
 			]
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,10 +15,12 @@
 				"python.linting.flake8Enabled": true,
 				"python.linting.pylintEnabled": false,
 				"python.testing.pytestEnabled": true,
-				"python.formatting.provider": "black",
 				"editor.formatOnSave": true,
 				"editor.codeActionsOnSave": {
 					"source.organizeImports": true
+				},
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter"
 				},
 				"editor.rulers": [
 					80

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,45 +2,45 @@
 	"name": "Keras-cv",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
+		"args": {
 			"VERSION": "2.11.0"
 			// Uncomment this if GPU support is required
 			// "VERSION": "2.11.0-gpu",
 		}
 	},
-
-	"settings": {
-		"python.pythonPath": "/usr/bin/python3",
-		"python.linting.enabled": true,
-		"python.linting.flake8Enabled": true,
-		"python.testing.pytestEnabled":true,
-		"python.editor.defaultFormatter": "ms-python.black-formatter",
-		"python.editor.formatOnSave": true,
-		"python.editor.codeActionsOnSave": {
-			"source.organizeImports": true
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.linting.enabled": true,
+				"python.linting.flake8Enabled": true,
+				"python.linting.pylintEnabled": false,
+				"python.testing.pytestEnabled": true,
+				"python.formatting.provider": "black",
+				"editor.formatOnSave": true,
+				"editor.codeActionsOnSave": {
+					"source.organizeImports": true
+				},
+				"editor.rulers": [
+					80
+				]
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-python.isort",
+				"ms-python.black-formatter"
+			]
 		}
 	},
-
-	"extensions": [
-		"ms-python.python",
-		"ms-python.isort",
-		"ms-python.black-formatter"
-	],
-
 	"features": {
-		"git": {
-			"version": "os-provided"
-		}
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-
 	// TODO: Improve to allow dynamic runArgs, see microsoft/vscode-remote-release#3972
 	// Uncomment this if GPU support is required
 	// "runArgs": [
-    	//     "--gpus=all"
+	//     "--gpus=all"
 	// ],
-
-	"onCreateCommand": "locale-gen \"en_US.UTF-8\""
+	"onCreateCommand": "locale-gen \"en_US.UTF-8\"",
 	// Optional: install pre-commit hooks
 	// "postCreateCommand": "git config core.hooksPath .github/.githooks"
-
+	"postCreateCommand": "sh /setup.sh"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,2 @@
+sudo pip install --upgrade pip
+sudo pip install -e ".[tests]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 80
+
+[tool.isort]
+profile = "black"
+force_single_line = "True"
+known_first_party = ["keras_cv", "tests"]
+default_section = "THIRDPARTY"
+line_length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,3 @@ ignore =
     W605
     # Ignore for tf.cond lambda
     E731
-
-[isort]
-profile = black
-force_single_line = True
-known_first_party = keras_cv,tests
-default_section = THIRDPARTY
-line_length = 80

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-isort --sl .
-black --line-length 80 .
+isort .
+black .

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -31,7 +31,7 @@ then
   exit 1
 fi
 [ $# -eq 0 ] && echo "no issues with flake8"
-black --line-length 80 --check $files
+black --check $files
 if ! [ $? -eq 0 ]
 then
   echo "Please run \"sh shell/format.sh\" to format the code."


### PR DESCRIPTION
This PR improves the devcontainer setup.
* Use the image specially prepared for devcontainers and install tensorflow on post commands.
* Extracted `isort` and `black` settings to `pyproject.toml` to make consistent behavior no matter how the commands are run. (Note that `pyproject.toml` is just there for the formatting setup not for package releases).
* Enable the GitHub CLI `gh` inside devcontainers.
* Fix the bug that `settings` in `devcontainer.json` did not work.
* Add a verticle ruler in the editor for line length limit.