### PR TITLE
Vectorize Mosaic

### DIFF
--- a/benchmarks/vectorized_mosaic.py
+++ b/benchmarks/vectorized_mosaic.py
@@ -1,0 +1,467 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+from keras_cv import bounding_box
+from keras_cv.layers import Mosaic
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    IMAGES,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    LABELS,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
+
+
+class OldMosaic(BaseImageAugmentationLayer):
+    """Mosaic implements the mosaic data augmentation technique.
+
+    Mosaic data augmentation first takes 4 images from the batch and makes a
+    grid. After that based on the offset, a crop is taken to form the mosaic
+    image. Labels are in the same ratio as the the area of their images in the
+    output image. Bounding boxes are translated according to the position of
+    the 4 images.
+
+    Args:
+        offset: A tuple of two floats, a single float or
+            `keras_cv.FactorSampler`. `offset` is used to determine the offset
+            of the mosaic center from the top-left corner of the mosaic. If a
+            tuple is used, the x and y coordinates of the mosaic center are
+            sampled between the two values for every image augmented. If a
+            single float is used, a value between `0.0` and the passed float is
+            sampled. In order to ensure the value is always the same, please
+            pass a tuple with two identical floats: `(0.5, 0.5)`. Defaults to
+            (0.25, 0.75).
+        bounding_box_format: a case-insensitive string (for example, "xyxy") to
+            be passed if bounding boxes are being augmented by this layer.
+            Each bounding box is defined by at least these 4 values. The inputs
+            may contain additional information such as classes and confidence
+            after these 4 values but these values will be ignored and returned
+            as is. For detailed information on the supported formats, see the
+            [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
+            Defualts to None.
+        seed: Integer. Used to create a random seed.
+
+    References:
+        - [Yolov4 paper](https://arxiv.org/pdf/2004.10934).
+        - [Yolov5 implementation](https://github.com/ultralytics/yolov5).
+        - [YoloX implementation](https://github.com/Megvii-BaseDetection/YOLOX)
+
+    Sample usage:
+    ```python
+    (images, labels), _ = keras.datasets.cifar10.load_data()
+    labels = tf.one_hot(labels,10)
+    labels = tf.cast(tf.squeeze(labels), tf.float32)
+    mosaic = keras_cv.layers.preprocessing.Mosaic()
+    output = mosaic({'images': images, 'labels': labels})
+    # output == {'images': updated_images, 'labels': updated_labels}
+    ```
+    """
+
+    def __init__(
+        self, offset=(0.25, 0.75), bounding_box_format=None, seed=None, **kwargs
+    ):
+        super().__init__(seed=seed, **kwargs)
+        self.offset = offset
+        self.bounding_box_format = bounding_box_format
+        self.center_sampler = preprocessing_utils.parse_factor(
+            offset, param_name="offset", seed=seed
+        )
+        self.seed = seed
+
+    def _batch_augment(self, inputs):
+        self._validate_inputs(inputs)
+        images = inputs.get("images", None)
+        labels = inputs.get("labels", None)
+        bounding_boxes = inputs.get("bounding_boxes", None)
+
+        batch_size = tf.shape(images)[0]
+        # pick 3 indices for every batch to create the mosaic output with.
+        permutation_order = tf.random.uniform(
+            (batch_size, 3),
+            minval=0,
+            maxval=batch_size,
+            dtype=tf.int32,
+            seed=self._random_generator.make_legacy_seed(),
+        )
+        # concatenate the batches with permutation order to get all 4 images of
+        # the mosaic
+        permutation_order = tf.concat(
+            [tf.expand_dims(tf.range(batch_size), axis=-1), permutation_order],
+            axis=-1,
+        )
+
+        input_height, input_width, _ = images.shape[1:]
+
+        mosaic_centers_x = (
+            self.center_sampler(
+                tf.expand_dims(batch_size, axis=0), dtype=self.compute_dtype
+            )
+            * input_width
+        )
+        mosaic_centers_y = (
+            self.center_sampler(
+                shape=tf.expand_dims(batch_size, axis=0),
+                dtype=self.compute_dtype,
+            )
+            * input_height
+        )
+        mosaic_centers = tf.stack((mosaic_centers_x, mosaic_centers_y), axis=-1)
+
+        # return the mosaics
+        images = tf.vectorized_map(
+            lambda index: self._update_image(
+                images, permutation_order, mosaic_centers, index
+            ),
+            tf.range(batch_size),
+        )
+
+        if labels is not None:
+            labels = tf.vectorized_map(
+                lambda index: self._update_label(
+                    images, labels, permutation_order, mosaic_centers, index
+                ),
+                tf.range(batch_size),
+            )
+            inputs["labels"] = labels
+
+        if bounding_boxes is not None:
+            # values to translate the boxes by in the mosaic image
+            translate_x = tf.stack(
+                [
+                    mosaic_centers_x - input_width,
+                    mosaic_centers_x,
+                    mosaic_centers_x - input_width,
+                    mosaic_centers_x,
+                ],
+                axis=-1,
+            )
+
+            translate_y = tf.stack(
+                [
+                    mosaic_centers_y - input_height,
+                    mosaic_centers_y - input_height,
+                    mosaic_centers_y,
+                    mosaic_centers_y,
+                ],
+                axis=-1,
+            )
+
+            bounding_boxes = bounding_box.to_dense(bounding_boxes)
+            bounding_boxes = tf.map_fn(
+                lambda index: self._update_bounding_box(
+                    images,
+                    bounding_boxes,
+                    permutation_order,
+                    translate_x,
+                    translate_y,
+                    index,
+                ),
+                tf.range(batch_size),
+                fn_output_signature={
+                    "boxes": tf.RaggedTensorSpec(
+                        shape=[None, 4],
+                        ragged_rank=1,
+                        dtype=self.compute_dtype,
+                    ),
+                    "classes": tf.RaggedTensorSpec(
+                        shape=[None], dtype=self.compute_dtype
+                    ),
+                },
+            )
+            bounding_boxes = bounding_box.to_ragged(bounding_boxes)
+            inputs["bounding_boxes"] = bounding_boxes
+        inputs["images"] = images
+        return inputs
+
+    def _augment(self, inputs):
+        raise ValueError(
+            "Mosaic received a single image to `call`.  The layer relies on "
+            "combining multiple examples, and as such will not behave as "
+            "expected.  Please call the layer with 4 or more samples."
+        )
+
+    def _update_image(self, images, permutation_order, mosaic_centers, index):
+        # forms mosaic for one image from the batch
+        input_height, input_width, _ = images.shape[1:]
+        mosaic_images = tf.gather(images, permutation_order[index])
+
+        top = tf.concat([mosaic_images[0], mosaic_images[1]], axis=1)
+        bottom = tf.concat([mosaic_images[2], mosaic_images[3]], axis=1)
+        output = tf.concat([top, bottom], axis=0)
+
+        # cropping coordinates for the mosaic
+        x1 = (input_width - mosaic_centers[index][0]) / (input_width * 2 - 1)
+        y1 = (input_height - mosaic_centers[index][1]) / (input_height * 2 - 1)
+        x2 = x1 + (input_width) / (input_width * 2 - 1)
+        y2 = y1 + (input_height) / (input_height * 2 - 1)
+
+        # helps avoid retracing caused by slicing, inspired by RRC
+        # implementation
+        output = tf.image.crop_and_resize(
+            tf.expand_dims(output, axis=0),
+            [[y1, x1, y2, x2]],
+            [0],
+            [input_height, input_width],
+        )
+        # tf.image.crop_and_resize will always output float32, so we need to
+        # recast tf.image.crop_and_resize outputs
+        # [num_boxes, crop_height, crop_width, depth] since num_boxes is always
+        # one we squeeze axis 0
+        output = tf.cast(output, self.compute_dtype)
+        output = tf.squeeze(output, axis=0)
+        return output
+
+    def _update_label(
+        self, images, labels, permutation_order, mosaic_centers, index
+    ):
+        # updates labels for one output mosaic
+        input_height, input_width, _ = images.shape[1:]
+        labels_for_mosaic = tf.gather(labels, permutation_order[index])
+        center_x = mosaic_centers[index][0]
+        center_y = mosaic_centers[index][1]
+
+        area = input_height * input_width
+
+        # labels are in the same ratio as the area of the images
+        top_left_ratio = (center_x * center_y) / area
+        top_right_ratio = ((input_width - center_x) * center_y) / area
+        bottom_left_ratio = (center_x * (input_height - center_y)) / area
+        bottom_right_ratio = (
+            (input_width - center_x) * (input_height - center_y)
+        ) / area
+        label = (
+            labels_for_mosaic[0] * top_left_ratio
+            + labels_for_mosaic[1] * top_right_ratio
+            + labels_for_mosaic[2] * bottom_left_ratio
+            + labels_for_mosaic[3] * bottom_right_ratio
+        )
+        return label
+
+    def _update_bounding_box(
+        self,
+        images,
+        bounding_boxes,
+        permutation_order,
+        translate_x,
+        translate_y,
+        index,
+    ):
+        # updates bounding_boxes for one output mosaic
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            source=self.bounding_box_format,
+            target="xyxy",
+            images=images,
+            dtype=self.compute_dtype,
+        )
+        boxes, classes = bounding_boxes["boxes"], bounding_boxes["classes"]
+
+        classes_for_mosaic = tf.gather(classes, permutation_order[index])
+        boxes_for_mosaic = tf.gather(boxes, permutation_order[index])
+
+        # stacking translate values such that the shape is (4, 1, 4) or
+        # (num_images, broadcast dim, coordinates)
+        translate_values = tf.stack(
+            [
+                translate_x[index],
+                translate_y[index],
+                translate_x[index],
+                translate_y[index],
+            ],
+            axis=-1,
+        )
+        translate_values = tf.expand_dims(translate_values, axis=1)
+        # translating boxes
+        boxes_for_mosaic = boxes_for_mosaic + translate_values
+
+        boxes_for_mosaic = tf.reshape(boxes_for_mosaic, [-1, 4])
+        classes_for_mosaic = tf.reshape(
+            classes_for_mosaic,
+            [
+                -1,
+            ],
+        )
+
+        boxes_for_mosaic = {
+            "boxes": boxes_for_mosaic,
+            "classes": classes_for_mosaic,
+        }
+        boxes_for_mosaic = bounding_box.clip_to_image(
+            boxes_for_mosaic,
+            bounding_box_format="xyxy",
+            images=images[index],
+        )
+        boxes_for_mosaic = bounding_box.to_ragged(boxes_for_mosaic)
+        boxes_for_mosaic = bounding_box.convert_format(
+            boxes_for_mosaic,
+            source="xyxy",
+            target=self.bounding_box_format,
+            images=images[index],
+            dtype=self.compute_dtype,
+        )
+        return boxes_for_mosaic
+
+    def _validate_inputs(self, inputs):
+        images = inputs.get("images", None)
+        labels = inputs.get("labels", None)
+        bounding_boxes = inputs.get("bounding_boxes", None)
+        if images is None or (labels is None and bounding_boxes is None):
+            raise ValueError(
+                "Mosaic expects inputs in a dictionary with format "
+                '{"images": images, "labels": labels}. or'
+                '{"images": images, "bounding_boxes": bounding_boxes}'
+                f"Got: inputs = {inputs}"
+            )
+        if labels is not None and not labels.dtype.is_floating:
+            raise ValueError(
+                f"Mosaic received labels with type {labels.dtype}. "
+                "Labels must be of type float."
+            )
+        if bounding_boxes is not None and self.bounding_box_format is None:
+            raise ValueError(
+                "Mosaic received bounding boxes but no bounding_box_format. "
+                "Please pass a bounding_box_format from the supported list."
+            )
+
+    def get_config(self):
+        config = {
+            "offset": self.offset,
+            "bounding_box_format": self.bounding_box_format,
+            "seed": self.seed,
+        }
+        base_config = super().get_config()
+
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class MosaicTest(tf.test.TestCase):
+    def test_consistency_with_old_impl(self):
+        image_shape = (1, 32, 32, 3)
+        fixed_offset = (0.5, 0.5)
+        fixed_seed = 2023
+        images = tf.random.uniform(shape=image_shape)
+        inputs = {
+            IMAGES: images,
+            LABELS: tf.one_hot(tf.zeros((1,), tf.int32), 10),
+        }
+
+        layer = Mosaic(offset=fixed_offset, seed=fixed_seed)
+        old_layer = OldMosaic(offset=fixed_offset, seed=fixed_seed)
+
+        output = layer(inputs)
+        old_output = old_layer(inputs)
+
+        self.assertNotAllClose(inputs[IMAGES], output[IMAGES])
+        self.assertAllClose(old_output[IMAGES], output[IMAGES])
+        self.assertAllClose(old_output[LABELS], output[LABELS])
+
+
+if __name__ == "__main__":
+    # Run benchmark
+    (x_train, _), _ = keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(np.float32)
+
+    num_images = [1000, 2000, 5000, 10000]
+    num_classes = 10
+    results = {}
+    aug_candidates = [Mosaic, OldMosaic]
+    aug_args = {}
+
+    for aug in aug_candidates:
+        # Eager Mode
+        c = aug.__name__
+        layer = aug(**aug_args)
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            # warmup
+            inputs = {
+                IMAGES: x_train[:n_images],
+                LABELS: tf.one_hot(
+                    tf.zeros((n_images,), tf.int32), num_classes
+                ),
+            }
+            layer(inputs)
+
+            t0 = time.time()
+            r1 = layer(inputs)
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # Graph Mode
+        c = aug.__name__ + " Graph Mode"
+        layer = aug(**aug_args)
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            inputs = {
+                IMAGES: x_train[:n_images],
+                LABELS: tf.one_hot(
+                    tf.zeros((n_images,), tf.int32), num_classes
+                ),
+            }
+            # warmup
+            apply_aug(inputs)
+
+            t0 = time.time()
+            r1 = apply_aug(inputs)
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # XLA Mode
+        # cannot run tf.image.crop_and_resize on XLA
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison.png")
+
+    # So we can actually see more relevant margins
+    del results[aug_candidates[1].__name__]
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison_no_old_eager.png")
+
+    # Run unit tests
+    tf.test.main()

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,36 +16,50 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
-from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
-    BaseImageAugmentationLayer,
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    BATCHED,
 )
-from keras_cv.utils import preprocessing
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    BOUNDING_BOXES,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    IMAGES,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    LABELS,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    VectorizedBaseImageAugmentationLayer,
+)
+from keras_cv.utils import preprocessing as preprocessing_utils
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class Mosaic(BaseImageAugmentationLayer):
+class Mosaic(VectorizedBaseImageAugmentationLayer):
     """Mosaic implements the mosaic data augmentation technique.
 
-    Mosaic data augmentation first takes 4 images from the batch and makes a grid.
-    After that based on the offset, a crop is taken to form the mosaic image. Labels
-    are in the same ratio as the the area of their images in the output image. Bounding
-    boxes are translated according to the position of the 4 images.
+    Mosaic data augmentation first takes 4 images from the batch and makes a
+    grid. After that based on the offset, a crop is taken to form the mosaic
+    image. Labels are in the same ratio as the the area of their images in the
+    output image. Bounding boxes are translated according to the position of
+    the 4 images.
 
     Args:
-        offset: A tuple of two floats, a single float or `keras_cv.FactorSampler`.
-            `offset` is used to determine the offset of the mosaic center from the
-            top-left corner of the mosaic. If a tuple is used, the x and y coordinates
-            of the mosaic center are sampled between the two values for every image
-            augmented. If a single float is used, a value between `0.0` and the passed
-            float is sampled.  In order to ensure the value is always the same, please
+        offset: A tuple of two floats, a single float or
+            `keras_cv.FactorSampler`. `offset` is used to determine the offset
+            of the mosaic center from the top-left corner of the mosaic. If a
+            tuple is used, the x and y coordinates of the mosaic center are
+            sampled between the two values for every image augmented. If a
+            single float is used, a value between `0.0` and the passed float is
+            sampled. In order to ensure the value is always the same, please
             pass a tuple with two identical floats: `(0.5, 0.5)`. Defaults to
             (0.25, 0.75).
-        bounding_box_format: a case-insensitive string (for example, "xyxy") to be
-            passed if bounding boxes are being augmented by this layer.
+        bounding_box_format: a case-insensitive string (for example, "xyxy") to
+            be passed if bounding boxes are being augmented by this layer.
             Each bounding box is defined by at least these 4 values. The inputs
-            may contain additional information such as classes and confidence after
-            these 4 values but these values will be ignored and returned as is. For
-            detailed information on the supported formats, see the
+            may contain additional information such as classes and confidence
+            after these 4 values but these values will be ignored and returned
+            as is. For detailed information on the supported formats, see the
             [KerasCV bounding box documentation](https://keras.io/api/keras_cv/bounding_box/formats/).
             Defualts to None.
         seed: Integer. Used to create a random seed.
@@ -72,159 +86,99 @@ class Mosaic(BaseImageAugmentationLayer):
         super().__init__(seed=seed, **kwargs)
         self.offset = offset
         self.bounding_box_format = bounding_box_format
-        self.center_sampler = preprocessing.parse_factor(
+        self.center_sampler = preprocessing_utils.parse_factor(
             offset, param_name="offset", seed=seed
         )
         self.seed = seed
 
-    def _batch_augment(self, inputs):
-        self._validate_inputs(inputs)
-        images = inputs.get("images", None)
-        labels = inputs.get("labels", None)
-        bounding_boxes = inputs.get("bounding_boxes", None)
-
-        batch_size = tf.shape(images)[0]
+    def get_random_transformation_batch(self, batch_size, **kwargs):
         # pick 3 indices for every batch to create the mosaic output with.
-        permutation_order = tf.random.uniform(
+        permutation_order = self._random_generator.random_uniform(
             (batch_size, 3),
             minval=0,
             maxval=batch_size,
             dtype=tf.int32,
-            seed=self._random_generator.make_legacy_seed(),
         )
-        # concatenate the batches with permutation order to get all 4 images of the mosaic
+        # concatenate the batches with permutation order to get all 4 images of
+        # the mosaic
         permutation_order = tf.concat(
             [tf.expand_dims(tf.range(batch_size), axis=-1), permutation_order],
             axis=-1,
         )
 
-        input_height, input_width, _ = images.shape[1:]
-
-        mosaic_centers_x = (
-            self.center_sampler(
-                tf.expand_dims(batch_size, axis=0), dtype=self.compute_dtype
-            )
-            * input_width
+        mosaic_centers_x = self.center_sampler(
+            shape=(batch_size,), dtype=self.compute_dtype
         )
-        mosaic_centers_y = (
-            self.center_sampler(
-                shape=tf.expand_dims(batch_size, axis=0),
-                dtype=self.compute_dtype,
-            )
-            * input_height
+        mosaic_centers_y = self.center_sampler(
+            shape=(batch_size,), dtype=self.compute_dtype
         )
         mosaic_centers = tf.stack((mosaic_centers_x, mosaic_centers_y), axis=-1)
 
-        # return the mosaics
-        images = tf.vectorized_map(
-            lambda index: self._update_image(
-                images, permutation_order, mosaic_centers, index
-            ),
-            tf.range(batch_size),
-        )
+        return {
+            "permutation_order": permutation_order,
+            "mosaic_centers": mosaic_centers,
+        }
 
-        if labels is not None:
-            labels = tf.vectorized_map(
-                lambda index: self._update_label(
-                    images, labels, permutation_order, mosaic_centers, index
-                ),
-                tf.range(batch_size),
-            )
-            inputs["labels"] = labels
-
-        if bounding_boxes is not None:
-            # values to translate the boxes by in the mosaic image
-            translate_x = tf.stack(
-                [
-                    mosaic_centers_x - input_width,
-                    mosaic_centers_x,
-                    mosaic_centers_x - input_width,
-                    mosaic_centers_x,
-                ],
-                axis=-1,
-            )
-
-            translate_y = tf.stack(
-                [
-                    mosaic_centers_y - input_height,
-                    mosaic_centers_y - input_height,
-                    mosaic_centers_y,
-                    mosaic_centers_y,
-                ],
-                axis=-1,
-            )
-
-            bounding_boxes = bounding_box.to_dense(bounding_boxes)
-            bounding_boxes = tf.map_fn(
-                lambda index: self._update_bounding_box(
-                    images,
-                    bounding_boxes,
-                    permutation_order,
-                    translate_x,
-                    translate_y,
-                    index,
-                ),
-                tf.range(batch_size),
-                fn_output_signature={
-                    "boxes": tf.RaggedTensorSpec(
-                        shape=[None, 4],
-                        ragged_rank=1,
-                        dtype=self.compute_dtype,
-                    ),
-                    "classes": tf.RaggedTensorSpec(
-                        shape=[None], dtype=self.compute_dtype
-                    ),
-                },
-            )
-            bounding_boxes = bounding_box.to_ragged(bounding_boxes)
-            inputs["bounding_boxes"] = bounding_boxes
-        inputs["images"] = images
-        return inputs
-
-    def _augment(self, inputs):
+    def augment_ragged_image(self, image, transformation, **kwargs):
         raise ValueError(
-            "Mosaic received a single image to `call`.  The layer relies on "
-            "combining multiple examples, and as such will not behave as "
-            "expected.  Please call the layer with 4 or more samples."
+            "Mosaic received a single ragged image to `call`. The "
+            "layer relies on combining multiple examples, and as such "
+            "will not behave as expected. Please call the layer with 4 "
+            "or more samples."
         )
 
-    def _update_image(self, images, permutation_order, mosaic_centers, index):
-        # forms mosaic for one image from the batch
+    def augment_images(self, images, transformations, **kwargs):
+        batch_size = tf.shape(images)[0]
         input_height, input_width, _ = images.shape[1:]
-        mosaic_images = tf.gather(images, permutation_order[index])
 
-        top = tf.concat([mosaic_images[0], mosaic_images[1]], axis=1)
-        bottom = tf.concat([mosaic_images[2], mosaic_images[3]], axis=1)
-        output = tf.concat([top, bottom], axis=0)
+        # forms mosaic for one image from the batch
+        permutation_order = transformations["permutation_order"]
+        mosaic_images = tf.gather(images, permutation_order)
+
+        tops = tf.concat([mosaic_images[:, 0], mosaic_images[:, 1]], axis=2)
+        bottoms = tf.concat([mosaic_images[:, 2], mosaic_images[:, 3]], axis=2)
+        outputs = tf.concat([tops, bottoms], axis=1)
 
         # cropping coordinates for the mosaic
-        x1 = (input_width - mosaic_centers[index][0]) / (input_width * 2 - 1)
-        y1 = (input_height - mosaic_centers[index][1]) / (input_height * 2 - 1)
-        x2 = x1 + (input_width) / (input_width * 2 - 1)
-        y2 = y1 + (input_height) / (input_height * 2 - 1)
+        mosaic_centers = transformations["mosaic_centers"]
+        mosaic_centers_x = mosaic_centers[..., 0] * input_width
+        mosaic_centers_y = mosaic_centers[..., 1] * input_height
+        x1s = (input_width - mosaic_centers_x) / (input_width * 2 - 1)
+        y1s = (input_height - mosaic_centers_y) / (input_height * 2 - 1)
+        x2s = x1s + (input_width) / (input_width * 2 - 1)
+        y2s = y1s + (input_height) / (input_height * 2 - 1)
+        cropping_boxes = tf.stack([y1s, x1s, y2s, x2s], axis=-1)
 
-        # helps avoid retracing caused by slicing, inspired by RRC implementation
-        output = tf.image.crop_and_resize(
-            tf.expand_dims(output, axis=0),
-            [[y1, x1, y2, x2]],
-            [0],
+        # helps avoid retracing caused by slicing, inspired by RRC
+        # implementation
+        # boxes must be type tf.float32
+        outputs = tf.image.crop_and_resize(
+            outputs,
+            tf.cast(cropping_boxes, tf.float32),
+            tf.range(batch_size),
             [input_height, input_width],
         )
-        # tf.image.crop_and_resize will always output float32, so we need to recast
-        # tf.image.crop_and_resize outputs [num_boxes, crop_height, crop_width, depth]
-        # since num_boxes is always one we squeeze axis 0
-        output = tf.cast(output, self.compute_dtype)
-        output = tf.squeeze(output, axis=0)
-        return output
+        # tf.image.crop_and_resize will always output float32, so we need to
+        # recast tf.image.crop_and_resize outputs
+        # [num_boxes, crop_height, crop_width, depth] since num_boxes is always
+        # one we squeeze axis 0
+        outputs = tf.cast(outputs, self.compute_dtype)
+        return outputs
 
-    def _update_label(
-        self, images, labels, permutation_order, mosaic_centers, index
-    ):
-        # updates labels for one output mosaic
+    def augment_targets(self, targets, transformations, image=None, **kwargs):
+        return self.augment_labels(
+            labels=targets, transformations=transformations, images=image
+        )
+
+    def augment_labels(self, labels, transformations, images=None, **kwargs):
         input_height, input_width, _ = images.shape[1:]
-        labels_for_mosaic = tf.gather(labels, permutation_order[index])
-        center_x = mosaic_centers[index][0]
-        center_y = mosaic_centers[index][1]
+        # updates labels for one output mosaic
+        permutation_order = transformations["permutation_order"]
+        labels_for_mosaic = tf.gather(labels, permutation_order)
+
+        mosaic_centers = transformations["mosaic_centers"]
+        center_x = mosaic_centers[..., 0] * input_width
+        center_y = mosaic_centers[..., 1] * input_height
 
         area = input_height * input_width
 
@@ -235,24 +189,20 @@ class Mosaic(BaseImageAugmentationLayer):
         bottom_right_ratio = (
             (input_width - center_x) * (input_height - center_y)
         ) / area
-        label = (
-            labels_for_mosaic[0] * top_left_ratio
-            + labels_for_mosaic[1] * top_right_ratio
-            + labels_for_mosaic[2] * bottom_left_ratio
-            + labels_for_mosaic[3] * bottom_right_ratio
+        labels = (
+            labels_for_mosaic[:, 0] * top_left_ratio[:, tf.newaxis]
+            + labels_for_mosaic[:, 1] * top_right_ratio[:, tf.newaxis]
+            + labels_for_mosaic[:, 2] * bottom_left_ratio[:, tf.newaxis]
+            + labels_for_mosaic[:, 3] * bottom_right_ratio[:, tf.newaxis]
         )
-        return label
+        return labels
 
-    def _update_bounding_box(
-        self,
-        images,
-        bounding_boxes,
-        permutation_order,
-        translate_x,
-        translate_y,
-        index,
+    def augment_bounding_boxes(
+        self, bounding_boxes, transformations, images=None, **kwargs
     ):
-        # updates bounding_boxes for one output mosaic
+        batch_size = tf.shape(images)[0]
+        input_height, input_width, _ = images.shape[1:]
+        bounding_boxes = bounding_box.to_dense(bounding_boxes)
         bounding_boxes = bounding_box.convert_format(
             bounding_boxes,
             source=self.bounding_box_format,
@@ -262,31 +212,44 @@ class Mosaic(BaseImageAugmentationLayer):
         )
         boxes, classes = bounding_boxes["boxes"], bounding_boxes["classes"]
 
-        classes_for_mosaic = tf.gather(classes, permutation_order[index])
-        boxes_for_mosaic = tf.gather(boxes, permutation_order[index])
-
-        # stacking translate values such that the shape is (4, 1, 4) or (num_images, broadcast dim, coordinates)
-        translate_values = tf.stack(
+        # values to translate the boxes by in the mosaic image
+        mosaic_centers = transformations["mosaic_centers"]
+        mosaic_centers_x = mosaic_centers[..., 0] * input_width
+        mosaic_centers_y = mosaic_centers[..., 1] * input_height
+        translate_x = tf.stack(
             [
-                translate_x[index],
-                translate_y[index],
-                translate_x[index],
-                translate_y[index],
+                mosaic_centers_x - input_width,
+                mosaic_centers_x,
+                mosaic_centers_x - input_width,
+                mosaic_centers_x,
             ],
             axis=-1,
         )
-        translate_values = tf.expand_dims(translate_values, axis=1)
-        # translating boxes
-        boxes_for_mosaic = boxes_for_mosaic + translate_values
-
-        boxes_for_mosaic = tf.reshape(boxes_for_mosaic, [-1, 4])
-        classes_for_mosaic = tf.reshape(
-            classes_for_mosaic,
+        translate_y = tf.stack(
             [
-                -1,
+                mosaic_centers_y - input_height,
+                mosaic_centers_y - input_height,
+                mosaic_centers_y,
+                mosaic_centers_y,
             ],
+            axis=-1,
         )
 
+        # updates bounding_boxes for one output mosaic
+        permutation_order = transformations["permutation_order"]
+        classes_for_mosaic = tf.gather(classes, permutation_order)
+        boxes_for_mosaic = tf.gather(boxes, permutation_order)
+
+        # stacking translate values such that the shape is (B, 4, 1, 4) or
+        # (batch_size, num_images, broadcast dim, coordinates)
+        translate_values = tf.stack(
+            [translate_x, translate_y, translate_x, translate_y], axis=-1
+        )
+        translate_values = tf.expand_dims(translate_values, axis=2)
+        # translating boxes
+        boxes_for_mosaic = boxes_for_mosaic + translate_values
+        boxes_for_mosaic = tf.reshape(boxes_for_mosaic, [batch_size, -1, 4])
+        classes_for_mosaic = tf.reshape(classes_for_mosaic, [batch_size, -1])
         boxes_for_mosaic = {
             "boxes": boxes_for_mosaic,
             "classes": classes_for_mosaic,
@@ -294,22 +257,37 @@ class Mosaic(BaseImageAugmentationLayer):
         boxes_for_mosaic = bounding_box.clip_to_image(
             boxes_for_mosaic,
             bounding_box_format="xyxy",
-            images=images[index],
+            images=images,
         )
-        boxes_for_mosaic = bounding_box.to_ragged(boxes_for_mosaic)
         boxes_for_mosaic = bounding_box.convert_format(
             boxes_for_mosaic,
             source="xyxy",
             target=self.bounding_box_format,
-            images=images[index],
+            images=images,
             dtype=self.compute_dtype,
         )
         return boxes_for_mosaic
 
+    def _batch_augment(self, inputs):
+        self._validate_inputs(inputs)
+        return super()._batch_augment(inputs)
+
+    def call(self, inputs, training=True):
+        if training is True:
+            _, metadata = self._format_inputs(inputs)
+            if metadata[BATCHED] is not True:
+                raise ValueError(
+                    "Mosaic received a single image to `call`. The "
+                    "layer relies on combining multiple examples, and as such "
+                    "will not behave as expected. Please call the layer with 4 "
+                    "or more samples."
+                )
+        return super().call(inputs=inputs, training=training)
+
     def _validate_inputs(self, inputs):
-        images = inputs.get("images", None)
-        labels = inputs.get("labels", None)
-        bounding_boxes = inputs.get("bounding_boxes", None)
+        images = inputs.get(IMAGES, None)
+        labels = inputs.get(LABELS, None)
+        bounding_boxes = inputs.get(BOUNDING_BOXES, None)
         if images is None or (labels is None and bounding_boxes is None):
             raise ValueError(
                 "Mosaic expects inputs in a dictionary with format "
@@ -337,3 +315,7 @@ class Mosaic(BaseImageAugmentationLayer):
         base_config = super().get_config()
 
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)


### PR DESCRIPTION
# What does this PR do?

Related to #291 

||Mode|n=1000|n=2000|n=5000|n=10000|
|-|-|-|-|-|-|
|OldMosaic|Eager|1.097s|1.591s|2.980s|6.105s|
|OldMosaic|Graph|0.347s|0.560s|1.576s|3.733s|
|Mosaic|Eager|0.014s|0.020s|0.077s|0.143s|
|Mosaic|Graph|0.010s|0.016s|0.070s|0.138s|

![comparison](https://user-images.githubusercontent.com/20734616/226543476-3c6b1c27-cfb2-4c25-a276-f9c356cc45b6.png)

XLA failed to run due to lacking `CropAndResize` kernel.

To visualize the outputs, I fixed `examples/layers/preprocessing/bounding_box/mosaic_demo.py` with the help from #1534:

```python
import tensorflow as tf
from examples.layers.preprocessing.bounding_box import demo_utils
from keras_cv.layers import preprocessing
from keras_cv.layers.preprocessing.jittered_resize import JitteredResize

def main():
    dataset = demo_utils.load_voc_dataset(bounding_box_format="xyxy")
    resize = JitteredResize(
        target_size=(256, 256),
        scale_factor=(0.5, 1.0),
        bounding_box_format="xyxy",
    )
    mosaic = preprocessing.Mosaic(bounding_box_format="xyxy")
    dataset = dataset.map(resize, num_parallel_calls=tf.data.AUTOTUNE)
    dataset = dataset.map(mosaic, num_parallel_calls=tf.data.AUTOTUNE)
    demo_utils.visualize_data(dataset, bounding_box_format="xyxy")

if __name__ == "__main__":
    main()
```

This layer (and the old implementation as well) cannot run with ragged images directly. But it works with dense images.

![output](https://user-images.githubusercontent.com/20734616/226544327-46aae7e4-618e-4c6e-9193-2ad86cb0f0b4.png)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 