### PR TITLE
Update definitions of tensor like args in preprocessing and auto_contrast docs

### DIFF
--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -31,7 +31,7 @@ class AutoContrast(VectorizedBaseImageAugmentationLayer):
 
     Args:
         value_range: the range of values the incoming images will have.
-            Represented as a two number tuple written [low, high]. 
+            Represented as a two number tuple written [low, high].
             This is typically either `[0, 1]` or `[0, 255]` depending
             on how your preprocessing pipeline is set up.
             (Note: It can be passed as any datatype that returns an integer on indexing like a list, tuple, numpy array or tf.tensor)

--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -31,7 +31,8 @@ class AutoContrast(VectorizedBaseImageAugmentationLayer):
 
     Args:
         value_range: the range of values the incoming images will have.
-            Represented as a two number tuple written [low, high].
+            Represented as a two number tuple written [low, high]. 
+            It can be passed as any datatype that returns an integer on indexing like a list, tuple, numpy array or tf.tensor
             This is typically either `[0, 1]` or `[0, 255]` depending
             on how your preprocessing pipeline is set up.
     """

--- a/keras_cv/layers/preprocessing/auto_contrast.py
+++ b/keras_cv/layers/preprocessing/auto_contrast.py
@@ -32,9 +32,9 @@ class AutoContrast(VectorizedBaseImageAugmentationLayer):
     Args:
         value_range: the range of values the incoming images will have.
             Represented as a two number tuple written [low, high]. 
-            It can be passed as any datatype that returns an integer on indexing like a list, tuple, numpy array or tf.tensor
             This is typically either `[0, 1]` or `[0, 255]` depending
             on how your preprocessing pipeline is set up.
+            (Note: It can be passed as any datatype that returns an integer on indexing like a list, tuple, numpy array or tf.tensor)
     """
 
     def __init__(

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -294,7 +294,8 @@ def transform(
       interpolation: Interpolation mode. Supported values: `"nearest"`,
         `"bilinear"`.
       output_shape: Output dimension after the transform, `[height, width]`.
-        If `None`, output is the same size as input image. Can be passed as any datatype that can be typecasted to a tf.tensor like list,tuple or numpy array. 
+        If `None`, output is the same size as input image. 
+        (Note: `output_shape` can be of any datatype that can be typecasted to a tf.tensor like list, tuple or numpy array.)
       name: The name of the op.
 
     Fill mode behavior for each valid value is as follows:

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -61,7 +61,7 @@ def transform_value_range(
         original_range: the value range to transform from.
         target_range: the value range to transform to.
         dtype: the dtype to compute the conversion with. Defaults to tf.float32.
-        (Note: `original_range` and `target_range` may be both different datatypes when passed but must be able to return integer on indexing.) 
+        (Note: `original_range` and `target_range` may be both different datatypes when passed but must be able to return integer on indexing.)
         
     Returns:
         a new Tensor with values in the target range.

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -58,10 +58,10 @@ def transform_value_range(
 
     Args:
         images: the set of images to transform to the target range.
-        original_range: the value range to transform from. Can be any datatype that returns integer value on indexing like list, tuple, numpy array or tf.tensor.
-        target_range: the value range to transform to. Can be any datatype that returns integer value on indexing like list, tuple, numpy array or tf.tensor.
+        original_range: the value range to transform from.
+        target_range: the value range to transform to.
         dtype: the dtype to compute the conversion with. Defaults to tf.float32.
-        (Note: `original_range` and `target_range` may be both different datatypes but both must be able to return integer on indexing) 
+        (Note: `original_range` and `target_range` may be both different datatypes when passed but must be able to return integer on indexing.) 
         
     Returns:
         a new Tensor with values in the target range.

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -53,15 +53,16 @@ def transform_value_range(
 ):
     """transforms values in input tensor from original_range to target_range.
     This function is intended to be used in preprocessing layers that
-    rely upon color values.  This allows us to assume internally that
+    rely upon color values. This allows us to assume internally that
     the input tensor is always in the range [0, 255].
 
     Args:
-        images: the set of images to transform to the target range range.
-        original_range: the value range to transform from.
-        target_range: the value range to transform to.
-        dtype: the dtype to compute the conversion with.  Defaults to tf.float32.
-
+        images: the set of images to transform to the target range.
+        original_range: the value range to transform from. Can be any datatype that returns integer value on indexing like list, tuple, numpy array or tf.tensor.
+        target_range: the value range to transform to. Can be any datatype that returns integer value on indexing like list, tuple, numpy array or tf.tensor.
+        dtype: the dtype to compute the conversion with. Defaults to tf.float32.
+        (Note: `original_range` and `target_range` may be both different datatypes but both must be able to return integer on indexing) 
+        
     Returns:
         a new Tensor with values in the target range.
 
@@ -115,10 +116,10 @@ def _unwrap_value_range(value_range, dtype=tf.float32):
 def blend(image1: tf.Tensor, image2: tf.Tensor, factor: float) -> tf.Tensor:
     """Blend image1 and image2 using 'factor'.
 
-    FactorSampler should be in the range [0, 1].  A value of 0.0 means only image1
-    is used. A value of 1.0 means only image2 is used.  A value between 0.0
+    FactorSampler should be in the range [0, 1]. A value of 0.0 means only image1
+    is used. A value of 1.0 means only image2 is used. A value between 0.0
     and 1.0 means we linearly interpolate the pixel values between the two
-    images.  A value greater than 1.0 "extrapolates" the difference
+    images. A value greater than 1.0 "extrapolates" the difference
     between the two pixel values, and we clip the results to values
     between 0 and 255.
     Args:
@@ -174,7 +175,7 @@ def random_inversion(random_generator):
     This can be used by KPLs to randomly invert sampled values.
 
     Args:
-        random_generator: a Keras random number generator.  An instance can be passed
+        random_generator: a Keras random number generator. An instance can be passed
         from the `self._random_generator` attribute of a `BaseImageAugmentationLayer`.
 
     Returns:
@@ -293,7 +294,7 @@ def transform(
       interpolation: Interpolation mode. Supported values: `"nearest"`,
         `"bilinear"`.
       output_shape: Output dimension after the transform, `[height, width]`.
-        If `None`, output is the same size as input image.
+        If `None`, output is the same size as input image. Can be passed as any datatype that can be typecasted to a tf.tensor like list,tuple or numpy array. 
       name: The name of the op.
 
     Fill mode behavior for each valid value is as follows:


### PR DESCRIPTION
# What does this PR do?

## Updates definition of :

*  'value_range' in  layers/preprocessing/auto_contrast.py

* original_range' & 'target_range' in utils/preprocessing.py

### Fixes some minor docstring errors.