### PR TITLE
Support multiple box losses for CenterPillar (one-per-class)

### DIFF
--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -195,7 +195,10 @@ class MultiHeadCenterPillar(keras.Model):
 
         Args:
             heatmap_loss: a Keras loss to use for heatmap regression.
-            box_loss: a Keras loss to use for box regression.
+            box_loss: a Keras loss to use for box regression, or a list of Keras
+                losses for box regression, one for each class. If only one loss
+                is specified, it will be used for all classes, otherwise exactly
+                one loss should be specified per class.
             kwargs: other `keras.Model.compile()` arguments are supported and
                 propagated to the `keras.Model` class.
         """

--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -200,9 +200,14 @@ class MultiHeadCenterPillar(keras.Model):
                 propagated to the `keras.Model` class.
         """
         losses = {}
+
+        if box_loss is not None and not isinstance(box_loss, list):
+            box_loss = [
+                box_loss for _ in range(self._multiclass_head._num_classes)
+            ]
         for i in range(self._multiclass_head._num_classes):
             losses[f"heatmap_class_{i+1}"] = heatmap_loss
-            losses[f"box_class_{i+1}"] = box_loss
+            losses[f"box_class_{i+1}"] = box_loss[i]
 
         super().compile(loss=losses, **kwargs)
 


### PR DESCRIPTION
For CenterPillar, we may need separate box losses for separate classes.

This updates the API to support this.