### PR TITLE
Add clang-format for devcontainer

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,2 +1,4 @@
 sudo pip install --upgrade pip
 sudo pip install -e ".[tests]"
+sudo apt update
+sudo apt install -y clang-format


### PR DESCRIPTION
# What does this PR do?

To avoid missing error for clang-format when executing `./shell/format.sh`, this PR adds installation instructions for devcontainer.

## Who can review?
@LukeWood @ianstenbit @haifeng-jin 
