### PR TITLE
Fix typo in CenterPillar loss dict keys

### DIFF
--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -226,8 +226,8 @@ class MultiHeadCenterPillar(keras.Model):
             # box_regression_mask = heatmap_groundtruth_gather >= 0.95
             box = tf.gather_nd(box, index, batch_dims=1)
             box_pred = tf.gather_nd(box_pred, index, batch_dims=1)
-            y_pred["bin_" + head_name] = tf.squeeze(box_pred)
-            y_true["bin_" + head_name] = tf.squeeze(box)
+            y_pred["box_" + head_name] = tf.squeeze(box_pred)
+            y_true["box_" + head_name] = tf.squeeze(box)
 
         return super().compute_loss(
             x={}, y=y_true, y_pred=y_pred, sample_weight=sample_weight


### PR DESCRIPTION
This doesn't have proper test coverage yet because I don't have an e2e integration test, but the tl;dr is that when you start trying to use a `box_loss` with this model, it breaks because the outputs passed to `compute_loss` aren't named correctly.