### PR TITLE
Fix docstrings to reflect the removal of `training` argument in 2D KPLs

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -77,9 +77,8 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
 
     The output of the `call()` will be the same structure as the inputs.
 
-    The `call()` will handle the logic detecting the training/inference mode,
-    unpack the inputs, forward to the correct function, and pack the output back
-    to the same structure as the inputs.
+    The `call()` will unpack the inputs, forward to the correct function, and
+    pack the output back to the same structure as the inputs.
 
     By default the `call()` method leverages the `tf.vectorized_map()` function.
     Auto-vectorization can be disabled by setting `self.auto_vectorize = False`

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -23,15 +23,13 @@ from keras_cv.utils import preprocessing as preprocessing_utils
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomBrightness(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly adjusts brightness during training.
+    """A preprocessing layer which randomly adjusts brightness.
+
     This layer will randomly increase/reduce the brightness for the input RGB
     images.
 
-    At inference time, the output will be identical to the input.
-    Call the layer with `training=True` to adjust the brightness of the input.
-
-    Note that different brightness adjustment factors
-    will be apply to each the images in the batch.
+    Note that different brightness adjustment factors will be apply to each the
+    images in the batch.
 
     Args:
       factor: Float or a list/tuple of 2 floats between -1.0 and 1.0. The

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -23,11 +23,11 @@ from keras_cv.utils import preprocessing as preprocessing_utils
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomContrast(VectorizedBaseImageAugmentationLayer):
-    """RandomContrast randomly adjusts contrast during training.
+    """RandomContrast randomly adjusts contrast.
 
     This layer will randomly adjust the contrast of an image or images by a
     random factor. Contrast is adjusted independently for each channel of each
-    image during training.
+    image.
 
     For each channel, this layer computes the mean of the image pixels in the
     channel and then adjusts each component `x` of each pixel to

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -29,16 +29,14 @@ W_AXIS = -2
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomCrop(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly crops images during training.
+    """A preprocessing layer which randomly crops images.
 
-    During training, this layer will randomly choose a location to crop images
-    down to a target size.
+    This layer will randomly choose a location to crop images down to a target
+    size.
 
-    During inference, and during training if an input image is smaller than the
-    target size, the input will be resized and cropped to return the largest
-    possible window in the image that matches the target aspect ratio. If you
-    want to apply random cropping during inference, you can set the training
-    parameter to True when calling the layer.
+    If an input image is smaller than the target size, the input will be
+    resized and cropped to return the largest possible window in the image that
+    matches the target aspect ratio.
 
     Input pixel values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and
     of interger or floating point dtype.

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -33,11 +33,10 @@ HORIZONTAL_AND_VERTICAL = "horizontal_and_vertical"
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomFlip(BaseImageAugmentationLayer):
-    """A preprocessing layer which randomly flips images during training.
+    """A preprocessing layer which randomly flips images.
 
     This layer will flip the images horizontally and or vertically based on the
-    `mode` attribute. During inference time, the output will be identical to
-    input. Call the layer with `training=True` to flip the input.
+    `mode` attribute.
 
     Input shape:
       3D (unbatched) or 4D (batched) tensor with shape:

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -26,8 +26,7 @@ class RandomHue(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the hue on given images.
 
     This layer will randomly increase/reduce the hue for the input RGB
-    images. At inference time, the output will be identical to the input.
-    Call the layer with `training=True` to adjust the brightness of the input.
+    images.
 
     The image hue is adjusted by converting the image(s) to HSV and rotating the
     hue channel (H) by delta. The image is then converted back to RGB.

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -30,14 +30,10 @@ W_AXIS = -2
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomRotation(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly rotates images during training.
+    """A preprocessing layer which randomly rotates images.
 
     This layer will apply random rotations to each image, filling empty space
     according to `fill_mode`.
-
-    By default, random rotations are only applied during training.
-    At inference time, the layer does nothing. If you need to apply random
-    rotations at inference time, set `training` to True when calling the layer.
 
     Input pixel values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and
     of interger or floating point dtype. By default, the layer will output

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -26,8 +26,7 @@ class RandomSaturation(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the saturation on given images.
 
     This layer will randomly increase/reduce the saturation for the input RGB
-    images. At inference time, the output will be identical to the input.
-    Call the layer with `training=True` to adjust the saturation of the input.
+    images.
 
     Args:
         factor: A tuple of two floats, a single float or `keras_cv.FactorSampler`.

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -27,14 +27,13 @@ from keras_cv.utils import preprocessing
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomShear(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly shears images during training.
+    """A preprocessing layer which randomly shears images.
 
     This layer will apply random shearings to each image, filling empty space
     according to `fill_mode`.
-    By default, random shears are only applied during training.
-    At inference time, the layer does nothing. If you need to apply random
-    shear at inference time, set `training` to True when calling the layer.
+
     Input pixel values can be of any range and any data type.
+
     Input shape:
       3D (unbatched) or 4D (batched) tensor with shape:
       `(..., height, width, channels)`, in `"channels_last"` format

--- a/keras_cv/layers/preprocessing/random_translation.py
+++ b/keras_cv/layers/preprocessing/random_translation.py
@@ -27,10 +27,10 @@ W_AXIS = -2
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomTranslation(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly translates images during training.
+    """A preprocessing layer which randomly translates images.
 
-    This layer will apply random translations to each image during training,
-    filling empty space according to `fill_mode`.
+    This layer will apply random translations to each image, filling empty
+    space according to `fill_mode`.
 
     Input pixel values can be of any range (e.g. `[0., 1.)` or `[0, 255]`) and
     of integer or floating point dtype. By default, the layer will output

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -30,7 +30,7 @@ W_AXIS = -2
 
 @keras.utils.register_keras_serializable(package="keras_cv")
 class RandomZoom(VectorizedBaseImageAugmentationLayer):
-    """A preprocessing layer which randomly zooms images during training.
+    """A preprocessing layer which randomly zooms images.
 
     This layer will randomly zoom in or out on each axis of an image
     independently, filling empty space according to `fill_mode`.

--- a/keras_cv/layers/preprocessing/rescaling.py
+++ b/keras_cv/layers/preprocessing/rescaling.py
@@ -40,9 +40,8 @@ class Rescaling(BaseImageAugmentationLayer):
     2. To rescale an input in the ``[0, 255]`` range to be in the `[-1, 1]`
     range, you would pass `scale=1./127.5, offset=-1`.
 
-    The rescaling is applied both during training and inference. Inputs can be
-    of integer or floating point dtype, and by default the layer will output
-    floats.
+    Inputs can be of integer or floating point dtype, and by default the layer
+    will output floats.
 
     Input shape:
       Arbitrary.

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -70,9 +70,8 @@ class VectorizedBaseImageAugmentationLayer(
     The output of the `call()` will be in two formats, which will be the same
     structure as the inputs.
 
-    The `call()` will handle the logic detecting the training/inference mode,
-    unpack the inputs, forward to the correct function, and pack the output back
-    to the same structure as the inputs.
+    The `call()` will unpack the inputs, forward to the correct function, and
+    pack the output back to the same structure as the inputs.
 
     Note that since the randomness is also a common functionality, this layer
     also includes a keras.backend.RandomGenerator, which can be used to


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up to #1676 

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit