### PR TITLE
Trivial fix to WaymoEvaluationCallback tests.

### DIFF
--- a/keras_cv/callbacks/waymo_evaluation_callback_test.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback_test.py
@@ -86,7 +86,7 @@ class WaymoEvaluationCallbackTest(tf.test.TestCase):
             lambda x: {
                 "3d_boxes": {
                     "boxes": x[:, :, :7],
-                    "classes": tf.cast(x[:, :, 7], tf.uint8),
+                    "classes": tf.cast(tf.abs(x[:, :, 7]), tf.uint8),
                     "confidence": x[:, :, 8],
                 }
             }


### PR DESCRIPTION
When running this test against TF compiled with strict type checking, it fails due to casting a negative number to an unsigned int.

This change resolves that issue.