### PR TITLE
Expand definition of 'value-range' in equalization docs

### DIFF
--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -24,9 +24,9 @@ class Equalization(BaseImageAugmentationLayer):
     """Equalization performs histogram equalization on a channel-wise basis.
 
     Args:
-        value_range: a tuple or a list of two elements. The first value represents
-            the lower bound for values in passed images, the second represents the
-            upper bound. Images passed to the layer should have values within
+        value_range: a tuple, list, numpy array, tf.tensor or any object that can return integer on indexing of two elements. 
+            The first value represents the lower bound for values in passed images, 
+            the second represents the upper bound. Images passed to the layer should have values within
             `value_range`.
         bins: Integer indicating the number of bins to use in histogram equalization.
             Should be in the range [0, 256].
@@ -41,8 +41,8 @@ class Equalization(BaseImageAugmentationLayer):
     ```
 
     Call arguments:
-        images: Tensor of pixels in range [0, 255], in RGB format.  Can be
-            of type float or int.  Should be in NHWC format.
+        images: Tensor of pixels in range [0, 255], in RGB format. Can be
+            of type float or int. Should be in NHWC format.
     """
 
     def __init__(self, value_range, bins=256, **kwargs):


### PR DESCRIPTION
# What this PR does:

* Updates the definition of value_range argument of Equalization class in preprocessing/layers/equalization.py

