### PR TITLE
Revert "Fix padding issue in StableDiffusion encoder"

### DIFF
--- a/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
+++ b/keras_cv/models/stable_diffusion/__internal__/layers/padded_conv2d.py
@@ -16,20 +16,10 @@ from tensorflow import keras
 
 
 class PaddedConv2D(keras.layers.Layer):
-    def __init__(
-        self,
-        filters,
-        kernel_size,
-        padding=0,
-        strides=1,
-        conv_padding="valid",
-        **kwargs
-    ):
+    def __init__(self, filters, kernel_size, padding=0, strides=1, **kwargs):
         super().__init__(**kwargs)
         self.padding2d = keras.layers.ZeroPadding2D(padding)
-        self.conv2d = keras.layers.Conv2D(
-            filters, kernel_size, strides=strides, padding=conv_padding
-        )
+        self.conv2d = keras.layers.Conv2D(filters, kernel_size, strides=strides)
 
     def call(self, inputs):
         x = self.padding2d(inputs)

--- a/keras_cv/models/stable_diffusion/image_encoder.py
+++ b/keras_cv/models/stable_diffusion/image_encoder.py
@@ -32,16 +32,16 @@ class ImageEncoder(keras.Sequential):
         super().__init__(
             [
                 keras.layers.Input((img_height, img_width, 3)),
-                PaddedConv2D(128, 3, padding=1, conv_padding="same"),
+                PaddedConv2D(128, 3, padding=1),
                 ResnetBlock(128),
                 ResnetBlock(128),
-                PaddedConv2D(128, 3, padding=1, strides=2, conv_padding="same"),
+                PaddedConv2D(128, 3, padding=1, strides=2),
                 ResnetBlock(256),
                 ResnetBlock(256),
-                PaddedConv2D(256, 3, padding=1, strides=2, conv_padding="same"),
+                PaddedConv2D(256, 3, padding=1, strides=2),
                 ResnetBlock(512),
                 ResnetBlock(512),
-                PaddedConv2D(512, 3, padding=1, strides=2, conv_padding="same"),
+                PaddedConv2D(512, 3, padding=1, strides=2),
                 ResnetBlock(512),
                 ResnetBlock(512),
                 ResnetBlock(512),
@@ -49,10 +49,8 @@ class ImageEncoder(keras.Sequential):
                 ResnetBlock(512),
                 keras.layers.GroupNormalization(epsilon=1e-5),
                 keras.layers.Activation("swish"),
-                PaddedConv2D(8, 3, padding=1, conv_padding="same"),
-                PaddedConv2D(8, 1, conv_padding="same"),
-                # Lambda gets rid of padding from the sides of the encoding.
-                keras.layers.Lambda(lambda x: x[..., 2:-2, 2:-2, :]),
+                PaddedConv2D(8, 3, padding=1),
+                PaddedConv2D(8, 1),
                 # TODO(lukewood): can this be refactored to be a Rescaling layer?
                 # Perhaps some sort of rescale and gather?
                 # Either way, we may need a lambda to gather the first 4 dimensions.


### PR DESCRIPTION
Reverts keras-team/keras-cv#1582

This seems to have broken Inpainting: [colab](https://colab.research.google.com/gist/ianstenbit/76200f3cf14a9db05c04d3523b091a1b/sd-inpainting.ipynb)