### PR TITLE
Cleanup internal format for encoded CenterPillar targets

### DIFF
--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -189,8 +189,10 @@ class MultiHeadCenterPillar(keras.Model):
 
     def compile(self, heatmap_loss=None, box_loss=None, **kwargs):
         """Compiles the MultiHeadCenterPillar.
+
         `compile()` mirrors the standard Keras `compile()` method, but allows
         for specification of heatmap and box-specific losses.
+
         Args:
             heatmap_loss: a Keras loss to use for heatmap regression.
             box_loss: a Keras loss to use for box regression.


### PR DESCRIPTION
For the CenterPillar model, the "targets" are like encoded boxes in 2D OD, and that encoding is somewhat expensive so it will happen during preprocessing .

The targets are derived from the actual 3D boxes, and an upcoming PR will add a utliity to derive these targets from the 3D boxes in the tf.data pipeline.

As a result, a user of CenterPillar will have input data in the format:
``` 
x = {
        "point_xyz": FloatTensor[B, N, 3],
        "point_feature": FloatTensor[B, N, ?], 
        "point_mask": BoolTensor[B, N]}
}
y = {
       "bounding_boxes":  {
               "boxes": FloatTensor[B, N, 7], 
               "classes": IntTensor[B, N], 
               "difficulty": IntTensor[B, N],
               "mask": BoolTensor[B, N]
        }
}
```

The encoded targets will be added to `y` and will have the structure
```
"class_n": {"heatmap": FloatTensor, "boxes": FloatTensor, "top_k_idx": FloatTensor}
```

The idea is to abstract away that encoding so that users don't have to wrestle with it, and this PR establishes the expected input structure for these encoded targets.