### PR TITLE
Remove training argument in 2D KPLs

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -383,25 +383,20 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         """
         return None
 
-    def call(self, inputs, training=True):
+    def call(self, inputs):
         inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        if training:
-            inputs, metadata = self._format_inputs(inputs)
-            images = inputs[IMAGES]
-            if images.shape.rank == 3:
-                return self._format_output(self._augment(inputs), metadata)
-            elif images.shape.rank == 4:
-                return self._format_output(
-                    self._batch_augment(inputs), metadata
-                )
-            else:
-                raise ValueError(
-                    "Image augmentation layers are expecting inputs to be "
-                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                    f"{images.shape}"
-                )
+        inputs, metadata = self._format_inputs(inputs)
+        images = inputs[IMAGES]
+        if images.shape.rank == 3:
+            return self._format_output(self._augment(inputs), metadata)
+        elif images.shape.rank == 4:
+            return self._format_output(self._batch_augment(inputs), metadata)
         else:
-            return inputs
+            raise ValueError(
+                "Image augmentation layers are expecting inputs to be "
+                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                f"{images.shape}"
+            )
 
     def _augment(self, inputs):
         raw_image = inputs.get(IMAGES, None)

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -269,18 +269,6 @@ class Mosaic(VectorizedBaseImageAugmentationLayer):
         self._validate_inputs(inputs)
         return super()._batch_augment(inputs)
 
-    def call(self, inputs, training=True):
-        if training is True:
-            _, metadata = self._format_inputs(inputs)
-            if metadata[BATCHED] is not True:
-                raise ValueError(
-                    "Mosaic received a single image to `call`. The "
-                    "layer relies on combining multiple examples, and as such "
-                    "will not behave as expected. Please call the layer with 4 "
-                    "or more samples."
-                )
-        return super().call(inputs=inputs, training=training)
-
     def _validate_inputs(self, inputs):
         images = inputs.get(IMAGES, None)
         labels = inputs.get(LABELS, None)

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -17,6 +17,9 @@ from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
+    BATCHED,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
     BOUNDING_BOXES,
 )
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
@@ -265,6 +268,17 @@ class Mosaic(VectorizedBaseImageAugmentationLayer):
     def _batch_augment(self, inputs):
         self._validate_inputs(inputs)
         return super()._batch_augment(inputs)
+
+    def call(self, inputs):
+        _, metadata = self._format_inputs(inputs)
+        if metadata[BATCHED] is not True:
+            raise ValueError(
+                "Mosaic received a single image to `call`. The "
+                "layer relies on combining multiple examples, and as such "
+                "will not behave as expected. Please call the layer with 4 "
+                "or more samples."
+            )
+        return super().call(inputs=inputs)
 
     def _validate_inputs(self, inputs):
         images = inputs.get(IMAGES, None)

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -17,9 +17,6 @@ from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
-    BATCHED,
-)
-from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
     BOUNDING_BOXES,
 )
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -95,3 +95,11 @@ class MosaicTest(tf.test.TestCase):
             ValueError, "Mosaic received labels with type"
         ):
             _ = layer(inputs)
+
+    def test_image_input(self):
+        xs = tf.ones((2, 512, 512, 3))
+        layer = Mosaic()
+        with self.assertRaisesRegexp(
+            ValueError, "Mosaic expects inputs in a dictionary with format"
+        ):
+            _ = layer(xs)

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,6 +85,16 @@ class MosaicTest(tf.test.TestCase):
             ValueError, "expects inputs in a dictionary"
         ):
             _ = layer(xs)
+
+    def test_single_image_input(self):
+        xs = tf.ones((512, 512, 3))
+        ys = tf.one_hot(tf.constant([1]), 2)
+        inputs = {"images": xs, "labels": ys}
+        layer = Mosaic()
+        with self.assertRaisesRegexp(
+            ValueError, "Mosaic received a single image to `call`"
+        ):
+            _ = layer(inputs)
 
     def test_int_labels(self):
         xs = tf.ones((2, 512, 512, 3))

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -86,16 +86,6 @@ class MosaicTest(tf.test.TestCase):
         ):
             _ = layer(xs)
 
-    def test_single_image_input(self):
-        xs = tf.ones((512, 512, 3))
-        ys = tf.one_hot(tf.constant([1]), 2)
-        inputs = {"images": xs, "labels": ys}
-        layer = Mosaic()
-        with self.assertRaisesRegexp(
-            ValueError, "Mosaic received a single image to `call`"
-        ):
-            _ = layer(inputs)
-
     def test_int_labels(self):
         xs = tf.ones((2, 512, 512, 3))
         ys = tf.one_hot(tf.constant([1, 0]), 2, dtype=tf.int32)
@@ -105,11 +95,3 @@ class MosaicTest(tf.test.TestCase):
             ValueError, "Mosaic received labels with type"
         ):
             _ = layer(inputs)
-
-    def test_image_input(self):
-        xs = tf.ones((2, 512, 512, 3))
-        layer = Mosaic()
-        with self.assertRaisesRegexp(
-            ValueError, "Mosaic expects inputs in a dictionary with format"
-        ):
-            _ = layer(xs)

--- a/keras_cv/layers/preprocessing/random_aspect_ratio_test.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio_test.py
@@ -27,15 +27,6 @@ class RandomAspectRatioTest(tf.test.TestCase):
         output = layer(image, training=True)
         self.assertNotEqual(output.shape, image.shape)
 
-    def test_inference_preserves_image(self):
-        # Checks if original and augmented images are different
-        input_image_shape = (8, 100, 100, 3)
-        image = tf.random.uniform(shape=input_image_shape)
-
-        layer = layers.RandomAspectRatio(factor=(0.9, 1.1))
-        output = layer(image, training=False)
-        self.assertAllClose(image, output)
-
     def test_grayscale(self):
         # Checks if original and augmented images are different
         input_image_shape = (8, 100, 100, 1)

--- a/keras_cv/layers/preprocessing/random_channel_shift_test.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift_test.py
@@ -115,11 +115,3 @@ class RandomChannelShiftTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(reconstructed_layer.value_range, layer.value_range)
         self.assertEqual(reconstructed_layer.seed, layer.seed)
         self.assertEqual(reconstructed_layer.channels, layer.channels)
-
-    def test_inference(self):
-        layer = preprocessing.RandomChannelShift(
-            factor=0.8, value_range=(0, 255)
-        )
-        inputs = np.random.randint(0, 255, size=(224, 224, 3))
-        output = layer(inputs, training=False)
-        self.assertAllClose(inputs, output)

--- a/keras_cv/layers/preprocessing/random_channel_shift_test.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/random_color_jitter_test.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter_test.py
@@ -104,16 +104,3 @@ class RandomColorJitterTest(tf.test.TestCase, parameterized.TestCase):
             reconstructed_layer.saturation_factor, layer.saturation_factor
         )
         self.assertEqual(reconstructed_layer.hue_factor, layer.hue_factor)
-
-    # Test 5: Check if inference model is OK.
-    def test_inference(self):
-        layer = preprocessing.RandomColorJitter(
-            value_range=(0, 255),
-            brightness_factor=0.5,
-            contrast_factor=(0.5, 0.9),
-            saturation_factor=(0.5, 0.9),
-            hue_factor=0.5,
-        )
-        inputs = np.random.randint(0, 255, size=(224, 224, 3))
-        output = layer(inputs, training=False)
-        self.assertAllClose(inputs, output)

--- a/keras_cv/layers/preprocessing/random_color_jitter_test.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -128,24 +128,6 @@ class RandomCropAndResize(BaseImageAugmentationLayer):
 
         return [[y1, x1, y2, x2]]
 
-    def call(self, inputs, training=True):
-        if training:
-            return super().call(inputs, training)
-        else:
-            inputs = self._ensure_inputs_are_compute_dtype(inputs)
-            inputs, meta_data = self._format_inputs(inputs)
-            output = inputs
-            # self._resize() returns valid results for both batched and
-            # unbatched
-            output["images"] = self._resize(inputs["images"])
-
-            if "segmentation_masks" in inputs:
-                output["segmentation_masks"] = self._resize(
-                    inputs["segmentation_masks"], interpolation="nearest"
-                )
-
-            return self._format_output(output, meta_data)
-
     def compute_image_signature(self, images):
         return tf.TensorSpec(
             shape=(self.target_size[0], self.target_size[1], images.shape[-1]),

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -59,21 +59,6 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(output.shape, (4, 224, 224, 1))
         self.assertNotAllClose(output, input_image_resized)
 
-    def test_preserves_image(self):
-        image_shape = (self.batch_size, self.height, self.width, 3)
-        image = tf.random.uniform(shape=image_shape)
-
-        layer = preprocessing.RandomCropAndResize(
-            target_size=self.target_size,
-            aspect_ratio_factor=(3 / 4, 4 / 3),
-            crop_area_factor=(0.8, 1.0),
-        )
-
-        input_resized = tf.image.resize(image, self.target_size)
-        output = layer(image, training=False)
-
-        self.assertAllClose(output, input_resized)
-
     @parameterized.named_parameters(
         ("Not tuple or list", dict()),
         ("Length not equal to 2", [1, 2, 3]),

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -77,13 +77,6 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
             actual_output = layer(inp, training=True)
             self.assertAllClose(expected_output, actual_output)
 
-    def test_random_flip_inference(self):
-        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
-        expected_output = input_images
-        layer = RandomFlip()
-        actual_output = layer(input_images, training=False)
-        self.assertAllClose(expected_output, actual_output)
-
     def test_random_flip_default(self):
         input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
         expected_output = np.flip(input_images, axis=2)

--- a/keras_cv/layers/preprocessing/random_rotation_test.py
+++ b/keras_cv/layers/preprocessing/random_rotation_test.py
@@ -26,13 +26,6 @@ class RandomRotationTest(tf.test.TestCase):
         actual_output = layer(input_images, training=True)
         self.assertEqual(expected_output.shape, actual_output.shape)
 
-    def test_random_rotation_inference(self):
-        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
-        expected_output = input_images
-        layer = RandomRotation(0.5)
-        actual_output = layer(input_images, training=False)
-        self.assertAllClose(expected_output, actual_output)
-
     def test_random_rotation_on_batched_images_independently(self):
         image = tf.random.uniform((100, 100, 3))
         batched_images = tf.stack((image, image), axis=0)

--- a/keras_cv/layers/preprocessing/random_translation_test.py
+++ b/keras_cv/layers/preprocessing/random_translation_test.py
@@ -185,13 +185,6 @@ class RandomTranslationTest(tf.test.TestCase, parameterized.TestCase):
             expected_output = np.reshape(expected_output, (1, 5, 5, 1))
             self.assertAllEqual(expected_output, output_image)
 
-    def test_random_translation_inference(self):
-        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
-        expected_output = input_images
-        layer = preprocessing.RandomTranslation(0.5, 0.5)
-        actual_output = layer(input_images, training=False)
-        self.assertAllClose(expected_output, actual_output)
-
     def test_random_translation_on_batched_images_independently(self):
         image = tf.random.uniform(shape=(100, 100, 3))
         input_images = tf.stack([image, image], axis=0)

--- a/keras_cv/layers/preprocessing/random_zoom_test.py
+++ b/keras_cv/layers/preprocessing/random_zoom_test.py
@@ -109,13 +109,6 @@ class RandomZoomTest(tf.test.TestCase, parameterized.TestCase):
             expected_output = np.reshape(expected_output, (1, 5, 5, 1))
             self.assertAllEqual(expected_output, output_image)
 
-    def test_random_zoom_inference(self):
-        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
-        expected_output = input_images
-        layer = RandomZoom(0.5, 0.5)
-        actual_output = layer(input_images, training=False)
-        self.assertAllClose(expected_output, actual_output)
-
     def test_random_zoom_on_batched_images_independently(self):
         image = tf.random.uniform(shape=(100, 100, 3))
         input_images = tf.stack([image, image], axis=0)

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
@@ -18,9 +18,6 @@ from tensorflow import keras
 
 from keras_cv import core
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
-    IMAGES,
-)
-from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing as preprocessing_utils

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop.py
@@ -259,19 +259,6 @@ class RandomlyZoomedCrop(VectorizedBaseImageAugmentationLayer):
                 axis=1,
             )
 
-    def call(self, inputs, training=True):
-        if training:
-            return super().call(inputs, training)
-        else:
-            inputs = self._ensure_inputs_are_compute_dtype(inputs)
-            inputs, meta_data = self._format_inputs(inputs)
-            output = inputs
-            # self._resize() returns valid results for both batched and
-            # unbatched
-            output[IMAGES] = self._resize(inputs[IMAGES])
-
-            return self._format_output(output, meta_data)
-
     def _resize(self, images, **kwargs):
         resizing_layer = keras.layers.Resizing(
             self.height, self.width, **kwargs

--- a/keras_cv/layers/preprocessing/randomly_zoomed_crop_test.py
+++ b/keras_cv/layers/preprocessing/randomly_zoomed_crop_test.py
@@ -61,22 +61,6 @@ class RandomlyZoomedCropTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(output.shape, (4, 224, 224, 1))
         self.assertNotAllClose(output, input_image_resized)
 
-    def test_preserves_image(self):
-        image_shape = (self.batch_size, self.height, self.width, 3)
-        image = tf.random.uniform(shape=image_shape)
-
-        layer = preprocessing.RandomlyZoomedCrop(
-            height=self.target_size[0],
-            width=self.target_size[1],
-            aspect_ratio_factor=(3 / 4, 4 / 3),
-            zoom_factor=(0.8, 1.0),
-        )
-
-        input_resized = tf.image.resize(image, self.target_size)
-        output = layer(image, training=False)
-
-        self.assertAllClose(output, input_resized)
-
     @parameterized.named_parameters(
         ("Not tuple or list", dict()),
         ("Length not equal to 2", [1, 2, 3]),

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -273,22 +273,6 @@ class Resizing(BaseImageAugmentationLayer):
         inputs["images"] = images
         return inputs
 
-    def call(self, inputs, training=True):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        self._check_inputs(inputs)
-        images = inputs["images"]
-        if images.shape.rank == 3:
-            return self._format_output(self._augment(inputs), metadata)
-        elif images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
-
     def _check_inputs(self, inputs):
         for key in inputs:
             if key not in supported_keys:

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -176,17 +176,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         self.assertNotIsInstance(outputs, tf.RaggedTensor)
         self.assertAllEqual(expected_output, outputs)
 
-    def test_raises_with_segmap(self):
-        inputs = {
-            "images": np.array([[[1], [2]], [[3], [4]]], dtype="float64"),
-            "segmentation_map": np.array(
-                [[[1], [2]], [[3], [4]]], dtype="float64"
-            ),
-        }
-        layer = cv_layers.Resizing(2, 2)
-        with self.assertRaises(ValueError):
-            layer(inputs)
-
     def test_output_dtypes(self):
         inputs = np.array([[[1], [2]], [[3], [4]]], dtype="float64")
         layer = cv_layers.Resizing(2, 2)

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -348,24 +348,18 @@ class VectorizedBaseImageAugmentationLayer(
             result[key] = inputs[key]
         return result
 
-    def call(self, inputs, training=True):
-        # TODO(lukewood): remove training=False behavior.
+    def call(self, inputs):
         inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        if training:
-            inputs, metadata = self._format_inputs(inputs)
-            images = inputs[IMAGES]
-            if images.shape.rank == 3 or images.shape.rank == 4:
-                return self._format_output(
-                    self._batch_augment(inputs), metadata
-                )
-            else:
-                raise ValueError(
-                    "Image augmentation layers are expecting inputs to be "
-                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                    f"{images.shape}"
-                )
+        inputs, metadata = self._format_inputs(inputs)
+        images = inputs[IMAGES]
+        if images.shape.rank == 3 or images.shape.rank == 4:
+            return self._format_output(self._batch_augment(inputs), metadata)
         else:
-            return inputs
+            raise ValueError(
+                "Image augmentation layers are expecting inputs to be "
+                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                f"{images.shape}"
+            )
 
     def _format_inputs(self, inputs):
         metadata = {IS_DICT: True, USE_TARGETS: False}


### PR DESCRIPTION
# What does this PR do?

Fixes #1659 

This PR removes `training` argument in 2D preprocessing layers and removes unnecessary unit tests for inference mode.

This PR will be ready after #1672 #1673 and #1674 have been completed.

The only `call` functions are in the `BaseImageAugmentationLayer` and `VectorizedBaseImageAugmentationLayer` classes.

```python
    # BaseImageAugmentationLayer
    def call(self, inputs):
        inputs = self._ensure_inputs_are_compute_dtype(inputs)
        inputs, metadata = self._format_inputs(inputs)
        images = inputs[IMAGES]
        if images.shape.rank == 3:
            return self._format_output(self._augment(inputs), metadata)
        elif images.shape.rank == 4:
            return self._format_output(self._batch_augment(inputs), metadata)
        else:
            raise ValueError(
                "Image augmentation layers are expecting inputs to be "
                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
                f"{images.shape}"
            )
```

```python
    # VectorizedBaseImageAugmentationLayer
    def call(self, inputs):
        inputs = self._ensure_inputs_are_compute_dtype(inputs)
        inputs, metadata = self._format_inputs(inputs)
        images = inputs[IMAGES]
        if images.shape.rank == 3 or images.shape.rank == 4:
            return self._format_output(self._batch_augment(inputs), metadata)
        else:
            raise ValueError(
                "Image augmentation layers are expecting inputs to be "
                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
                f"{images.shape}"
            )
```

There is one exception for Mosaic that requires checking whether the inputs are batched or not.

```python
    def call(self, inputs):
        _, metadata = self._format_inputs(inputs)
        if metadata[BATCHED] is not True:
            raise ValueError(
                "Mosaic received a single image to `call`. The "
                "layer relies on combining multiple examples, and as such "
                "will not behave as expected. Please call the layer with 4 "
                "or more samples."
            )
        return super().call(inputs=inputs)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @haifeng-jin @ianstenbit