### PR TITLE
Typo fixes in converters docs

### DIFF
--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -300,33 +300,33 @@ def convert_format(
     f"""Converts bounding_boxes from one format to another.
 
     Supported formats are:
-    - `"xyxy"`, also known as `corners` format. In this format the first four axes
+    - `"xyxy"`, also known as `corners` format.  In this format the first four axes
         represent `[left, top, right, bottom]` in that order.
-    - `"rel_xyxy"`. In this format, the axes are the same as `"xyxy"` but the x
+    - `"rel_xyxy"`.  In this format, the axes are the same as `"xyxy"` but the x
         coordinates are normalized using the image width, and the y axes the image
-        height. All values in `rel_xyxy` are in the range `(0, 1)`.
-    - `"xywh"`. In this format the first four axes represent
+        height.  All values in `rel_xyxy` are in the range `(0, 1)`.
+    - `"xywh"`.  In this format the first four axes represent
         `[left, top, width, height]`.
-    - `"rel_xywh". In this format the first four axes represent
+    - `"rel_xywh".  In this format the first four axes represent
         [left, top, width, height], just like `"xywh"`. But unlike `"xywh"`, the values
         are in the range (0, 1) instead of absolute pixel values.
-    - `"center_xyWH"`. In this format the first two coordinates represent the x and y
+    - `"center_xyWH"`.  In this format the first two coordinates represent the x and y
         coordinates of the center of the bounding box, while the last two represent
         the width and height of the bounding box.
-    - `"center_yxHW"`. In this format the first two coordinates represent the y and x
+    - `"center_yxHW"`.  In this format the first two coordinates represent the y and x
         coordinates of the center of the bounding box, while the last two represent
         the height and width of the bounding box.
-    - `"yxyx"`. In this format the first four axes represent [top, left, bottom, right]
+    - `"yxyx"`.  In this format the first four axes represent [top, left, bottom, right]
         in that order.
-    - `"rel_yxyx"`. In this format, the axes are the same as `"yxyx"` but the x
+    - `"rel_yxyx"`.  In this format, the axes are the same as `"yxyx"` but the x
         coordinates are normalized using the image width, and the y coordinates using the image
-        height. All values in `rel_yxyx` are in the range (0, 1).
-    Formats are case insensitive. It is recommended that you capitalize width and
+        height.  All values in `rel_yxyx` are in the range (0, 1).
+    Formats are case insensitive.  It is recommended that you capitalize width and
     height to maximize the visual difference between `"xyWH"` and `"xyxy"`.
 
     Relative formats, abbreviated `rel`, make use of the shapes of the `images` passed.
     In these formats, the coordinates, widths, and heights are all specified as
-    percentages of the host image. Here `images` may be a ragged Tensor. Note that using a
+    percentages of the host image. Here `images` may be a ragged Tensor.  Note that using a
     ragged Tensor for images may cause a substantial performance loss, as each image
     will need to be processed separately due to the mismatching image shapes.
 
@@ -345,19 +345,19 @@ def convert_format(
         boxes: tf.Tensor representing bounding boxes in the format specified in the
             `source` parameter. Here `boxes` can optionally have extra dimensions stacked on
              the final axis to store metadata. Here boxes should be a 3D Tensor, with the
-             shape `[batch_size, num_boxes, 4]`. Alternatively, boxes can be a
+             shape `[batch_size, num_boxes, 4]`.  Alternatively, boxes can be a
              dictionary with key 'boxes' containing a Tensor matching the aforementioned
              spec.
-        source: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}. Used
+        source: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.  Used
             to specify the original format of the `boxes` parameter.
-        target: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}. Used
+        target: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.  Used
             to specify the destination format of the `boxes` parameter.
         images: (Optional) a batch of images aligned with `boxes` on the first axis.
             Should be at least 3 dimensions, with the first 3 dimensions representing:
-            `[batch_size, height, width]`. Used in some converters to compute relative
-            pixel values of the bounding box dimensions. Required when transforming
+            `[batch_size, height, width]`.  Used in some converters to compute relative
+            pixel values of the bounding box dimensions.  Required when transforming
             from a rel format to a non-rel format.
-        dtype: the data type to use when transforming the boxes. Defaults to
+        dtype: the data type to use when transforming the boxes.  Defaults to
             `tf.float32`.
     """
     if isinstance(boxes, dict):

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -300,33 +300,33 @@ def convert_format(
     f"""Converts bounding_boxes from one format to another.
 
     Supported formats are:
-    - `"xyxy"`, also known as `corners` format.  In this format the first four axes
+    - `"xyxy"`, also known as `corners` format. In this format the first four axes
         represent `[left, top, right, bottom]` in that order.
-    - `"rel_xyxy"`.  In this format, the axes are the same as `"xyxy"` but the x
+    - `"rel_xyxy"`. In this format, the axes are the same as `"xyxy"` but the x
         coordinates are normalized using the image width, and the y axes the image
-        height.  All values in `rel_xyxy` are in the range `(0, 1)`.
-    - `"xywh"`.  In this format the first four axes represent
+        height. All values in `rel_xyxy` are in the range `(0, 1)`.
+    - `"xywh"`. In this format the first four axes represent
         `[left, top, width, height]`.
-    - `"rel_xywh".  In this format the first four axes represent
-        [left, top, width, height], just like `"xywh"`.  Unlike `"xywh"`, the values
+    - `"rel_xywh". In this format the first four axes represent
+        [left, top, width, height], just like `"xywh"`. But unlike `"xywh"`, the values
         are in the range (0, 1) instead of absolute pixel values.
-    - `"center_xyWH"`.  In this format the first two coordinates represent the x and y
+    - `"center_xyWH"`. In this format the first two coordinates represent the x and y
         coordinates of the center of the bounding box, while the last two represent
         the width and height of the bounding box.
-    - `"center_yxHW"`.  In this format the first two coordinates represent the y and x
+    - `"center_yxHW"`. In this format the first two coordinates represent the y and x
         coordinates of the center of the bounding box, while the last two represent
         the height and width of the bounding box.
-    - `"yxyx"`.  In this format the first four axes represent [top, left, bottom, right]
+    - `"yxyx"`. In this format the first four axes represent [top, left, bottom, right]
         in that order.
-    - `"rel_yxyx"`.  In this format, the axes are the same as `"yxyx"` but the x
-        coordinates are normalized using the image width, and the y axes the image
-        height.  All values in `rel_yxyx` are in the range (0, 1).
-    Formats are case insensitive.  It is recommended that you capitalize width and
+    - `"rel_yxyx"`. In this format, the axes are the same as `"yxyx"` but the x
+        coordinates are normalized using the image width, and the y coordinates using the image
+        height. All values in `rel_yxyx` are in the range (0, 1).
+    Formats are case insensitive. It is recommended that you capitalize width and
     height to maximize the visual difference between `"xyWH"` and `"xyxy"`.
 
     Relative formats, abbreviated `rel`, make use of the shapes of the `images` passed.
     In these formats, the coordinates, widths, and heights are all specified as
-    percentages of the host image.  `images` may be a ragged Tensor.  Note that using a
+    percentages of the host image. Here `images` may be a ragged Tensor. Note that using a
     ragged Tensor for images may cause a substantial performance loss, as each image
     will need to be processed separately due to the mismatching image shapes.
 
@@ -343,21 +343,21 @@ def convert_format(
 
     Args:
         boxes: tf.Tensor representing bounding boxes in the format specified in the
-            `source` parameter.  `boxes` can optionally have extra dimensions stacked on
-             the final axis to store metadata.  boxes should be a 3D Tensor, with the
-             shape `[batch_size, num_boxes, 4]`.  Alternatively, boxes can be a
+            `source` parameter. Here `boxes` can optionally have extra dimensions stacked on
+             the final axis to store metadata. Here boxes should be a 3D Tensor, with the
+             shape `[batch_size, num_boxes, 4]`. Alternatively, boxes can be a
              dictionary with key 'boxes' containing a Tensor matching the aforementioned
              spec.
-        source: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.  Used
+        source: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}. Used
             to specify the original format of the `boxes` parameter.
-        target: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.  Used
+        target: One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}. Used
             to specify the destination format of the `boxes` parameter.
         images: (Optional) a batch of images aligned with `boxes` on the first axis.
             Should be at least 3 dimensions, with the first 3 dimensions representing:
-            `[batch_size, height, width]`.  Used in some converters to compute relative
-            pixel values of the bounding box dimensions.  Required when transforming
+            `[batch_size, height, width]`. Used in some converters to compute relative
+            pixel values of the bounding box dimensions. Required when transforming
             from a rel format to a non-rel format.
-        dtype: the data type to use when transforming the boxes.  Defaults to
+        dtype: the data type to use when transforming the boxes. Defaults to
             `tf.float32`.
     """
     if isinstance(boxes, dict):


### PR DESCRIPTION
# What this PR does:

* Attempts to fix minor documentation errors in bounding_box/converters.py
