### PR TITLE
Change __new__() args from self to cls

### DIFF
--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -435,7 +435,7 @@ ALIAS_DOCSTRING = """ResNetV2Backbone model with {num_layers} layers.
 
 class ResNet18V2Backbone(ResNetV2Backbone):
     def __new__(
-        self,
+        cls,
         include_rescaling=True,
         input_shape=(None, None, 3),
         input_tensor=None,
@@ -464,7 +464,7 @@ class ResNet18V2Backbone(ResNetV2Backbone):
 
 class ResNet34V2Backbone(ResNetV2Backbone):
     def __new__(
-        self,
+        cls,
         include_rescaling=True,
         input_shape=(None, None, 3),
         input_tensor=None,
@@ -493,7 +493,7 @@ class ResNet34V2Backbone(ResNetV2Backbone):
 
 class ResNet50V2Backbone(ResNetV2Backbone):
     def __new__(
-        self,
+        cls,
         include_rescaling=True,
         input_shape=(None, None, 3),
         input_tensor=None,
@@ -526,7 +526,7 @@ class ResNet50V2Backbone(ResNetV2Backbone):
 
 class ResNet101V2Backbone(ResNetV2Backbone):
     def __new__(
-        self,
+        cls,
         include_rescaling=True,
         input_shape=(None, None, 3),
         input_tensor=None,
@@ -555,7 +555,7 @@ class ResNet101V2Backbone(ResNetV2Backbone):
 
 class ResNet152V2Backbone(ResNetV2Backbone):
     def __new__(
-        self,
+        cls,
         include_rescaling=True,
         input_shape=(None, None, 3),
         input_tensor=None,


### PR DESCRIPTION
Minor fixes for ResNetV2Backbone.
Changing the `self` to `cls` in `__new__()` signature.