### PR TITLE
Add epsilon for NaN prevention + test case to RetinaNet

### DIFF
--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -416,7 +416,7 @@ class RetinaNet(Task):
         )
 
         positive_mask = tf.cast(tf.greater(classes, -1.0), dtype=tf.float32)
-        normalizer = tf.reduce_sum(positive_mask)
+        normalizer = tf.reduce_sum(positive_mask) + keras.backend.epsilon()
         cls_weights = tf.cast(
             tf.math.not_equal(classes, -2.0), dtype=tf.float32
         )

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -416,7 +416,7 @@ class RetinaNet(Task):
         )
 
         positive_mask = tf.cast(tf.greater(classes, -1.0), dtype=tf.float32)
-        normalizer = tf.reduce_sum(positive_mask) + keras.backend.epsilon()
+        normalizer = tf.reduce_sum(positive_mask)
         cls_weights = tf.cast(
             tf.math.not_equal(classes, -2.0), dtype=tf.float32
         )
@@ -434,6 +434,16 @@ class RetinaNet(Task):
             "box": box_weights,
             "classification": cls_weights,
         }
+        zero_weight = {
+            "box": tf.zeros_like(box_weights),
+            "classification": tf.zeros_like(cls_weights),
+        }
+
+        sample_weights = tf.cond(
+            normalizer == 0,
+            lambda: zero_weight,
+            lambda: sample_weights,
+        )
         return super().compute_loss(
             x=x, y=y_true, y_pred=y_pred, sample_weight=sample_weights
         )

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -146,10 +146,18 @@ class RetinaNetTest(tf.test.TestCase):
             classification_loss="focal",
             box_loss="smoothl1",
         )
-        xs, ys = _create_bounding_box_dataset(bounding_box_format)
-        ys = {"classes": tf.constant([]), "boxes": tf.constant([[]])}
-        # call once
-        retina_net.fit(xs, ys, epochs=1)
+
+        # only a -1 box
+        xs = tf.ones((1, 512, 512, 3), tf.float32)
+        ys = {
+            "classes": tf.constant([[-1]], tf.float32),
+            "boxes": tf.constant([[[0, 0, 0, 0]]], tf.float32),
+        }
+        ds = tf.data.Dataset.from_tensor_slices((xs, ys))
+        ds = ds.repeat(2)
+        ds = ds.ragged_batch(2)
+        retina_net.fit(ds, epochs=1)
+
         weights = retina_net.get_weights()
         for weight in weights:
             self.assertFalse(tf.math.reduce_any(tf.math.is_nan(weight)))

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -155,7 +155,7 @@ class RetinaNetTest(tf.test.TestCase):
         }
         ds = tf.data.Dataset.from_tensor_slices((xs, ys))
         ds = ds.repeat(2)
-        ds = ds.ragged_batch(2)
+        ds = ds.batch(2)
         retina_net.fit(ds, epochs=1)
 
         weights = retina_net.get_weights()


### PR DESCRIPTION
fixes https://github.com/keras-team/keras-cv/issues/1683

I actually took a `tf.cond()` based approach here to zero out sample weights instead.  I do this because I found that when we divide by normalizer, and normalizer is zero, the background classes all get absolutely massive values for class weight - causing massive gradients.

An alternative is perhaps to use a small value, i.e. 0.3~ for the class weights?  I think the ideal mask is something like: `tf.where(positive_mask, 0.1, 0.0)` where 0.1 is any tiny value.   Though, using all zeros is probably safer and easier.