### PR TITLE
Fix the serialization of RetinaNet

### DIFF
--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -18,6 +18,7 @@ from tensorflow import keras
 from keras_cv import bounding_box
 
 
+@keras.utils.register_keras_serializable(package="keras_cv")
 class AnchorGenerator(keras.layers.Layer):
     """AnchorGenerator generates anchors for multiple feature maps.
 

--- a/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
+++ b/keras_cv/models/object_detection/retina_net/__internal__/layers/prediction_head.py
@@ -64,9 +64,22 @@ class PredictionHead(layers.Layer):
 
     def get_config(self):
         config = {
-            "bias_initializer": self.bias_initializer,
+            "bias_initializer": keras.initializers.serialize(
+                self.bias_initializer
+            ),
             "output_filters": self.output_filters,
             "num_conv_layers": self.num_conv_layers,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        config.update(
+            {
+                "bias_initializer": keras.initializers.deserialize(
+                    config["bias_initializer"]
+                )
+            }
+        )
+        return super().from_config(config)

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -193,7 +193,9 @@ class RetinaNet(keras.Model):
             self.backbone, extractor_layer_names, extractor_levels
         )
         self.feature_pyramid = layers_lib.FeaturePyramid()
-        prior_probability = tf.constant_initializer(-np.log((1 - 0.01) / 0.01))
+        prior_probability = keras.initializers.Constant(
+            -np.log((1 - 0.01) / 0.01)
+        )
 
         self.classification_head = (
             classification_head
@@ -204,7 +206,7 @@ class RetinaNet(keras.Model):
         )
 
         self.box_head = box_head or layers_lib.PredictionHead(
-            output_filters=9 * 4, bias_initializer="zeros"
+            output_filters=9 * 4, bias_initializer=keras.initializers.Zeros()
         )
 
     def make_predict_function(self, force=False):
@@ -516,12 +518,9 @@ class RetinaNet(keras.Model):
         return {
             "num_classes": self.num_classes,
             "bounding_box_format": self.bounding_box_format,
-            # TODO(bischof): actually serialize the backbone
             "backbone": self.backbone,
-            "anchor_generator": self.anchor_generator,
             "label_encoder": self.label_encoder,
             "prediction_decoder": self._prediction_decoder,
-            "feature_pyramid": self.feature_pyramid,
             "classification_head": self.classification_head,
             "box_head": self.box_head,
         }

--- a/keras_cv/models/object_detection/retina_net/retina_net_label_encoder.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_label_encoder.py
@@ -21,6 +21,7 @@ from keras_cv.layers.object_detection import box_matcher
 from keras_cv.utils import target_gather
 
 
+@keras.utils.register_keras_serializable(package="keras_cv")
 class RetinaNetLabelEncoder(layers.Layer):
     """Transforms the raw labels into targets for training.
 

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 
 import pytest
@@ -207,3 +208,15 @@ class RetinaNetTest(tf.test.TestCase):
 
         retina_net.fit(dataset, epochs=1)
         retina_net.evaluate(dataset)
+
+    def test_serialization(self):
+        model = keras_cv.models.RetinaNet(
+            num_classes=20,
+            bounding_box_format="xywh",
+        )
+        serialized_1 = keras.utils.serialize_keras_object(model)
+        restored = keras.utils.deserialize_keras_object(
+            copy.deepcopy(serialized_1)
+        )
+        serialized_2 = keras.utils.serialize_keras_object(restored)
+        self.assertEqual(serialized_1, serialized_2)


### PR DESCRIPTION
removed the `anchor_generator` from `get_config()` because it cannot be provided together with `label_encoder` and `prediction_decoder` while initializing the class.

I suggest we start to add these serialization tests when implementing new models.
Otherwise, many models may not work in saving.