### PR TITLE
Revert accidental change to logits activation

### DIFF
--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
@@ -78,7 +78,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
             target=target_format,
         )
         if self.from_logits:
-            class_prediction = tf.nn.softmax(class_prediction)
+            class_prediction = tf.math.sigmoid(class_prediction)
 
         box_prediction = tf.expand_dims(box_prediction, axis=-2)
         (

--- a/keras_cv/models/object_detection/retina_net/retina_net_presets.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_presets.py
@@ -30,7 +30,7 @@ retina_net_presets = {
             # performance.
             "num_classes": 21,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50.weights.h5",  # noqa: E501
-        "weights_hash": "c9b11357b289512adf1e6077ab7da73f",
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/pascal_voc/resnet50-v2.weights.h5",  # noqa: E501
+        "weights_hash": "4c021b278b0bfe737bdd7d2a0c526c43",
     },
 }

--- a/keras_cv/models/object_detection/retina_net/retina_net_presets.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net_presets.py
@@ -30,7 +30,7 @@ retina_net_presets = {
             # performance.
             "num_classes": 21,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/pascal_voc/resnet50-v2.weights.h5",  # noqa: E501
-        "weights_hash": "4c021b278b0bfe737bdd7d2a0c526c43",
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50.weights.h5",  # noqa: E501
+        "weights_hash": "c9b11357b289512adf1e6077ab7da73f",
     },
 }


### PR DESCRIPTION
At some point while we were trying to create a single decoder to use for MaskRCNN + RetinaNet the activation for the prediction decoder was changed to be softmax instead of sigmoid.  This has a few undesirable properties, but the most notable is that at times the model will make a prediction for a box with a logit of 0.000001 if the rest of the logits are all 0 or negative

This also removes the need for the extra class in RetinaNet.  We can just use len(class_ids) now.