### PR TITLE
Vectorize RandomFlip

### DIFF
--- a/benchmarks/vectorized_random_flip.py
+++ b/benchmarks/vectorized_random_flip.py
@@ -1,0 +1,384 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+import unittest
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+from keras_cv import bounding_box
+from keras_cv.layers import RandomFlip
+from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
+    BaseImageAugmentationLayer,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
+    BOUNDING_BOXES,
+)
+from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
+    IMAGES,
+)
+
+# In order to support both unbatched and batched inputs, the horizontal
+# and vertical axis is reverse indexed
+H_AXIS = -3
+W_AXIS = -2
+
+# Defining modes for random flipping
+HORIZONTAL = "horizontal"
+VERTICAL = "vertical"
+HORIZONTAL_AND_VERTICAL = "horizontal_and_vertical"
+
+
+class OldRandomFlip(BaseImageAugmentationLayer):
+    """A preprocessing layer which randomly flips images.
+
+    This layer will flip the images horizontally and or vertically based on the
+    `mode` attribute.
+
+    Input shape:
+      3D (unbatched) or 4D (batched) tensor with shape:
+      `(..., height, width, channels)`, in `"channels_last"` format.
+
+    Output shape:
+      3D (unbatched) or 4D (batched) tensor with shape:
+      `(..., height, width, channels)`, in `"channels_last"` format.
+
+    Arguments:
+      mode: String indicating which flip mode to use. Can be `"horizontal"`,
+        `"vertical"`, or `"horizontal_and_vertical"`, defaults to
+        `"horizontal"`. `"horizontal"` is a left-right flip and `"vertical"` is
+        a top-bottom flip.
+      seed: Integer. Used to create a random seed.
+      bounding_box_format: The format of bounding boxes of input dataset.
+        Refer to
+        https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/converters.py
+        for more details on supported bounding box formats.
+    """
+
+    def __init__(
+        self, mode=HORIZONTAL, seed=None, bounding_box_format=None, **kwargs
+    ):
+        super().__init__(seed=seed, force_generator=True, **kwargs)
+        self.mode = mode
+        self.seed = seed
+        if mode == HORIZONTAL:
+            self.horizontal = True
+            self.vertical = False
+        elif mode == VERTICAL:
+            self.horizontal = False
+            self.vertical = True
+        elif mode == HORIZONTAL_AND_VERTICAL:
+            self.horizontal = True
+            self.vertical = True
+        else:
+            raise ValueError(
+                "RandomFlip layer {name} received an unknown mode="
+                "{arg}".format(name=self.name, arg=mode)
+            )
+        self.auto_vectorize = True
+        self.bounding_box_format = bounding_box_format
+
+    def augment_label(self, label, transformation, **kwargs):
+        return label
+
+    def augment_image(self, image, transformation, **kwargs):
+        return OldRandomFlip._flip_image(image, transformation)
+
+    def get_random_transformation(self, **kwargs):
+        flip_horizontal = False
+        flip_vertical = False
+        if self.horizontal:
+            flip_horizontal = (
+                self._random_generator.random_uniform(shape=[]) > 0.5
+            )
+        if self.vertical:
+            flip_vertical = (
+                self._random_generator.random_uniform(shape=[]) > 0.5
+            )
+        return {
+            "flip_horizontal": tf.cast(flip_horizontal, dtype=tf.bool),
+            "flip_vertical": tf.cast(flip_vertical, dtype=tf.bool),
+        }
+
+    def _flip_image(image, transformation):
+        flipped_output = tf.cond(
+            transformation["flip_horizontal"],
+            lambda: tf.image.flip_left_right(image),
+            lambda: image,
+        )
+        flipped_output = tf.cond(
+            transformation["flip_vertical"],
+            lambda: tf.image.flip_up_down(flipped_output),
+            lambda: flipped_output,
+        )
+        flipped_output.set_shape(image.shape)
+        return flipped_output
+
+    def _flip_bounding_boxes_horizontal(bounding_boxes):
+        x1, x2, x3, x4 = tf.split(
+            bounding_boxes["boxes"], [1, 1, 1, 1], axis=-1
+        )
+        output = tf.stack(
+            [
+                1 - x3,
+                x2,
+                1 - x1,
+                x4,
+            ],
+            axis=-1,
+        )
+        bounding_boxes = bounding_boxes.copy()
+        bounding_boxes["boxes"] = tf.squeeze(output, axis=1)
+        return bounding_boxes
+
+    def _flip_bounding_boxes_vertical(bounding_boxes):
+        x1, x2, x3, x4 = tf.split(
+            bounding_boxes["boxes"], [1, 1, 1, 1], axis=-1
+        )
+        output = tf.stack(
+            [
+                x1,
+                1 - x4,
+                x3,
+                1 - x2,
+            ],
+            axis=-1,
+        )
+        output = tf.squeeze(output, axis=1)
+        bounding_boxes = bounding_boxes.copy()
+        bounding_boxes["boxes"] = output
+        return bounding_boxes
+
+    def augment_bounding_boxes(
+        self, bounding_boxes, transformation=None, image=None, **kwargs
+    ):
+        if self.bounding_box_format is None:
+            raise ValueError(
+                "`RandomFlip()` was called with bounding boxes,"
+                "but no `bounding_box_format` was specified in the constructor."
+                "Please specify a bounding box format in the constructor. i.e."
+                "`RandomFlip(bounding_box_format='xyxy')`"
+            )
+        bounding_boxes = bounding_boxes.copy()
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            source=self.bounding_box_format,
+            target="rel_xyxy",
+            images=image,
+        )
+        bounding_boxes = tf.cond(
+            transformation["flip_horizontal"],
+            lambda: OldRandomFlip._flip_bounding_boxes_horizontal(
+                bounding_boxes
+            ),
+            lambda: bounding_boxes,
+        )
+        bounding_boxes = tf.cond(
+            transformation["flip_vertical"],
+            lambda: OldRandomFlip._flip_bounding_boxes_vertical(bounding_boxes),
+            lambda: bounding_boxes,
+        )
+        bounding_boxes = bounding_box.clip_to_image(
+            bounding_boxes,
+            bounding_box_format="rel_xyxy",
+            images=image,
+        )
+        bounding_boxes = bounding_box.convert_format(
+            bounding_boxes,
+            source="rel_xyxy",
+            target=self.bounding_box_format,
+            dtype=self.compute_dtype,
+            images=image,
+        )
+        return bounding_box.to_ragged(bounding_boxes)
+
+    def augment_segmentation_mask(
+        self, segmentation_mask, transformation=None, **kwargs
+    ):
+        return OldRandomFlip._flip_image(segmentation_mask, transformation)
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def get_config(self):
+        config = {
+            "mode": self.mode,
+            "seed": self.seed,
+            "bounding_box_format": self.bounding_box_format,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class RandomFlipTest(tf.test.TestCase):
+    def test_consistency_with_old_impl(self):
+        mode = HORIZONTAL_AND_VERTICAL
+        image = tf.random.uniform(shape=(1, 64, 64, 3)) * 255.0
+
+        layer = RandomFlip(
+            mode=mode,
+        )
+        old_layer = OldRandomFlip(
+            mode=mode,
+        )
+
+        with unittest.mock.patch.object(
+            layer._random_generator,
+            "random_uniform",
+            return_value=tf.convert_to_tensor([[0.6]]),
+        ):
+            output = layer(image)
+        with unittest.mock.patch.object(
+            old_layer._random_generator,
+            "random_uniform",
+            return_value=tf.convert_to_tensor(0.6),
+        ):
+            old_output = old_layer(image)
+
+        self.assertAllClose(old_output, output)
+
+
+if __name__ == "__main__":
+    # Run benchmark
+    (x_train, _), _ = keras.datasets.cifar10.load_data()
+    x_train = x_train.astype(np.float32)
+
+    is_inputs_containing_bounding_boxes = False
+    num_images = [100, 200, 500, 1000]
+    results = {}
+    aug_candidates = [RandomFlip, OldRandomFlip]
+    aug_args = {
+        "mode": HORIZONTAL_AND_VERTICAL,
+        "bounding_box_format": "xyxy",
+    }
+
+    for aug in aug_candidates:
+        # Eager Mode
+        c = aug.__name__
+        layer = aug(**aug_args)
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            inputs = {IMAGES: x_train[:n_images]}
+            if is_inputs_containing_bounding_boxes:
+                inputs.update(
+                    {
+                        BOUNDING_BOXES: {
+                            "classes": tf.zeros(shape=(n_images, 4)),
+                            "boxes": tf.zeros(shape=(n_images, 4, 4)),
+                        }
+                    }
+                )
+            # warmup
+            layer(inputs)
+
+            t0 = time.time()
+            r1 = layer(inputs)
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # Graph Mode
+        c = aug.__name__ + " Graph Mode"
+        layer = aug(**aug_args)
+
+        @tf.function()
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            inputs = {IMAGES: x_train[:n_images]}
+            if is_inputs_containing_bounding_boxes:
+                inputs.update(
+                    {
+                        BOUNDING_BOXES: {
+                            "classes": tf.zeros(shape=(n_images, 4)),
+                            "boxes": tf.zeros(shape=(n_images, 4, 4)),
+                        }
+                    }
+                )
+            # warmup
+            apply_aug(inputs)
+
+            t0 = time.time()
+            r1 = apply_aug(inputs)
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+        # XLA Mode
+        # OldRandomFlip fails to run on XLA
+        if aug is OldRandomFlip:
+            continue
+        c = aug.__name__ + " XLA Mode"
+        layer = aug(**aug_args)
+
+        @tf.function(jit_compile=True)
+        def apply_aug(inputs):
+            return layer(inputs)
+
+        runtimes = []
+        print(f"Timing {c}")
+
+        for n_images in num_images:
+            inputs = {IMAGES: x_train[:n_images]}
+            if is_inputs_containing_bounding_boxes:
+                inputs.update(
+                    {
+                        BOUNDING_BOXES: {
+                            "classes": tf.zeros(shape=(n_images, 4)),
+                            "boxes": tf.zeros(shape=(n_images, 4, 4)),
+                        }
+                    }
+                )
+            # warmup
+            apply_aug(inputs)
+
+            t0 = time.time()
+            r1 = apply_aug(inputs)
+            t1 = time.time()
+            runtimes.append(t1 - t0)
+            print(f"Runtime for {c}, n_images={n_images}: {t1-t0}")
+        results[c] = runtimes
+
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison.png")
+
+    # So we can actually see more relevant margins
+    del results[aug_candidates[1].__name__]
+    plt.figure()
+    for key in results:
+        plt.plot(num_images, results[key], label=key)
+        plt.xlabel("Number images")
+
+    plt.ylabel("Runtime (seconds)")
+    plt.legend()
+    plt.savefig("comparison_no_old_eager.png")
+
+    # Run unit tests
+    tf.test.main()

--- a/examples/layers/preprocessing/bounding_box/random_flip_demo.py
+++ b/examples/layers/preprocessing/bounding_box/random_flip_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@ from keras_cv.layers import preprocessing
 
 
 def main():
-    dataset = demo_utils.load_voc_dataset(bounding_box_format="xywh")
-    random_flip = preprocessing.RandomFlip(bounding_box_format="xywh")
+    dataset = demo_utils.load_voc_dataset(bounding_box_format="xyxy")
+    random_flip = preprocessing.RandomFlip(
+        mode="horizontal_and_vertical", bounding_box_format="xyxy"
+    )
     result = dataset.map(random_flip, num_parallel_calls=tf.data.AUTOTUNE)
-    demo_utils.visualize_data(result, bounding_box_format="xywh")
+    demo_utils.visualize_data(result, bounding_box_format="xyxy")
 
 
 if __name__ == "__main__":

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -39,18 +39,20 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
     `mode` attribute.
 
     Input shape:
-      3D (unbatched) or 4D (batched) tensor with shape:
-      `(..., height, width, channels)`, in `"channels_last"` format.
+        3D (unbatched) or 4D (batched) tensor with shape:
+        `(..., height, width, channels)`, in `"channels_last"` format.
 
     Output shape:
-      3D (unbatched) or 4D (batched) tensor with shape:
-      `(..., height, width, channels)`, in `"channels_last"` format.
+        3D (unbatched) or 4D (batched) tensor with shape:
+        `(..., height, width, channels)`, in `"channels_last"` format.
 
     Arguments:
       mode: String indicating which flip mode to use. Can be `"horizontal"`,
         `"vertical"`, or `"horizontal_and_vertical"`, defaults to
         `"horizontal"`. `"horizontal"` is a left-right flip and `"vertical"` is
         a top-bottom flip.
+      rate: A float that controls the frequency of flipping. 1.0 indicates that
+        images are always flipped. 0.0 indicates no flipping. Defaults to 0.5.
       seed: Integer. Used to create a random seed.
       bounding_box_format: The format of bounding boxes of input dataset.
         Refer to
@@ -59,7 +61,12 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
     """
 
     def __init__(
-        self, mode=HORIZONTAL, seed=None, bounding_box_format=None, **kwargs
+        self,
+        mode=HORIZONTAL,
+        rate=0.5,
+        seed=None,
+        bounding_box_format=None,
+        **kwargs
     ):
         super().__init__(seed=seed, force_generator=True, **kwargs)
         self.mode = mode
@@ -79,7 +86,7 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
                 "{arg}".format(name=self.name, arg=mode)
             )
         self.bounding_box_format = bounding_box_format
-        self.rate = 0.5
+        self.rate = rate
 
     def get_random_transformation_batch(self, batch_size, **kwargs):
         flip_horizontals = tf.zeros(shape=(batch_size, 1))
@@ -227,6 +234,7 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
     def get_config(self):
         config = {
             "mode": self.mode,
+            "rate": self.rate,
             "seed": self.seed,
             "bounding_box_format": self.bounding_box_format,
         }

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -66,7 +66,7 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
         rate=0.5,
         seed=None,
         bounding_box_format=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(seed=seed, force_generator=True, **kwargs)
         self.mode = mode
@@ -86,6 +86,10 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
                 "{arg}".format(name=self.name, arg=mode)
             )
         self.bounding_box_format = bounding_box_format
+        if rate < 0.0 or rate > 1.0:
+            raise ValueError(
+                f"`rate` should be inside of range [0, 1]. Got rate={rate}"
+            )
         self.rate = rate
 
     def get_random_transformation_batch(self, batch_size, **kwargs):
@@ -160,12 +164,12 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
         )
 
         boxes = tf.where(
-            flip_horizontals > self.rate,
+            flip_horizontals > (1.0 - self.rate),
             self._flip_boxes_horizontal(boxes),
             boxes,
         )
         boxes = tf.where(
-            flip_verticals > self.rate,
+            flip_verticals > (1.0 - self.rate),
             self._flip_boxes_vertical(boxes),
             boxes,
         )
@@ -209,12 +213,12 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
         )
 
         flipped_outputs = tf.where(
-            flip_horizontals > self.rate,
+            flip_horizontals > (1.0 - self.rate),
             tf.image.flip_left_right(images),
             images,
         )
         flipped_outputs = tf.where(
-            flip_verticals > self.rate,
+            flip_verticals > (1.0 - self.rate),
             tf.image.flip_up_down(flipped_outputs),
             flipped_outputs,
         )

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -46,18 +46,19 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
         3D (unbatched) or 4D (batched) tensor with shape:
         `(..., height, width, channels)`, in `"channels_last"` format.
 
-    Arguments:
-      mode: String indicating which flip mode to use. Can be `"horizontal"`,
-        `"vertical"`, or `"horizontal_and_vertical"`, defaults to
-        `"horizontal"`. `"horizontal"` is a left-right flip and `"vertical"` is
-        a top-bottom flip.
-      rate: A float that controls the frequency of flipping. 1.0 indicates that
-        images are always flipped. 0.0 indicates no flipping. Defaults to 0.5.
-      seed: Integer. Used to create a random seed.
-      bounding_box_format: The format of bounding boxes of input dataset.
-        Refer to
-        https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/converters.py
-        for more details on supported bounding box formats.
+    Args:
+        mode: String indicating which flip mode to use. Can be `"horizontal"`,
+            `"vertical"`, or `"horizontal_and_vertical"`, defaults to
+            `"horizontal"`. `"horizontal"` is a left-right flip and
+            `"vertical"` is a top-bottom flip.
+        rate: A float that controls the frequency of flipping. 1.0 indicates
+            that images are always flipped. 0.0 indicates no flipping.
+            Defaults to 0.5.
+        seed: Integer. Used to create a random seed.
+        bounding_box_format: The format of bounding boxes of input dataset.
+            Refer to
+            https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/converters.py
+            for more details on supported bounding box formats.
     """
 
     def __init__(

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -184,20 +184,6 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
     ):
         return self._flip_images(segmentation_masks, transformations)
 
-    def _get_image_shape(self, images):
-        if isinstance(images, tf.RaggedTensor):
-            heights = tf.reshape(images.row_lengths(), (-1, 1))
-            widths = tf.reshape(
-                tf.reduce_max(images.row_lengths(axis=2), 1), (-1, 1)
-            )
-        else:
-            batch_size = tf.shape(images)[0]
-            heights = tf.repeat(tf.shape(images)[H_AXIS], repeats=[batch_size])
-            heights = tf.reshape(heights, shape=(-1, 1))
-            widths = tf.repeat(tf.shape(images)[W_AXIS], repeats=[batch_size])
-            widths = tf.reshape(widths, shape=(-1, 1))
-        return tf.cast(heights, dtype=tf.int32), tf.cast(widths, dtype=tf.int32)
-
     def _flip_images(self, images, transformations):
         batch_size = tf.shape(images)[0]
         height, width = tf.shape(images)[1], tf.shape(images)[2]

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -59,7 +59,7 @@ class RandomFlip(VectorizedBaseImageAugmentationLayer):
             Refer to
             https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/converters.py
             for more details on supported bounding box formats.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The KerasCV Authors
+# Copyright 2023 The KerasCV Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,22 +18,23 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv import bounding_box
+from keras_cv.layers.preprocessing.random_flip import HORIZONTAL_AND_VERTICAL
 from keras_cv.layers.preprocessing.random_flip import RandomFlip
 
 
 class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
     def test_horizontal_flip(self):
         np.random.seed(1337)
-        mock_random = [0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         inp = np.random.random((2, 5, 8, 3))
         expected_output = np.flip(inp, axis=2)
         layer = RandomFlip("horizontal")
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            actual_output = layer(inp, training=True)
+            actual_output = layer(inp)
             self.assertAllClose(expected_output, actual_output)
 
     def test_flip_ragged(self):
@@ -50,21 +51,21 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_vertical_flip(self):
         np.random.seed(1337)
-        mock_random = [0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         inp = np.random.random((2, 5, 8, 3))
         expected_output = np.flip(inp, axis=1)
         layer = RandomFlip("vertical")
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            actual_output = layer(inp, training=True)
+            actual_output = layer(inp)
             self.assertAllClose(expected_output, actual_output)
 
     def test_flip_both(self):
         np.random.seed(1337)
-        mock_random = [0.6, 0.6, 0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         inp = np.random.random((2, 5, 8, 3))
         expected_output = np.flip(inp, axis=2)
         expected_output = np.flip(expected_output, axis=1)
@@ -72,22 +73,22 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            actual_output = layer(inp, training=True)
-            self.assertAllClose(expected_output, actual_output)
+            actual_output = layer(inp)
+        self.assertAllClose(expected_output, actual_output)
 
     def test_random_flip_default(self):
         input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
         expected_output = np.flip(input_images, axis=2)
-        mock_random = [0.6, 0.6, 0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         layer = RandomFlip()
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            actual_output = layer(input_images, training=True)
+            actual_output = layer(input_images)
             self.assertAllClose(expected_output, actual_output)
 
     def test_config_with_custom_name(self):
@@ -99,14 +100,14 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
     def test_random_flip_unbatched_image(self):
         input_image = np.random.random((4, 4, 1)).astype(np.float32)
         expected_output = np.flip(input_image, axis=0)
-        mock_random = [0.6, 0.6, 0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6]])
         layer = RandomFlip("vertical")
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            actual_output = layer(input_image, training=True)
+            actual_output = layer(input_image)
             self.assertAllClose(expected_output, actual_output)
 
     def test_output_dtypes(self):
@@ -128,26 +129,23 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
             ),
             "classes": tf.convert_to_tensor(
                 [
-                    [
-                        0,
-                        0,
-                    ],
+                    [0, 0],
                     [0, 0],
                 ]
             ),
         }
 
         input = {"images": [image, image], "bounding_boxes": bounding_boxes}
-        mock_random = [0.6, 0.6, 0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         layer = RandomFlip(
             "horizontal_and_vertical", bounding_box_format="xyxy"
         )
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            output = layer(input, training=True)
+            output = layer(input)
 
         expected_output = {
             "boxes": tf.convert_to_tensor(
@@ -158,10 +156,7 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
             ),
             "classes": tf.convert_to_tensor(
                 [
-                    [
-                        0,
-                        0,
-                    ],
+                    [0, 0],
                     [0, 0],
                 ]
             ),
@@ -187,16 +182,16 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         }
 
         input = {"images": image, "bounding_boxes": bounding_boxes}
-        mock_random = [0.6, 0.6, 0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
         layer = RandomFlip(
             "horizontal_and_vertical", bounding_box_format="xyxy"
         )
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            output = layer(input, training=True)
+            output = layer(input)
 
         expected_output = {
             "boxes": tf.ragged.constant(
@@ -225,15 +220,15 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         input = {"images": image, "segmentation_masks": mask}
 
         # Flip both vertically and horizontally
-        mock_random = [0.6, 0.6]
+        mock_random = tf.convert_to_tensor([[0.6]])
         layer = RandomFlip("horizontal_and_vertical")
 
         with unittest.mock.patch.object(
             layer._random_generator,
             "random_uniform",
-            side_effect=mock_random,
+            return_value=mock_random,
         ):
-            output = layer(input, training=True)
+            output = layer(input)
 
         expected_mask = np.flip(np.flip(mask, axis=1), axis=2)
 
@@ -255,3 +250,21 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         input = {"images": input_image, "bounding_boxes": bounding_boxes}
         layer = RandomFlip(bounding_box_format="xyxy")
         _ = layer(input)
+
+    def test_independence_of_random_flip_on_batched_images(self):
+        image = tf.random.uniform((100, 100, 3))
+        batched_images = tf.stack((image, image), axis=0)
+        seed = 2023
+        layer = RandomFlip(mode=HORIZONTAL_AND_VERTICAL, seed=seed)
+
+        results = layer(batched_images)
+
+        self.assertNotAllClose(results[0], results[1])
+
+    def test_config(self):
+        layer = RandomFlip(
+            mode=HORIZONTAL_AND_VERTICAL, bounding_box_format="xyxy"
+        )
+        config = layer.get_config()
+        self.assertEqual(config["mode"], HORIZONTAL_AND_VERTICAL)
+        self.assertEqual(config["bounding_box_format"], "xyxy")

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -91,6 +91,34 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
             actual_output = layer(input_images)
             self.assertAllClose(expected_output, actual_output)
 
+    def test_random_flip_low_rate(self):
+        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
+        expected_output = input_images
+        # mock_random > 0.5 but no flipping occurs due to low rate
+        mock_random = tf.convert_to_tensor([[0.6], [0.6]])
+        layer = RandomFlip(rate=0.1)
+        with unittest.mock.patch.object(
+            layer._random_generator,
+            "random_uniform",
+            return_value=mock_random,
+        ):
+            actual_output = layer(input_images)
+        self.assertAllClose(expected_output, actual_output)
+
+    def test_random_flip_high_rate(self):
+        input_images = np.random.random((2, 5, 8, 3)).astype(np.float32)
+        expected_output = np.flip(input_images, axis=2)
+        # mock_random is small (0.2) but flipping still occurs due to high rate
+        mock_random = tf.convert_to_tensor([[0.2], [0.2]])
+        layer = RandomFlip(rate=0.9)
+        with unittest.mock.patch.object(
+            layer._random_generator,
+            "random_uniform",
+            return_value=mock_random,
+        ):
+            actual_output = layer(input_images)
+        self.assertAllClose(expected_output, actual_output)
+
     def test_config_with_custom_name(self):
         layer = RandomFlip(name="image_preproc")
         config = layer.get_config()

--- a/keras_cv/layers/preprocessing/with_labels_test.py
+++ b/keras_cv/layers/preprocessing/with_labels_test.py
@@ -92,6 +92,7 @@ TEST_CONFIGURATIONS = [
         layers.RandomContrast,
         {"value_range": (0, 255), "factor": 0.5},
     ),
+    ("RandomFlip", layers.RandomFlip, {"mode": "horizontal"}),
     (
         "RandomGaussianBlur",
         layers.RandomGaussianBlur,

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -59,6 +59,7 @@ TEST_CONFIGURATIONS = [
         layers.RandomCutout,
         {"height_factor": 0.2, "width_factor": 0.2},
     ),
+    ("RandomFlip", layers.RandomFlip, {"mode": "horizontal"}),
     (
         "RandomHue",
         layers.RandomHue,


### PR DESCRIPTION
# What does this PR do?

## Benchmarks

Vectorized RandomFlip is super fast compared to old one.

||Mode|n=100|n=200|n=500|n=1000|
|-|-|-|-|-|-|
|OldRandomFlip|Eager|0.703s|1.556s|8.011s|29.660s|
|OldRandomFlip|Graph|0.311s|1.191s|7.337s|29.395s|
|RandomFlip|Eager|0.005s|0.006s|0.008s|0.011s|
|RandomFlip|Graph|0.001s|0.002s|0.003s|0.006s|
|RandomFlip|XLA|0.001s|0.002s|0.003s|0.006s|

![comparison](https://user-images.githubusercontent.com/20734616/230883608-5daf69fd-dea9-47c8-b386-61b3e4983aae.png)

OldRandomFlip is too slow, therefore I have set `n` to `[100, 200, 500, 1000]`. OldRandomFlip cannot run on XLA.

## Visualization

This PR updates the working pipeline for visualization.
`mode="horizontal_and_vertical"`

![output](https://user-images.githubusercontent.com/20734616/230883491-632c146b-fa46-4326-b6e4-b5eb9490271f.png)

## Notes

This PR fixes some missing unit tests for RandomFlip.

Vectorized RandomFlip can be run on XLA and provide a speed-up.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 