### PR TITLE
EPOCHS already defined

### DIFF
--- a/examples/training/object_detection/pascal_voc/faster_rcnn.py
+++ b/examples/training/object_detection/pascal_voc/faster_rcnn.py
@@ -337,4 +337,6 @@ model.compile(
     rpn_box_loss="Huber",
     rpn_classification_loss="BinaryCrossentropy",
 )
-model.fit(train_ds, epochs=FLAGS.epochs, validation_data=eval_ds, callbacks=callbacks)
+model.fit(
+    train_ds, epochs=FLAGS.epochs, validation_data=eval_ds, callbacks=callbacks
+)

--- a/examples/training/object_detection/pascal_voc/faster_rcnn.py
+++ b/examples/training/object_detection/pascal_voc/faster_rcnn.py
@@ -36,7 +36,7 @@ flags.DEFINE_string(
 )
 flags.DEFINE_integer(
     "epochs",
-    50,
+    18,
     "Number of epochs to run for.",
 )
 flags.DEFINE_string(
@@ -324,7 +324,6 @@ weight_decay = 0.0001
 step = 0
 
 callbacks = [
-    keras.callbacks.EarlyStopping(patience=10),
     keras.callbacks.ModelCheckpoint(FLAGS.weights_path, save_weights_only=True),
     keras.callbacks.TensorBoard(
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True

--- a/examples/training/object_detection/pascal_voc/faster_rcnn.py
+++ b/examples/training/object_detection/pascal_voc/faster_rcnn.py
@@ -34,6 +34,11 @@ flags.DEFINE_string(
     "weights_{epoch:02d}.h5",
     "Directory which will be used to store weight checkpoints.",
 )
+flags.DEFINE_integer(
+    "epochs",
+    50,
+    "Number of epochs to run for.",
+)
 flags.DEFINE_string(
     "tensorboard_path",
     "logs",
@@ -319,6 +324,7 @@ weight_decay = 0.0001
 step = 0
 
 callbacks = [
+    keras.callbacks.EarlyStopping(patience=10),
     keras.callbacks.ModelCheckpoint(FLAGS.weights_path, save_weights_only=True),
     keras.callbacks.TensorBoard(
         log_dir=FLAGS.tensorboard_path, write_steps_per_second=True
@@ -332,4 +338,4 @@ model.compile(
     rpn_box_loss="Huber",
     rpn_classification_loss="BinaryCrossentropy",
 )
-model.fit(train_ds, epochs=18, validation_data=eval_ds, callbacks=callbacks)
+model.fit(train_ds, epochs=FLAGS.epochs, validation_data=eval_ds, callbacks=callbacks)

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -383,6 +383,6 @@ callbacks = [
 history = model.fit(
     train_ds,
     validation_data=eval_ds,
-    epochs=35,
+    epochs=EPOCHS,
     callbacks=callbacks,
 )

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -34,7 +34,7 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 
 flags.DEFINE_integer(
     "epochs",
-    50,
+    35,
     "Number of epochs to run for.",
 )
 

--- a/examples/training/object_detection/pascal_voc/retina_net.py
+++ b/examples/training/object_detection/pascal_voc/retina_net.py
@@ -32,7 +32,11 @@ from keras_cv.callbacks import PyCOCOCallback
 low, high = resource.getrlimit(resource.RLIMIT_NOFILE)
 resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
 
-EPOCHS = 100
+flags.DEFINE_integer(
+    "epochs",
+    50,
+    "Number of epochs to run for.",
+)
 
 flags.DEFINE_string(
     "weights_name",
@@ -383,6 +387,6 @@ callbacks = [
 history = model.fit(
     train_ds,
     validation_data=eval_ds,
-    epochs=EPOCHS,
+    epochs=FLAGS.epochs,
     callbacks=callbacks,
 )


### PR DESCRIPTION
# What does this PR do?

EPOCHS is already defined to be 100, and in the model fit, a new number was included in `model.fit` 

Also, since all the `examples/training` includes the epochs input as Flag, the code examples for `object_detection/pascal_voc/` directly take an epoch value(100 in `retina_net` and 18 in `faster_rcnn`). 

Do let me know if I need to modify this PR by including the Flag value for epoch:

```py
flags.DEFINE_integer(
    "epochs",
    100,
    "Number of epochs to run for.",
)
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LukeWood 