### PR TITLE
Explicitly serialize backbone in RetinaNet

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -514,11 +514,21 @@ class RetinaNet(keras.Model):
                 metrics[metric.name] = result
         return metrics
 
+    @classmethod
+    def from_config(cls, config):
+        config["backbone"] = keras.utils.deserialize_keras_object(
+            config["backbone"]
+        )
+        return super().from_config(config)
+
     def get_config(self):
         return {
             "num_classes": self.num_classes,
             "bounding_box_format": self.bounding_box_format,
-            "backbone": self.backbone,
+            "backbone": keras.utils.serialize_keras_object(self.backbone),
+            # TODO(haifengj): handle custom anchor_generator. we now rely on
+            # label_encoder and prediction_decoder to reconstruct
+            # anchor_gnerator.
             "label_encoder": self.label_encoder,
             "prediction_decoder": self._prediction_decoder,
             "classification_head": self.classification_head,

--- a/keras_cv/models/object_detection/retina_net/retina_net_test.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_test.py
@@ -210,6 +210,8 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net.evaluate(dataset)
 
     def test_serialization(self):
+        # TODO(haifengj): Reuse test code from
+        # ModelTest._test_model_serialization.
         model = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",


### PR DESCRIPTION
This is to address the future serialization & deserialization mechanism changes in TF 2.13.
It would no longer implicitly serialize & deserialize any attribute of the object (e.g. self.backbone).
So we do it explicitly.