### PR TITLE
Fix augment methods in `VectorizedBaseImageAugmentationLayer`

### DIFF
--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -164,11 +164,6 @@ class Mosaic(VectorizedBaseImageAugmentationLayer):
         outputs = tf.cast(outputs, self.compute_dtype)
         return outputs
 
-    def augment_targets(self, targets, transformations, image=None, **kwargs):
-        return self.augment_labels(
-            labels=targets, transformations=transformations, images=image
-        )
-
     def augment_labels(self, labels, transformations, images=None, **kwargs):
         input_height, input_width, _ = images.shape[1:]
         # updates labels for one output mosaic

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -163,7 +163,7 @@ class VectorizedBaseImageAugmentationLayer(
         Returns:
           output 2D tensor, which will be forward to `layer.call()`.
         """
-        return self.augment_labels(targets, transformations)
+        return self.augment_labels(targets, transformations, **kwargs)
 
     def augment_bounding_boxes(self, bounding_boxes, transformations, **kwargs):
         """Augment bounding boxes for one image during training.
@@ -295,7 +295,7 @@ class VectorizedBaseImageAugmentationLayer(
                 images,
                 transformations=transformations,
                 bounding_boxes=bounding_boxes,
-                label=labels,
+                labels=labels,
             )
 
         result = {IMAGES: images}
@@ -304,7 +304,7 @@ class VectorizedBaseImageAugmentationLayer(
                 labels,
                 transformations=transformations,
                 bounding_boxes=bounding_boxes,
-                image=images,
+                images=images,
             )
             result[LABELS] = labels
 
@@ -322,7 +322,7 @@ class VectorizedBaseImageAugmentationLayer(
             keypoints = self.augment_keypoints(
                 keypoints,
                 transformations=transformations,
-                label=labels,
+                labels=labels,
                 bounding_boxes=bounding_boxes,
                 images=images,
             )
@@ -331,6 +331,9 @@ class VectorizedBaseImageAugmentationLayer(
             segmentation_masks = self.augment_segmentation_masks(
                 segmentation_masks,
                 transformations=transformations,
+                labels=labels,
+                bounding_boxes=bounding_boxes,
+                images=images,
             )
             result[SEGMENTATION_MASKS] = segmentation_masks
 

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -57,6 +57,130 @@ class VectorizedRandomAddLayer(VectorizedBaseImageAugmentationLayer):
         return segmentation_masks + transformations[:, None, None, None]
 
 
+TF_ALL_TENSOR_TYPES = (tf.Tensor, tf.RaggedTensor, tf.SparseTensor)
+
+
+class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def augment_ragged_image(
+        self,
+        image,
+        label=None,
+        bounding_boxes=None,
+        keypoints=None,
+        segmentation_mask=None,
+        transformation=None,
+        **kwargs
+    ):
+        assert isinstance(image, TF_ALL_TENSOR_TYPES)
+        assert isinstance(label, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(keypoints, TF_ALL_TENSOR_TYPES)
+        assert isinstance(segmentation_mask, TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformation, TF_ALL_TENSOR_TYPES)
+        return image
+
+    def get_random_transformation_batch(
+        self,
+        batch_size,
+        images=None,
+        labels=None,
+        bounding_boxes=None,
+        keypoints=None,
+        segmentation_masks=None,
+        **kwargs
+    ):
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(keypoints, TF_ALL_TENSOR_TYPES)
+        assert isinstance(segmentation_masks, TF_ALL_TENSOR_TYPES)
+        return self._random_generator.random_uniform((batch_size,))
+
+    def augment_images(
+        self,
+        images,
+        transformations=None,
+        bounding_boxes=None,
+        labels=None,
+        **kwargs
+    ):
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        return images
+
+    def augment_labels(
+        self,
+        labels,
+        transformations=None,
+        bounding_boxes=None,
+        images=None,
+        **kwargs
+    ):
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        return labels
+
+    def augment_bounding_boxes(
+        self,
+        bounding_boxes,
+        transformations=None,
+        labels=None,
+        images=None,
+        **kwargs
+    ):
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        return bounding_boxes
+
+    def augment_keypoints(
+        self,
+        keypoints,
+        transformations=None,
+        labels=None,
+        bounding_boxes=None,
+        images=None,
+        **kwargs
+    ):
+        assert isinstance(keypoints, TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        return keypoints
+
+    def augment_segmentation_masks(
+        self,
+        segmentation_masks,
+        transformations=None,
+        labels=None,
+        bounding_boxes=None,
+        images=None,
+        **kwargs
+    ):
+        assert isinstance(segmentation_masks, TF_ALL_TENSOR_TYPES)
+        assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
+        assert isinstance(labels, TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
+        assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        return segmentation_masks
+
+
 class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_single_image(self):
         add_layer = VectorizedRandomAddLayer(fixed_value=2.0)
@@ -285,3 +409,58 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
         self.assertNotAllClose(
             segmentation_mask_diff[0], segmentation_mask_diff[1]
         )
+
+    def test_augment_all_data_for_assertion(self):
+        images = np.random.random(size=(2, 8, 8, 3)).astype("float32")
+        labels = np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
+        bounding_boxes = {
+            "boxes": np.random.random(size=(2, 3, 4)).astype("float32"),
+            "classes": np.random.random(size=(2, 3)).astype("float32"),
+        }
+        keypoints = np.random.random(size=(2, 5, 2)).astype("float32")
+        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype(
+            "float32"
+        )
+        assertion_layer = VectorizedAssertionLayer()
+
+        _ = assertion_layer(
+            {
+                "images": images,
+                "labels": labels,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_masks": segmentation_masks,
+            }
+        )
+
+        # assertion is at VectorizedAssertionLayer's methods
+
+    def test_augment_all_data_with_ragged_images_for_assertion(self):
+        images = tf.ragged.stack(
+            [
+                np.random.random(size=(8, 8, 3)).astype("float32"),
+                np.random.random(size=(16, 8, 3)).astype("float32"),
+            ]
+        )
+        labels = np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
+        bounding_boxes = {
+            "boxes": np.random.random(size=(2, 3, 4)).astype("float32"),
+            "classes": np.random.random(size=(2, 3)).astype("float32"),
+        }
+        keypoints = np.random.random(size=(2, 5, 2)).astype("float32")
+        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype(
+            "float32"
+        )
+        assertion_layer = VectorizedAssertionLayer()
+
+        _ = assertion_layer(
+            {
+                "images": images,
+                "labels": labels,
+                "bounding_boxes": bounding_boxes,
+                "keypoints": keypoints,
+                "segmentation_masks": segmentation_masks,
+            }
+        )
+
+        # assertion is at VectorizedAssertionLayer's methods


### PR DESCRIPTION
# What does this PR do?

I have originally reported a bug in https://github.com/keras-team/keras-cv/pull/1555#issuecomment-1477423343

This PR fixes the arguments in `_batch_augment` and the missing `**kwargs` in `augment_targets`.

This PR also adds `labels`, `bounding_boxes` and `images` for `augment_segmentation_masks` to align to `augment_keypoints`. It should be a harmless addition.

An assertion test including VectorizedAssertionLayer is added to verify the changes.

As a result, the workaround in Mosaic must be removed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 
