### PR TITLE
Make the Waymo metrics callback cast class preds to uint8

### DIFF
--- a/keras_cv/callbacks/waymo_evaluation_callback.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback.py
@@ -128,8 +128,9 @@ class WaymoEvaluationCallback(Callback):
         predicted_boxes = tf.reshape(
             model_outputs["boxes"], (total_predicted_boxes, 7)
         )
-        predicted_classes = tf.reshape(
-            model_outputs["classes"], (total_predicted_boxes, 1)
+        predicted_classes = tf.cast(
+            tf.reshape(model_outputs["classes"], (total_predicted_boxes, 1)),
+            tf.uint8,
         )
         prediction_scores = tf.reshape(
             model_outputs["confidence"], (total_predicted_boxes, 1)

--- a/keras_cv/callbacks/waymo_evaluation_callback_test.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback_test.py
@@ -86,7 +86,7 @@ class WaymoEvaluationCallbackTest(tf.test.TestCase):
             lambda x: {
                 "3d_boxes": {
                     "boxes": x[:, :, :7],
-                    "classes": tf.cast(tf.abs(x[:, :, 7]), tf.uint8),
+                    "classes": tf.abs(x[:, :, 7]),
                     "confidence": x[:, :, 8],
                 }
             }


### PR DESCRIPTION
Also updates test to skip the casting in the model, to meaningfully enforce that the callback itself does the casting.