### PR TITLE
Rewrite benchmark test for backbones

### DIFF
--- a/keras_cv/benchmarks/classification_training_benchmark_test.py
+++ b/keras_cv/benchmarks/classification_training_benchmark_test.py
@@ -20,6 +20,7 @@ import tensorflow_datasets as tfds
 from tensorflow import keras
 
 from keras_cv import models
+from keras_cv.models.classification import image_classifier
 
 # isort: off
 from tensorflow.python.platform.benchmark import (
@@ -33,19 +34,22 @@ class ClassificationTrainingBenchmark(
     """Benchmarks for classification models using `tf.test.Benchmark`."""
 
     _benchmark_parameters = [
-        # TODO(jbischof): revert to ResNetV2 once classification head ready
-        ("DenseNet121", models.DenseNet121),
+        ("ResNet18V2Backbone", models.ResNet18V2Backbone),
     ]
 
     def __init__(self):
         super().__init__()
         self.num_classes = 10
         self.batch_size = 64
+        # x shape is (batch_size, 56, 56, 3)
+        # y shape is (batch_size, 10)
         self.dataset = (
             tfds.load("mnist", split="test")
             .map(
                 lambda x: (
-                    tf.image.resize(x["image"], (56, 56)),
+                    tf.image.grayscale_to_rgb(
+                        tf.image.resize(x["image"], (56, 56))
+                    ),
                     tf.one_hot(x["label"], self.num_classes),
                 ),
                 num_parallel_calls=tf.data.AUTOTUNE,
@@ -64,11 +68,9 @@ class ClassificationTrainingBenchmark(
         with strategy.scope():
             t0 = time.time()
 
-            model = app(
-                include_top=True,
+            model = image_classifier.ImageClassifier(
+                backbone=app(),
                 num_classes=self.num_classes,
-                input_shape=(56, 56, 1),
-                include_rescaling=True,
             )
             model.compile(
                 optimizer=keras.optimizers.SGD(learning_rate=0.1, momentum=0.9),


### PR DESCRIPTION
This is to address [this comment](https://github.com/keras-team/keras-cv/pull/1508/files#r1151189880).
To keep the corresponding PR (#1508) clean since it is an example PR, we will do the rewrite of the test in this separate PR and add the ResNet V1 into the test in that PR (#1508).