### PR TITLE
Expand 'chain_depth' definition in AugMix docs

### DIFF
--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -47,7 +47,9 @@ class AugMix(BaseImageAugmentationLayer):
         num_chains: an integer representing the number of different chains to
             be mixed. Defaults to 3.
         chain_depth: an integer or range representing the number of transformations in
-            the chains. Defaults to [1,3].
+            the chains.
+            If a range is passed, a random `chain_depth` value sampled from a uniform distribution over the given range is called at the start of the chain.
+            Defaults to [1,3].
         alpha: a float value used as the probability coefficients for the
             Beta and Dirichlet distributions. Defaults to 1.0.
         seed: Integer. Used to create a random seed.


### PR DESCRIPTION
# What this PR does :

* Attempts to expand and update upon the existing definition of 'chain_depth' arg in AugMix