### PR TITLE
Fix CI -- broken due to GitHub actions outage today

### DIFF
--- a/keras_cv/models/segmentation/deeplab_test.py
+++ b/keras_cv/models/segmentation/deeplab_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 import tensorflow as tf
 import tensorflow_datasets as tfds


### PR DESCRIPTION
I merged #1611 because I saw that CI was green, but because of the GitHub actions outage, the linter never ran, and that PR broke our CI.

This is a fix-forward.