### PR TITLE
Fix padding issue in StableDiffusion encoder

### DIFF
--- a/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
@@ -16,10 +16,20 @@ from tensorflow import keras
 
 
 class PaddedConv2D(keras.layers.Layer):
-    def __init__(self, filters, kernel_size, padding=0, strides=1, **kwargs):
+    def __init__(
+        self,
+        filters,
+        kernel_size,
+        padding=0,
+        strides=1,
+        conv_padding="valid",
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.padding2d = keras.layers.ZeroPadding2D(padding)
-        self.conv2d = keras.layers.Conv2D(filters, kernel_size, strides=strides)
+        self.conv2d = keras.layers.Conv2D(
+            filters, kernel_size, strides=strides, padding=conv_padding
+        )
 
     def call(self, inputs):
         x = self.padding2d(inputs)

--- a/keras_cv/models/stable_diffusion/image_encoder.py
+++ b/keras_cv/models/stable_diffusion/image_encoder.py
@@ -32,16 +32,16 @@ class ImageEncoder(keras.Sequential):
         super().__init__(
             [
                 keras.layers.Input((img_height, img_width, 3)),
-                PaddedConv2D(128, 3, padding=1),
+                PaddedConv2D(128, 3, padding=1, conv_padding="same"),
                 ResnetBlock(128),
                 ResnetBlock(128),
-                PaddedConv2D(128, 3, padding=1, strides=2),
+                PaddedConv2D(128, 3, padding=1, strides=2, conv_padding="same"),
                 ResnetBlock(256),
                 ResnetBlock(256),
-                PaddedConv2D(256, 3, padding=1, strides=2),
+                PaddedConv2D(256, 3, padding=1, strides=2, conv_padding="same"),
                 ResnetBlock(512),
                 ResnetBlock(512),
-                PaddedConv2D(512, 3, padding=1, strides=2),
+                PaddedConv2D(512, 3, padding=1, strides=2, conv_padding="same"),
                 ResnetBlock(512),
                 ResnetBlock(512),
                 ResnetBlock(512),
@@ -49,8 +49,10 @@ class ImageEncoder(keras.Sequential):
                 ResnetBlock(512),
                 keras.layers.GroupNormalization(epsilon=1e-5),
                 keras.layers.Activation("swish"),
-                PaddedConv2D(8, 3, padding=1),
-                PaddedConv2D(8, 1),
+                PaddedConv2D(8, 3, padding=1, conv_padding="same"),
+                PaddedConv2D(8, 1, conv_padding="same"),
+                # Lambda gets rid of padding from the sides of the encoding.
+                keras.layers.Lambda(lambda x: x[..., 2:-2, 2:-2, :]),
                 # TODO(lukewood): can this be refactored to be a Rescaling layer?
                 # Perhaps some sort of rescale and gather?
                 # Either way, we may need a lambda to gather the first 4 dimensions.

--- a/keras_cv/models/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion_test.py
@@ -19,7 +19,7 @@ from keras_cv.models import StableDiffusion
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    def test_end_to_end_golden_value(self):
+    def DISABLED_test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 

--- a/keras_cv/models/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion_test.py
@@ -19,7 +19,7 @@ from keras_cv.models import StableDiffusion
 
 
 class StableDiffusionTest(tf.test.TestCase):
-    def DISABLED_test_end_to_end_golden_value(self):
+    def test_end_to_end_golden_value(self):
         prompt = "a caterpillar smoking a hookah while sitting on a mushroom"
         stablediff = StableDiffusion(128, 128)
 


### PR DESCRIPTION
Fixes #1172

In the [testing colab](https://colab.research.google.com/gist/ianstenbit/4c20db0d98dde03b0a68e7afaf713084/sd-encoder-padding.ipynb), you can see that the gray bar on the top and left sides of the auto-encoded image are now gone.

Additionally, the mean error of the reconstructed image is down about 10x (probably just from getting rid of the bars).

This is not the most elegant fix the world has ever seen, but it does seem to fix the numerics of the model, and the qualitative results from the encoder are much better.

I've manually run the SD tests, and I am currently also re-running the Textual Inversion notebook (as it depends on the encoder heavily). I'll post results once it's done, but it's looking fine so far.