### PR TITLE
Disable currently failing XLAMlirBridge test for MultiClassNMS

### DIFF
--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -47,21 +47,3 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["boxes"].shape, [8, 100, 4])
         self.assertEqual(result["classes"].shape, [8, 100])
         self.assertEqual(result["confidence"].shape, [8, 100])
-
-
-# class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
-#     def setUp(self):
-#         tf.config.experimental.enable_mlir_bridge()
-
-#     def tearDown(self):
-#         tf.config.experimental.disable_mlir_bridge()
-
-#     # @unittest.expectedFailure
-#     def test_decode_predictions_output_shapes(self):
-#         xla_function = tf.function(
-#             decode_predictions_output_shapes, jit_compile=True
-#         )
-#         result = xla_function()
-#         self.assertEqual(result["boxes"].shape, [8, 100, 4])
-#         self.assertEqual(result["classes"].shape, [8, 100])
-#         self.assertEqual(result["confidence"].shape, [8, 100])

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -49,19 +49,19 @@ class NmsPredictionDecoderTest(tf.test.TestCase):
         self.assertEqual(result["confidence"].shape, [8, 100])
 
 
-class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
-    def setUp(self):
-        tf.config.experimental.enable_mlir_bridge()
+# class NmsPredictionDecoderTestWithXLAMlirBridge(tf.test.TestCase):
+#     def setUp(self):
+#         tf.config.experimental.enable_mlir_bridge()
 
-    def tearDown(self):
-        tf.config.experimental.disable_mlir_bridge()
+#     def tearDown(self):
+#         tf.config.experimental.disable_mlir_bridge()
 
-    # @unittest.expectedFailure
-    def test_decode_predictions_output_shapes(self):
-        xla_function = tf.function(
-            decode_predictions_output_shapes, jit_compile=True
-        )
-        result = xla_function()
-        self.assertEqual(result["boxes"].shape, [8, 100, 4])
-        self.assertEqual(result["classes"].shape, [8, 100])
-        self.assertEqual(result["confidence"].shape, [8, 100])
+#     # @unittest.expectedFailure
+#     def test_decode_predictions_output_shapes(self):
+#         xla_function = tf.function(
+#             decode_predictions_output_shapes, jit_compile=True
+#         )
+#         result = xla_function()
+#         self.assertEqual(result["boxes"].shape, [8, 100, 4])
+#         self.assertEqual(result["classes"].shape, [8, 100])
+#         self.assertEqual(result["confidence"].shape, [8, 100])


### PR DESCRIPTION
Context from an internal message:

> I prevent constant folding to stateless RNGs like StatelessRandomGetKeyCounter op because those ops are device dependent, so they shouldn't be constant folded (we are doing the wrong thing before). While for this test, because this op now is not constant folded, when we do legalization in MLIR bridge, tf.CombinedNonMaxSuppression will be kept (previously, this op will be removed due to constant folding). tf.CombinedNonMaxSuppression is not supported to be legalized in mlir bridge today. That's why the test fails.
