### PR TITLE
Cleans up imports in accordance with replacing `tf.keras` with `keras` throughout KerasCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install git+https://github.com/keras-team/keras-cv.git tensorflow --upgrade
 ```python
 import keras_cv
 import tensorflow as tf
-from tensorflow import keras
+import keras
 import tensorflow_datasets as tfds
 
 # Create a preprocessing pipeline

--- a/benchmarks/vectorization_strategy_benchmark.py
+++ b/benchmarks/vectorization_strategy_benchmark.py
@@ -16,11 +16,11 @@
 """
 import time
 
+import keras
+import keras.layers as layers
 import matplotlib.pyplot as plt
 import tensorflow as tf
-import tensorflow.keras as keras
-import tensorflow.keras.layers as layers
-from tensorflow.keras import backend
+from keras import backend
 
 from keras_cv.utils import bounding_box
 from keras_cv.utils import fill_utils

--- a/benchmarks/vectorized_auto_contrast.py
+++ b/benchmarks/vectorized_auto_contrast.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import time
 
+import keras
 import matplotlib.pyplot as plt
 import tensorflow as tf
-import tensorflow.keras as keras
 
 from keras_cv.layers import AutoContrast
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/benchmarks/vectorized_grayscale.py
+++ b/benchmarks/vectorized_grayscale.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import time
 
+import keras
 import matplotlib.pyplot as plt
 import tensorflow as tf
-import tensorflow.keras as keras
 
 from keras_cv.layers import Grayscale
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/benchmarks/vectorized_random_saturation.py
+++ b/benchmarks/vectorized_random_saturation.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 import time
 
+import keras
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv.layers import RandomSaturation
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/examples/training/classification/imagenet/basic_training.py
+++ b/examples/training/classification/imagenet/basic_training.py
@@ -22,13 +22,13 @@ Description: Use KerasCV to train an image classifier using modern best practice
 import math
 import sys
 
+import keras
 import tensorflow as tf
 from absl import flags
-from tensorflow import keras
-from tensorflow.keras import callbacks
-from tensorflow.keras import losses
-from tensorflow.keras import metrics
-from tensorflow.keras import optimizers
+from keras import callbacks
+from keras import losses
+from keras import metrics
+from keras import optimizers
 
 import keras_cv
 from keras_cv import models

--- a/examples/training/contrastive/imagenet/simclr_training.py
+++ b/examples/training/contrastive/imagenet/simclr_training.py
@@ -14,13 +14,13 @@
 
 import sys
 
+import keras
 import tensorflow as tf
 from absl import flags
-from tensorflow import keras
-from tensorflow.keras import callbacks
-from tensorflow.keras import layers
-from tensorflow.keras import metrics
-from tensorflow.keras import optimizers
+from keras import callbacks
+from keras import layers
+from keras import metrics
+from keras import optimizers
 
 from keras_cv import losses
 from keras_cv import models

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -21,10 +21,10 @@ Description: Use KerasCV to train a RetinaNet on Pascal VOC 2007.
 import resource
 import sys
 
+import keras
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from absl import flags
-import keras
 
 import keras_cv
 from keras_cv.callbacks import PyCOCOCallback

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -24,7 +24,7 @@ import sys
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from absl import flags
-from tensorflow import keras
+import keras
 
 import keras_cv
 from keras_cv.callbacks import PyCOCOCallback

--- a/keras_cv/datasets/imagenet/load.py
+++ b/keras_cv/datasets/imagenet/load.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 
 def parse_imagenet_example(img_size, crop_to_aspect_ratio):

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow.keras.layers import CenterCrop
-from tensorflow.keras.layers import RandomHeight
-from tensorflow.keras.layers import RandomWidth
+from keras.layers import CenterCrop
+from keras.layers import RandomHeight
+from keras.layers import RandomWidth
 
 from keras_cv.layers.feature_pyramid import FeaturePyramid
 from keras_cv.layers.fusedmbconv import FusedMBConvBlock

--- a/keras_cv/layers/fusedmbconv.py
+++ b/keras_cv/layers/fusedmbconv.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import tensorflow as tf
 from keras import backend
-from tensorflow.keras import layers
+from keras import layers
 
 BN_AXIS = 3
 

--- a/keras_cv/layers/fusedmbconv_test.py
+++ b/keras_cv/layers/fusedmbconv_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 import tensorflow as tf
 

--- a/keras_cv/layers/mbconv.py
+++ b/keras_cv/layers/mbconv.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import tensorflow as tf
 from keras import backend
-from tensorflow.keras import layers
+from keras import layers
 
 BN_AXIS = 3
 

--- a/keras_cv/layers/mbconv_test.py
+++ b/keras_cv/layers/mbconv_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 import tensorflow as tf
 

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
 

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -15,9 +15,9 @@
 # Also export the image KPLs from core keras, so that user can import all the image
 # KPLs from one place.
 
-from tensorflow.keras.layers import CenterCrop
-from tensorflow.keras.layers import RandomHeight
-from tensorflow.keras.layers import RandomWidth
+from keras.layers import CenterCrop
+from keras.layers import RandomHeight
+from keras.layers import RandomWidth
 
 from keras_cv.layers.preprocessing.aug_mix import AugMix
 from keras_cv.layers.preprocessing.augmenter import Augmenter

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/cut_mix_test.py
+++ b/keras_cv/layers/preprocessing/cut_mix_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.cut_mix import CutMix

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/fourier_mix_test.py
+++ b/keras_cv/layers/preprocessing/fourier_mix_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.fourier_mix import FourierMix

--- a/keras_cv/layers/preprocessing/grayscale_test.py
+++ b/keras_cv/layers/preprocessing/grayscale_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv import core
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/grid_mask_test.py
+++ b/keras_cv/layers/preprocessing/grid_mask_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import tensorflow as tf
 
 import keras_cv

--- a/keras_cv/layers/preprocessing/jittered_resize_test.py
+++ b/keras_cv/layers/preprocessing/jittered_resize_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/maybe_apply.py
+++ b/keras_cv/layers/preprocessing/maybe_apply.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/maybe_apply_test.py
+++ b/keras_cv/layers/preprocessing/maybe_apply_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import bounding_box

--- a/keras_cv/layers/preprocessing/mix_up_test.py
+++ b/keras_cv/layers/preprocessing/mix_up_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.mix_up import MixUp

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.mosaic import Mosaic

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/posterization_test.py
+++ b/keras_cv/layers/preprocessing/posterization_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing/ragged_image_test.py
+++ b/keras_cv/layers/preprocessing/ragged_image_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import core

--- a/keras_cv/layers/preprocessing/rand_augment_test.py
+++ b/keras_cv/layers/preprocessing/rand_augment_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/random_aspect_ratio.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 import keras_cv

--- a/keras_cv/layers/preprocessing/random_aspect_ratio_test.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import bounding_box

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/random_brightness_test.py
+++ b/keras_cv/layers/preprocessing/random_brightness_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import core

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/random_color_degeneration_test.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/random_contrast_test.py
+++ b/keras_cv/layers/preprocessing/random_contrast_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import tensorflow as tf
 
 from keras_cv import bounding_box

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/keras_cv/layers/preprocessing/random_crop_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 
 import numpy as np

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/random_cutout_test.py
+++ b/keras_cv/layers/preprocessing/random_cutout_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 
 import numpy as np

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/random_rotation_test.py
+++ b/keras_cv/layers/preprocessing/random_rotation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import core

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/random_sharpness_test.py
+++ b/keras_cv/layers/preprocessing/random_sharpness_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers import preprocessing

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import warnings
 
 import tensorflow as tf

--- a/keras_cv/layers/preprocessing/random_shear_test.py
+++ b/keras_cv/layers/preprocessing/random_shear_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv import bounding_box

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import tensorflow as tf
 from keras import backend
 

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop_test.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/repeated_augmentation_test.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 import keras_cv.layers as cv_layers

--- a/keras_cv/layers/preprocessing/rescaling_test.py
+++ b/keras_cv/layers/preprocessing/rescaling_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized

--- a/keras_cv/layers/preprocessing/solarization_test.py
+++ b/keras_cv/layers/preprocessing/solarization_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d_test.py
+++ b/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/frustum_random_dropping_points_test.py
+++ b/keras_cv/layers/preprocessing_3d/frustum_random_dropping_points_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/frustum_random_point_feature_noise_test.py
+++ b/keras_cv/layers/preprocessing_3d/frustum_random_point_feature_noise_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/global_random_dropping_points_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_dropping_points_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_flip_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/global_random_rotation_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_rotation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/global_random_scaling_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_scaling_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/global_random_translation_test.py
+++ b/keras_cv/layers/preprocessing_3d/global_random_translation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/group_points_by_bounding_boxes_test.py
+++ b/keras_cv/layers/preprocessing_3d/group_points_by_bounding_boxes_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import numpy as np

--- a/keras_cv/layers/preprocessing_3d/random_copy_paste_test.py
+++ b/keras_cv/layers/preprocessing_3d/random_copy_paste_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 
 import numpy as np

--- a/keras_cv/layers/preprocessing_3d/random_drop_box_test.py
+++ b/keras_cv/layers/preprocessing_3d/random_drop_box_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/preprocessing_3d/swap_background_test.py
+++ b/keras_cv/layers/preprocessing_3d/swap_background_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tensorflow as tf
-from keras.__internal__.layers import BaseRandomLayer
+from tensorflow.keras.__internal__.layers import BaseRandomLayer
 
 from keras_cv.utils import conv_utils
 

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tensorflow as tf
-from tensorflow.keras.__internal__.layers import BaseRandomLayer
+from keras.__internal__.layers import BaseRandomLayer
 
 from keras_cv.utils import conv_utils
 

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")

--- a/keras_cv/layers/spatial_pyramid.py
+++ b/keras_cv/layers/spatial_pyramid.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Any
 from typing import List
 from typing import Mapping

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")

--- a/keras_cv/layers/vit_layers.py
+++ b/keras_cv/layers/vit_layers.py
@@ -15,7 +15,7 @@
 import math
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")

--- a/keras_cv/layers/vit_layers_test.py
+++ b/keras_cv/layers/vit_layers_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 from keras_cv.layers.vit_layers import PatchingAndEmbedding

--- a/keras_cv/losses/simclr_loss.py
+++ b/keras_cv/losses/simclr_loss.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 
 LARGE_NUM = 1e9
 

--- a/keras_cv/metrics/coco/mean_average_precision_test.py
+++ b/keras_cv/metrics/coco/mean_average_precision_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests for _COCOMeanAveragePrecision."""
 
+import keras
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv.metrics import _COCOMeanAveragePrecision
 

--- a/keras_cv/metrics/coco/recall.py
+++ b/keras_cv/metrics/coco/recall.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 import warnings
 
+import keras
+import keras.initializers as initializers
 import tensorflow as tf
-import tensorflow.keras as keras
-import tensorflow.keras.initializers as initializers
 
 from keras_cv import bounding_box
 from keras_cv.bounding_box import iou as iou_lib

--- a/keras_cv/models/__internal__/darknet_utils.py
+++ b/keras_cv/models/__internal__/darknet_utils.py
@@ -18,10 +18,10 @@ Reference:
   - [YoloV3 implementation](https://github.com/ultralytics/yolov3)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras import backend
+from keras import layers
 
 
 def DarknetConvBlock(

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-from tensorflow.keras import initializers
-from tensorflow.keras import layers
-from tensorflow.keras import regularizers
+import keras
+from keras import initializers
+from keras import layers
+from keras import regularizers
 
 
 def Block(filters, downsample, sync_bn):

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -15,7 +15,7 @@
 
 import os
 
-from tensorflow import keras
+import keras
 
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -19,9 +19,9 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+import keras
+from keras import backend
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -16,7 +16,7 @@ import os
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
+import keras
 
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet50V2Backbone,

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -14,9 +14,9 @@
 
 import os
 
+import keras
 import tensorflow as tf
 from absl.testing import parameterized
-import keras
 
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNet50V2Backbone,

--- a/keras_cv/models/convmixer.py
+++ b/keras_cv/models/convmixer.py
@@ -19,9 +19,9 @@ References:
 - [Patches Are All You Need?](https://arxiv.org/abs/2201.09792)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.weights import parse_weights

--- a/keras_cv/models/convnext.py
+++ b/keras_cv/models/convnext.py
@@ -18,10 +18,10 @@ References:
   (CVPR 2022)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras import backend
+from keras import layers
 
 from keras_cv.layers.regularization import StochasticDepth
 from keras_cv.models import utils

--- a/keras_cv/models/csp_darknet.py
+++ b/keras_cv/models/csp_darknet.py
@@ -21,9 +21,9 @@ Reference:
 """
 import types
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.__internal__.darknet_utils import CrossStagePartial

--- a/keras_cv/models/darknet.py
+++ b/keras_cv/models/darknet.py
@@ -18,9 +18,9 @@ Reference:
     - [YoloV3 implementation](https://github.com/ultralytics/yolov3)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.__internal__.darknet_utils import DarknetConvBlock

--- a/keras_cv/models/densenet.py
+++ b/keras_cv/models/densenet.py
@@ -19,9 +19,9 @@ Reference:
   - [Based on the Original keras.applications DenseNet](https://github.com/keras-team/keras/blob/master/keras/applications/densenet.py)
 """
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+import keras
+from keras import backend
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.weights import parse_weights

--- a/keras_cv/models/efficientnet_v1.py
+++ b/keras_cv/models/efficientnet_v1.py
@@ -24,10 +24,10 @@ Reference:
 import copy
 import math
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras import backend
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.weights import parse_weights

--- a/keras_cv/models/efficientnet_v2.py
+++ b/keras_cv/models/efficientnet_v2.py
@@ -24,9 +24,9 @@ Reference:
 import copy
 import math
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.layers import FusedMBConvBlock
 from keras_cv.layers import MBConvBlock

--- a/keras_cv/models/mlp_mixer.py
+++ b/keras_cv/models/mlp_mixer.py
@@ -18,10 +18,10 @@ Reference:
   - [MLP-Mixer: An all-MLP Architecture for Vision](https://arxiv.org/abs/2105.01601)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras import backend
+from keras import layers
 
 from keras_cv.models import utils
 

--- a/keras_cv/models/mobilenet_v3.py
+++ b/keras_cv/models/mobilenet_v3.py
@@ -19,11 +19,11 @@ References:
     - [Based on the original keras.applications MobileNetv3](https://github.com/keras-team/keras/blob/master/keras/applications/mobilenet_v3.py)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
-from tensorflow.keras.utils import custom_object_scope
+from keras import backend
+from keras import layers
+from keras.utils import custom_object_scope
 
 from keras_cv import layers as cv_layers
 from keras_cv.models import utils

--- a/keras_cv/models/models_test.py
+++ b/keras_cv/models/models_test.py
@@ -15,10 +15,10 @@
 
 import os
 
+import keras
 import pytest
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
+from keras import backend
 
 
 class ModelsTest:

--- a/keras_cv/models/object_detection/__test_utils__.py
+++ b/keras_cv/models/object_detection/__test_utils__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import tensorflow as tf
 
 import keras_cv

--- a/keras_cv/models/object_detection/faster_rcnn_test.py
+++ b/keras_cv/models/object_detection/faster_rcnn_test.py
@@ -17,7 +17,7 @@ import os
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow.keras import optimizers
+from keras import optimizers
 
 import keras_cv
 from keras_cv.models import ResNet50V2Backbone

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/feature_pyramid.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 
 @tf.keras.utils.register_keras_serializable(package="keras_cv")

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box

--- a/keras_cv/models/object_detection/retina_net/retina_net_coco_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_coco_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 import tensorflow as tf
-from tensorflow.keras import optimizers
+from keras import optimizers
 
 import keras_cv
 from keras_cv.models.object_detection.__test_utils__ import (

--- a/keras_cv/models/object_detection/retina_net/retina_net_label_encoder.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_label_encoder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv import bounding_box
 from keras_cv.layers.object_detection import box_matcher

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 import tensorflow as tf
-from tensorflow.keras import optimizers
+from keras import optimizers
 
 import keras_cv
 from keras_cv.models.object_detection.__test_utils__ import (

--- a/keras_cv/models/resnet_v1.py
+++ b/keras_cv/models/resnet_v1.py
@@ -19,10 +19,10 @@ Reference:
 
 import types
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras import backend
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.weights import parse_weights

--- a/keras_cv/models/segmentation/deeplab.py
+++ b/keras_cv/models/segmentation/deeplab.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
 from keras import layers
-import keras
 
 from keras_cv.layers.spatial_pyramid import SpatialPyramidPooling
 from keras_cv.models import utils

--- a/keras_cv/models/segmentation/deeplab.py
+++ b/keras_cv/models/segmentation/deeplab.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
+import keras
 
 from keras_cv.layers.spatial_pyramid import SpatialPyramidPooling
 from keras_cv.models import utils

--- a/keras_cv/models/stable_diffusion/__internal__/layers/attention_block.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/attention_block.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv.models.stable_diffusion.__internal__.layers.padded_conv2d import (
     PaddedConv2D,

--- a/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
+import keras
 
 
 class PaddedConv2D(keras.layers.Layer):

--- a/keras_cv/models/stable_diffusion/__internal__/layers/resnet_block.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/resnet_block.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
+import keras
 
 from keras_cv.models.stable_diffusion.__internal__.layers.padded_conv2d import (
     PaddedConv2D,

--- a/keras_cv/models/stable_diffusion/clip_tokenizer.py
+++ b/keras_cv/models/stable_diffusion/clip_tokenizer.py
@@ -17,8 +17,8 @@ import gzip
 import html
 from functools import lru_cache
 
+import keras
 import regex as re
-from tensorflow import keras
 
 
 @lru_cache()

--- a/keras_cv/models/stable_diffusion/decoder.py
+++ b/keras_cv/models/stable_diffusion/decoder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
+import keras
 
 from keras_cv.models.stable_diffusion.__internal__.layers.attention_block import (
     AttentionBlock,

--- a/keras_cv/models/stable_diffusion/diffusion_model.py
+++ b/keras_cv/models/stable_diffusion/diffusion_model.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv.models.stable_diffusion.__internal__.layers.padded_conv2d import (
     PaddedConv2D,

--- a/keras_cv/models/stable_diffusion/image_encoder.py
+++ b/keras_cv/models/stable_diffusion/image_encoder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
+import keras
 
 from keras_cv.models.stable_diffusion.__internal__.layers.attention_block import (
     AttentionBlock,

--- a/keras_cv/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion.py
@@ -23,9 +23,9 @@ The current implementation is a rewrite of the initial TF/Keras port by Divam Gu
 
 import math
 
+import keras
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv.models.stable_diffusion.clip_tokenizer import SimpleTokenizer
 from keras_cv.models.stable_diffusion.constants import _ALPHAS_CUMPROD

--- a/keras_cv/models/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow.keras import mixed_precision
+from keras import mixed_precision
 
 from keras_cv.models import StableDiffusion
 

--- a/keras_cv/models/stable_diffusion/text_encoder.py
+++ b/keras_cv/models/stable_diffusion/text_encoder.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
 from tensorflow.experimental import numpy as tfnp
 
 

--- a/keras_cv/models/utils.py
+++ b/keras_cv/models/utils.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 """Utility functions for models"""
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 
 def parse_model_inputs(input_shape, input_tensor):

--- a/keras_cv/models/vgg16.py
+++ b/keras_cv/models/vgg16.py
@@ -18,9 +18,9 @@ Reference:
   - [Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556) (ICLR 2015)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.models import utils
 

--- a/keras_cv/models/vgg19.py
+++ b/keras_cv/models/vgg19.py
@@ -17,9 +17,9 @@
 Reference:
   - [Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556) (ICLR 2015)
 """
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.models import utils
 from keras_cv.models.vgg16 import apply_vgg_block

--- a/keras_cv/models/vit.py
+++ b/keras_cv/models/vit.py
@@ -17,9 +17,9 @@ Reference:
   - [How to train your ViT? Data, Augmentation, and Regularization in Vision Transformers](https://arxiv.org/abs/2106.10270) (CoRR 2021)
 """
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
 
 from keras_cv.layers import TransformerEncoder
 from keras_cv.layers.vit_layers import PatchingAndEmbedding

--- a/keras_cv/models/weights.py
+++ b/keras_cv/models/weights.py
@@ -10,6 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+
 import tensorflow as tf
 from keras.utils import data_utils
 

--- a/keras_cv/training/contrastive/contrastive_trainer.py
+++ b/keras_cv/training/contrastive/contrastive_trainer.py
@@ -14,7 +14,7 @@
 
 
 import tensorflow as tf
-from tensorflow import keras
+import keras
 
 from keras_cv.utils.train import convert_inputs_to_tf_dataset
 

--- a/keras_cv/training/contrastive/contrastive_trainer.py
+++ b/keras_cv/training/contrastive/contrastive_trainer.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-import tensorflow as tf
 import keras
+import tensorflow as tf
 
 from keras_cv.utils.train import convert_inputs_to_tf_dataset
 

--- a/keras_cv/training/contrastive/contrastive_trainer_test.py
+++ b/keras_cv/training/contrastive/contrastive_trainer_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-from tensorflow.keras import metrics
-from tensorflow.keras import optimizers
+from keras import layers
+from keras import metrics
+from keras import optimizers
 
 from keras_cv.layers import preprocessing
 from keras_cv.losses import SimCLRLoss

--- a/keras_cv/training/contrastive/simclr_trainer.py
+++ b/keras_cv/training/contrastive/simclr_trainer.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras import layers
+import keras
 
 from keras_cv.layers import preprocessing
 from keras_cv.training import ContrastiveTrainer

--- a/keras_cv/training/contrastive/simclr_trainer.py
+++ b/keras_cv/training/contrastive/simclr_trainer.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras import layers
 import keras
+from keras import layers
 
 from keras_cv.layers import preprocessing
 from keras_cv.training import ContrastiveTrainer

--- a/keras_cv/training/contrastive/simclr_trainer_test.py
+++ b/keras_cv/training/contrastive/simclr_trainer_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
 from keras import layers
 from keras import optimizers
-import keras
 
 from keras_cv.losses import SimCLRLoss
 from keras_cv.models import ResNet50V2Backbone

--- a/keras_cv/training/contrastive/simclr_trainer_test.py
+++ b/keras_cv/training/contrastive/simclr_trainer_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
-from tensorflow.keras import optimizers
+from keras import layers
+from keras import optimizers
+import keras
 
 from keras_cv.losses import SimCLRLoss
 from keras_cv.models import ResNet50V2Backbone

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tensorflow as tf
-from tensorflow.keras import backend
+from keras import backend
 
 from keras_cv import core
 


### PR DESCRIPTION
# What does this PR do?

Fixes the imports for #1527 
Do let me know if I need to include any other changes.

## Who can review?

@ianstenbit @LukeWood 