### PR TITLE
fix a minor spelling error in RandomAugmentationPipeline layer API reference

### DIFF
--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -59,7 +59,7 @@ class RandomAugmentationPipeline(BaseImageAugmentationLayer):
             `call()` method.
         rate: the rate at which to apply each augmentation.  This is applied on a per
             augmentation bases, so if `augmentations_per_image=3` and `rate=0.5`, the
-            odds an image will receive no augmentations is 0.5^3, or 0.5*0.5*0.5.
+            odds an image will receive no augmentations is 0.5^3, or 0.5 * 0.5 * 0.5.
         auto_vectorize: whether to use `tf.vectorized_map` or `tf.map_fn` to
             apply the augmentations.  This offers a significant performance boost, but
             can only be used if all the layers provided to the `layers` argument


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

See my issue #1589 raised before. I will close my issue and this PR if it is not necessary to change!


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- 
Feel free to tag @LukeWood and @tanzhenyu in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
