### PR TITLE
Add raw images information to augment methods in VectorizedBaseImageAugmentationLayer

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +83,9 @@ from keras_cv.layers.preprocessing.repeated_augmentation import (
 from keras_cv.layers.preprocessing.rescaling import Rescaling
 from keras_cv.layers.preprocessing.resizing import Resizing
 from keras_cv.layers.preprocessing.solarization import Solarization
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    VectorizedBaseImageAugmentationLayer,
+)
 from keras_cv.layers.preprocessing_3d.frustum_random_dropping_points import (
     FrustumRandomDroppingPoints,
 )

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,11 +31,13 @@ from keras_cv.layers.preprocessing.equalization import Equalization
 from keras_cv.layers.preprocessing.fourier_mix import FourierMix
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
+from keras_cv.layers.preprocessing.jittered_resize import JitteredResize
 from keras_cv.layers.preprocessing.maybe_apply import MaybeApply
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.mosaic import Mosaic
 from keras_cv.layers.preprocessing.posterization import Posterization
 from keras_cv.layers.preprocessing.rand_augment import RandAugment
+from keras_cv.layers.preprocessing.random_aspect_ratio import RandomAspectRatio
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,
 )
@@ -75,3 +77,6 @@ from keras_cv.layers.preprocessing.repeated_augmentation import (
 from keras_cv.layers.preprocessing.rescaling import Rescaling
 from keras_cv.layers.preprocessing.resizing import Resizing
 from keras_cv.layers.preprocessing.solarization import Solarization
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    VectorizedBaseImageAugmentationLayer,
+)

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -33,6 +33,7 @@ BATCHED = "batched"
 USE_TARGETS = "use_targets"
 
 
+@keras.utils.register_keras_serializable(package="keras_cv")
 class VectorizedBaseImageAugmentationLayer(
     keras.__internal__.layers.BaseRandomLayer
 ):
@@ -263,6 +264,7 @@ class VectorizedBaseImageAugmentationLayer(
 
     def _batch_augment(self, inputs):
         images = inputs.get(IMAGES, None)
+        raw_images = images
         labels = inputs.get(LABELS, None)
         bounding_boxes = inputs.get(BOUNDING_BOXES, None)
         keypoints = inputs.get(KEYPOINTS, None)
@@ -305,6 +307,7 @@ class VectorizedBaseImageAugmentationLayer(
                 transformations=transformations,
                 bounding_boxes=bounding_boxes,
                 images=images,
+                raw_images=raw_images,
             )
             result[LABELS] = labels
 
@@ -314,6 +317,7 @@ class VectorizedBaseImageAugmentationLayer(
                 transformations=transformations,
                 labels=labels,
                 images=images,
+                raw_images=raw_images,
             )
             bounding_boxes = bounding_box.to_ragged(bounding_boxes)
             result[BOUNDING_BOXES] = bounding_boxes
@@ -325,6 +329,7 @@ class VectorizedBaseImageAugmentationLayer(
                 labels=labels,
                 bounding_boxes=bounding_boxes,
                 images=images,
+                raw_images=raw_images,
             )
             result[KEYPOINTS] = keypoints
         if segmentation_masks is not None:
@@ -334,6 +339,7 @@ class VectorizedBaseImageAugmentationLayer(
                 labels=labels,
                 bounding_boxes=bounding_boxes,
                 images=images,
+                raw_images=raw_images,
             )
             result[SEGMENTATION_MASKS] = segmentation_masks
 

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -122,6 +122,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         transformations=None,
         bounding_boxes=None,
         images=None,
+        raw_images=None,
         **kwargs
     ):
         assert isinstance(labels, TF_ALL_TENSOR_TYPES)
@@ -129,6 +130,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(raw_images, TF_ALL_TENSOR_TYPES)
         return labels
 
     def augment_bounding_boxes(
@@ -137,6 +139,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         transformations=None,
         labels=None,
         images=None,
+        raw_images=None,
         **kwargs
     ):
         assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
@@ -144,6 +147,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         assert isinstance(transformations, TF_ALL_TENSOR_TYPES)
         assert isinstance(labels, TF_ALL_TENSOR_TYPES)
         assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(raw_images, TF_ALL_TENSOR_TYPES)
         return bounding_boxes
 
     def augment_keypoints(
@@ -153,6 +157,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         labels=None,
         bounding_boxes=None,
         images=None,
+        raw_images=None,
         **kwargs
     ):
         assert isinstance(keypoints, TF_ALL_TENSOR_TYPES)
@@ -161,6 +166,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(raw_images, TF_ALL_TENSOR_TYPES)
         return keypoints
 
     def augment_segmentation_masks(
@@ -170,6 +176,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         labels=None,
         bounding_boxes=None,
         images=None,
+        raw_images=None,
         **kwargs
     ):
         assert isinstance(segmentation_masks, TF_ALL_TENSOR_TYPES)
@@ -178,6 +185,7 @@ class VectorizedAssertionLayer(VectorizedBaseImageAugmentationLayer):
         assert isinstance(bounding_boxes["boxes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(bounding_boxes["classes"], TF_ALL_TENSOR_TYPES)
         assert isinstance(images, TF_ALL_TENSOR_TYPES)
+        assert isinstance(raw_images, TF_ALL_TENSOR_TYPES)
         return segmentation_masks
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #1590 

Moreover, this PR adds `keras.utils.register_keras_serializable` to VectorizedBaseImageAugmentationLayer, as well as fixes for some missing layers in the `__init__.py`.

The unit test has been updated to ensure that `raw_images` is present.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 