### PR TITLE
Update CenterPillar to use dictionary-formatted outputs

### DIFF
--- a/keras_cv/callbacks/waymo_evaluation_callback.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback.py
@@ -146,8 +146,8 @@ class WaymoEvaluationCallback(Callback):
             tf.repeat(frame_ids, boxes_per_pred_frame), pred_real_boxes
         )
         predictions["prediction_bbox"] = predicted_boxes
-        predictions["prediction_type"] = predicted_classes
-        predictions["prediction_score"] = prediction_scores
+        predictions["prediction_type"] = tf.squeeze(predicted_classes)
+        predictions["prediction_score"] = tf.squeeze(prediction_scores)
         predictions["prediction_overlap_nlz"] = tf.cast(
             tf.zeros(predicted_boxes.shape[0]), tf.bool
         )

--- a/keras_cv/callbacks/waymo_evaluation_callback.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback.py
@@ -69,21 +69,41 @@ class WaymoEvaluationCallback(Callback):
             return point_clouds
 
         def boxes_only(point_clouds, target):
-            return target["boxes"]
+            return target["3d_boxes"]
 
-        predicted_boxes, predicted_classes = self.model.predict(
-            dataset.map(point_clouds_only)
+        model_outputs = self.model.predict(dataset.map(point_clouds_only))[
+            "3d_boxes"
+        ]
+
+        def flatten_target(boxes):
+            return tf.concat(
+                [
+                    boxes["boxes"],
+                    tf.expand_dims(
+                        tf.cast(boxes["classes"], tf.float32), axis=-1
+                    ),
+                    tf.expand_dims(
+                        tf.cast(boxes["difficulty"], tf.float32), axis=-1
+                    ),
+                ],
+                axis=-1,
+            )
+
+        gt_boxes = tf.concat(
+            [flatten_target(x) for x in iter(dataset.map(boxes_only))], axis=0
         )
-        gt_boxes = tf.concat([x for x in iter(dataset.map(boxes_only))], axis=0)
 
         boxes_per_gt_frame = gt_boxes.shape[1]
         num_frames = gt_boxes.shape[0]
 
         gt_boxes = tf.reshape(gt_boxes, (num_frames * boxes_per_gt_frame, 9))
 
-        # Remove boxes with class of -1 (these are non-boxes that come from padding)
-        gt_real_boxes = tf.not_equal(
-            gt_boxes[:, CENTER_XYZ_DXDYDZ_PHI.CLASS], -1
+        # Remove padded boxes
+        gt_real_boxes = tf.concat(
+            [x["mask"] for x in iter(dataset.map(boxes_only))], axis=0
+        )
+        gt_real_boxes = tf.reshape(
+            gt_real_boxes, (num_frames * boxes_per_gt_frame)
         )
         gt_boxes = tf.boolean_mask(gt_boxes, gt_real_boxes)
 
@@ -103,18 +123,22 @@ class WaymoEvaluationCallback(Callback):
             gt_boxes[:, CENTER_XYZ_DXDYDZ_PHI.CLASS + 1], tf.uint8
         )
 
-        boxes_per_pred_frame = predicted_boxes.shape[1]
+        boxes_per_pred_frame = model_outputs["boxes"].shape[1]
         total_predicted_boxes = boxes_per_pred_frame * num_frames
         predicted_boxes = tf.reshape(
-            predicted_boxes, (total_predicted_boxes, 7)
+            model_outputs["boxes"], (total_predicted_boxes, 7)
         )
         predicted_classes = tf.reshape(
-            predicted_classes, (total_predicted_boxes, 2)
+            model_outputs["classes"], (total_predicted_boxes, 1)
         )
-        # Remove boxes with class of -1 (these are non-boxes that come from padding)
+        prediction_scores = tf.reshape(
+            model_outputs["confidence"], (total_predicted_boxes, 1)
+        )
+        # Remove boxes with class of -1 (these are non-boxes that may come from padding)
         pred_real_boxes = tf.reduce_all(predicted_classes != -1, axis=[-1])
         predicted_boxes = tf.boolean_mask(predicted_boxes, pred_real_boxes)
         predicted_classes = tf.boolean_mask(predicted_classes, pred_real_boxes)
+        prediction_scores = tf.boolean_mask(prediction_scores, pred_real_boxes)
 
         predictions = {}
 
@@ -122,12 +146,8 @@ class WaymoEvaluationCallback(Callback):
             tf.repeat(frame_ids, boxes_per_pred_frame), pred_real_boxes
         )
         predictions["prediction_bbox"] = predicted_boxes
-        predictions["prediction_type"] = tf.cast(
-            tf.argmax(predicted_classes, axis=-1), tf.uint8
-        )
-        predictions["prediction_score"] = tf.reduce_max(
-            predicted_classes, axis=-1
-        )
+        predictions["prediction_type"] = predicted_classes
+        predictions["prediction_score"] = prediction_scores
         predictions["prediction_overlap_nlz"] = tf.cast(
             tf.zeros(predicted_boxes.shape[0]), tf.bool
         )

--- a/keras_cv/callbacks/waymo_evaluation_callback_test.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback_test.py
@@ -21,7 +21,7 @@ NUM_RECORDS = 10
 POINT_FEATURES = 3
 NUM_POINTS = 20
 NUM_BOXES = 2
-BOX_FEATURES = 9
+BOX_FEATURES = 7
 
 METRIC_KEYS = [
     "average_precision",
@@ -54,7 +54,18 @@ class WaymoEvaluationCallbackTest(tf.test.TestCase):
             (
                 points,
                 {
-                    "boxes": boxes,
+                    "3d_boxes": {
+                        "boxes": boxes,
+                        "classes": tf.ones((NUM_RECORDS, NUM_BOXES)),
+                        "difficulty": tf.ones((NUM_RECORDS, NUM_BOXES)),
+                        "mask": tf.concat(
+                            [
+                                tf.ones((NUM_RECORDS // 2, NUM_BOXES)),
+                                tf.zeros((NUM_RECORDS // 2, NUM_BOXES)),
+                            ],
+                            axis=0,
+                        ),
+                    }
                 },
             )
         ).batch(5)
@@ -67,9 +78,18 @@ class WaymoEvaluationCallbackTest(tf.test.TestCase):
     def build_model(self):
         inputs = tf.keras.Input(shape=(POINT_FEATURES, NUM_POINTS))
         x = keras.layers.Flatten()(inputs)
-        x = keras.layers.Dense(BOX_FEATURES * NUM_BOXES)(x)
-        x = keras.layers.Reshape((NUM_BOXES, BOX_FEATURES))(x)
-        x = keras.layers.Lambda(lambda x: (x[:, :, :7], x[:, :, 7:]))(x)
+        # Add extra features for class and confidence
+        x = keras.layers.Dense(NUM_BOXES * (BOX_FEATURES + 2))(x)
+        x = keras.layers.Reshape((NUM_BOXES, BOX_FEATURES + 2))(x)
+        x = keras.layers.Lambda(
+            lambda x: {
+                "3d_boxes": {
+                    "boxes": x[:, :, :7],
+                    "classes": tf.cast(x[:, :, 7], tf.uint8),
+                    "confidence": x[:, :, 8],
+                }
+            }
+        )(x)
 
         class MeanLoss(keras.losses.Loss):
             def call(self, y_true, y_pred):

--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -112,10 +112,22 @@ class MultiClassHeatmapDecoder(tf.keras.layers.Layer):
             )
 
     def call(self, predictions):
-        decoded_predictions = {}
+        box_predictions = []
+        class_predictions = []
+        box_confidence = []
         for k, v in predictions.items():
-            decoded_predictions[k] = self.decoders[k](v)
-        return decoded_predictions
+            boxes, classes, confidence = self.decoders[k](v)
+            box_predictions.append(boxes)
+            class_predictions.append(classes)
+            box_confidence.append(confidence)
+
+        return {
+            "3d_boxes": {
+                "boxes": tf.concat(box_predictions, axis=1),
+                "classes": tf.concat(class_predictions, axis=1),
+                "confidence": tf.concat(box_confidence, axis=1),
+            }
+        }
 
 
 class MultiHeadCenterPillar(tf.keras.Model):

--- a/keras_cv/models/object_detection_3d/center_pillar_test.py
+++ b/keras_cv/models/object_detection_3d/center_pillar_test.py
@@ -93,7 +93,14 @@ class CenterPillarTest(tf.test.TestCase):
         point_xyz = tf.random.normal([2, 1000, 3])
         point_feature = tf.random.normal([2, 1000, 4])
         point_mask = tf.constant(True, shape=[2, 1000])
-        outputs = model(point_xyz, point_feature, point_mask, training=True)
+        outputs = model(
+            {
+                "point_xyz": point_xyz,
+                "point_feature": point_feature,
+                "point_mask": point_mask,
+            },
+            training=True,
+        )
         self.assertEqual(outputs["class_1"].shape, [2, 400, 400, 12])
         self.assertEqual(outputs["class_2"].shape, [2, 400, 400, 12])
 
@@ -129,7 +136,14 @@ class CenterPillarTest(tf.test.TestCase):
         point_xyz = tf.random.normal([2, 1000, 3])
         point_feature = tf.random.normal([2, 1000, 4])
         point_mask = tf.constant(True, shape=[2, 1000])
-        outputs = model(point_xyz, point_feature, point_mask, training=False)
+        outputs = model(
+            {
+                "point_xyz": point_xyz,
+                "point_feature": point_feature,
+                "point_mask": point_mask,
+            },
+            training=False,
+        )
         # max number boxes is 3
         self.assertEqual(outputs["class_1"][0].shape, [2, 3, 7])
         self.assertEqual(outputs["class_1"][1].shape, [2, 3])

--- a/keras_cv/models/object_detection_3d/center_pillar_test.py
+++ b/keras_cv/models/object_detection_3d/center_pillar_test.py
@@ -145,9 +145,10 @@ class CenterPillarTest(tf.test.TestCase):
             training=False,
         )
         # max number boxes is 3
-        self.assertEqual(outputs["class_1"][0].shape, [2, 3, 7])
-        self.assertEqual(outputs["class_1"][1].shape, [2, 3])
-        self.assertEqual(outputs["class_1"][2].shape, [2, 3])
-        self.assertEqual(outputs["class_2"][0].shape, [2, 4, 7])
-        self.assertEqual(outputs["class_2"][1].shape, [2, 4])
-        self.assertEqual(outputs["class_2"][2].shape, [2, 4])
+        self.assertEqual(outputs["3d_boxes"]["boxes"].shape, [2, 7, 7])
+        self.assertEqual(outputs["3d_boxes"]["classes"].shape, [2, 7])
+        self.assertEqual(outputs["3d_boxes"]["confidence"].shape, [2, 7])
+        self.assertAllEqual(
+            outputs["3d_boxes"]["classes"],
+            tf.constant([1, 1, 1, 2, 2, 2, 2] * 2, shape=(2, 7)),
+        )


### PR DESCRIPTION
This also updates the WaymoEvaluationCallback to handle the new dictionary format for outputs.

This uses the same box format that we use for 2D OD:
```
{
     "3d_boxes": {
         "boxes": ...,
         "classes": ...,
         "confidence": ...,
     }
}
```

Because Waymo tests don't run on our CI, I've manually run these on a GCP VM with tf 2.10 and Waymo Open Dataset (tf 2.11 support not ready for WOD)