### PR TITLE
Updates weights for RetinaNet

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net_presets.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_presets.py
@@ -30,7 +30,7 @@ retina_net_presets = {
             # performance.
             "num_classes": 21,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50.weights.h5",  # noqa: E501
-        "weights_hash": "c9b11357b289512adf1e6077ab7da73f",
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50.h5",  # noqa: E501
+        "weights_hash": "2b081b41690fca8ea431b98aefa0f233",
     },
 }

--- a/keras_cv/models/object_detection/retina_net/retina_net_presets.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_presets.py
@@ -30,7 +30,7 @@ retina_net_presets = {
             # performance.
             "num_classes": 21,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50.h5",  # noqa: E501
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50-v2.h5",  # noqa: E501
         "weights_hash": "2b081b41690fca8ea431b98aefa0f233",
     },
 }


### PR DESCRIPTION
Much better scores- 0.36 MaP.

This was achieved by NOT freezing batchnorm, and using a slower LR schedule with more epochs.

From https://github.com/keras-team/keras-cv/pull/1691