### PR TITLE
Avoid caching the entire Waymo Open Dataset during loading

### DIFF
--- a/keras_cv/datasets/waymo/load.py
+++ b/keras_cv/datasets/waymo/load.py
@@ -28,9 +28,9 @@ except ImportError:
 
 def _generate_frames(segments, transformer):
     def _generator():
-        for record in tfds.as_numpy(segments):
+        for record in segments:
             frame = waymo_open_dataset.dataset_pb2.Frame()
-            frame.ParseFromString(record)
+            frame.ParseFromString(record.numpy())
             yield transformer(frame)
 
     return _generator

--- a/keras_cv/datasets/waymo/load.py
+++ b/keras_cv/datasets/waymo/load.py
@@ -15,7 +15,6 @@
 import os
 
 import tensorflow as tf
-import tensorflow_datasets as tfds
 
 from keras_cv.datasets.waymo import transformer
 from keras_cv.utils import assert_waymo_open_dataset_installed


### PR DESCRIPTION
This was an oversight in the original implementation, and I've discovered it's a performance nightmare when trying to use this with a large dataset (basically anything greater than one TFRecord slice)