### PR TITLE
Fix `bounding_box.converters.convert_format`

### DIFF
--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -511,9 +511,8 @@ def _image_shape(images, image_shape, boxes):
             width = tf.reshape(
                 tf.reduce_max(images.row_lengths(axis=2), 1), (-1, 1)
             )
-            if isinstance(boxes, tf.RaggedTensor):
-                height = tf.expand_dims(height, axis=-1)
-                width = tf.expand_dims(width, axis=-1)
+            height = tf.expand_dims(height, axis=-1)
+            width = tf.expand_dims(width, axis=-1)
     else:
         height, width = image_shape[0], image_shape[1]
     return tf.cast(height, boxes.dtype), tf.cast(width, boxes.dtype)


### PR DESCRIPTION
# What does this PR do?

Fixes #1572 

This PR fixes the bug in unit tests as well as `_image_shape` in converters.

A new unit test called `test_dense_bounding_box_with_ragged_images` has been added to validate inputs with ragged images and dense bounding_boxes, which were causing error as mentioned in https://github.com/keras-team/keras-cv/pull/1537#issuecomment-1479032369

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 
