### PR TITLE
Fixes RandomShearDemo

### DIFF
--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -64,14 +64,14 @@ def visualize_data(data, bounding_box_format):
 def visualize_bounding_boxes(image, bounding_boxes, bounding_box_format):
     color = np.array([[255.0, 0.0, 0.0]])
     bounding_boxes = bounding_box.to_dense(bounding_boxes)
-    if isinstance(image, tf.RaggedTensor):
-        image = image.to_tensor(0)
     bounding_boxes = bounding_box.convert_format(
         bounding_boxes,
         source=bounding_box_format,
         target="rel_yxyx",
         images=image,
     )
+    if isinstance(image, tf.RaggedTensor):
+        image = image.to_tensor(0)
     bounding_boxes = bounding_boxes["boxes"]
     return tf.image.draw_bounding_boxes(image, bounding_boxes, color, name=None)
 

--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -67,11 +67,17 @@ def visualize_bounding_boxes(image, bounding_boxes, bounding_box_format):
     bounding_boxes = bounding_box.convert_format(
         bounding_boxes,
         source=bounding_box_format,
-        target="rel_yxyx",
+        target="yxyx",
         images=image,
     )
     if isinstance(image, tf.RaggedTensor):
         image = image.to_tensor(0)
+    bounding_boxes = bounding_box.convert_format(
+        bounding_boxes,
+        source='yxyx',
+        target="rel_yxyx",
+        images=image,
+    )
     bounding_boxes = bounding_boxes["boxes"]
     return tf.image.draw_bounding_boxes(image, bounding_boxes, color, name=None)
 

--- a/examples/layers/preprocessing/bounding_box/demo_utils.py
+++ b/examples/layers/preprocessing/bounding_box/demo_utils.py
@@ -74,7 +74,7 @@ def visualize_bounding_boxes(image, bounding_boxes, bounding_box_format):
         image = image.to_tensor(0)
     bounding_boxes = bounding_box.convert_format(
         bounding_boxes,
-        source='yxyx',
+        source="yxyx",
         target="rel_yxyx",
         images=image,
     )

--- a/examples/layers/preprocessing/bounding_box/random_shear_demo.py
+++ b/examples/layers/preprocessing/bounding_box/random_shear_demo.py
@@ -22,14 +22,14 @@ from keras_cv.layers import preprocessing
 
 
 def main():
-    dataset = demo_utils.load_voc_dataset(bounding_box_format="rel_xyxy")
+    dataset = demo_utils.load_voc_dataset(bounding_box_format="xyxy")
     random_shear = preprocessing.RandomShear(
         x_factor=(0.1, 0.5),
         y_factor=(0.1, 0.5),
-        bounding_box_format="rel_xyxy",
+        bounding_box_format="xyxy",
     )
     dataset = dataset.map(random_shear, num_parallel_calls=tf.data.AUTOTUNE)
-    demo_utils.visualize_data(dataset, bounding_box_format="rel_xyxy")
+    demo_utils.visualize_data(dataset, bounding_box_format="xyxy")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
FYI @sebastian-sz - it looks like the demo utils are just not robust to arbitrary format w/ ragged images.  The conversion function was not accounting for the fact that ragged images have a different width/height than the originals, so calling `images.to_tensor()` will actually modify the locations of boxes within a batch.  After this change boxes are more in line with what you'd expect, but they still aren't perfect.

Before this change:
![225731150-05270c4c-7d77-4e9d-86a2-a798207d72bf](https://user-images.githubusercontent.com/12191303/225820460-66aa33fa-e188-4d99-b1bd-dcd9955ee532.png)

After this change:
![ ](https://user-images.githubusercontent.com/12191303/225820993-89ac0225-526c-40ed-b578-736548c3a7e1.png)

Still actually not perfect and there is a rounding error/minor bug somewhere, but an improvement.