### PR TITLE
Bump TF version in GCB image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VERSION": "2.11.0"
+			"VERSION": "2.12.0"
 			// Uncomment this if GPU support is required
-			// "VERSION": "2.11.0-gpu",
+			// "VERSION": "2.12.0-gpu",
 		}
 	},
 	"customizations": {

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,10 +14,10 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow-cpu==2.11.0
+        pip install tensorflow-cpu==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Build custom ops for tests
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,19 @@ jobs:
         # https://github.com/bazelbuild/bazel/issues/14232#issuecomment-1011247429
         os: ['macos-12', 'windows-2019', 'ubuntu-18.04']
         py-version: ['3.7', '3.8', '3.9', '3.10']
-        tf-version: ['2.11.0']
+        tf-version: ['2.12.0']
         use-macos-arm: [false]
         include:
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.12.0'
             py-version: '3.8'
             use-macos-arm: true
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.12.0'
             py-version: '3.9'
             use-macos-arm: true
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.12.0'
             py-version: '3.10'
             use-macos-arm: true
       fail-fast: false
@@ -99,7 +99,7 @@ jobs:
         python-version: 3.7
     - name: Build wheels
       run: |
-        pip install tensorflow==2.11.0
+        pip install tensorflow==2.12.0
         python -m pip install --upgrade pip setuptools wheel twine
         export BUILD_WITH_CUSTOM_OPS=false
         python setup.py sdist bdist_wheel

--- a/cloudbuild/README.md
+++ b/cloudbuild/README.md
@@ -30,7 +30,7 @@ To add a dependency for GPU tests:
 - Have a Keras team member update the Docker image for GPU tests by running the remaining steps
 - Create a `Dockerfile` with the following contents:
 ```
-FROM tensorflow/tensorflow:2.11.0-gpu
+FROM tensorflow/tensorflow:2.12.0-gpu
 RUN \
     apt-get -y update && \
     apt-get -y install openjdk-8-jdk && \

--- a/keras_cv/utils/resource_loader.py
+++ b/keras_cv/utils/resource_loader.py
@@ -22,7 +22,7 @@ import warnings
 
 import tensorflow as tf
 
-TF_VERSION_FOR_ABI_COMPATIBILITY = "2.11"
+TF_VERSION_FOR_ABI_COMPATIBILITY = "2.12"
 abi_warning_already_raised = False
 
 


### PR DESCRIPTION
Justification: Seeing some extremely strange behavior in our GCBRun environment with the `keras.Model` class.

See failures in https://github.com/keras-team/keras-cv/pull/1618