### PR TITLE
Fix RetinaNet serialization for Keras 2.13+

### DIFF
--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -534,9 +534,6 @@ class RetinaNet(Task):
         config["backbone"] = keras.utils.deserialize_keras_object(
             config["backbone"]
         )
-        config["classification_head"] = keras.utils.deserialize_keras_object(
-            config["classification_head"]
-        )
         return super().from_config(config)
 
     def get_config(self):

--- a/keras_cv/models/object_detection/retina_net/retina_net.py
+++ b/keras_cv/models/object_detection/retina_net/retina_net.py
@@ -529,6 +529,16 @@ class RetinaNet(Task):
                 metrics[metric.name] = result
         return metrics
 
+    @classmethod
+    def from_config(cls, config):
+        config["backbone"] = keras.utils.deserialize_keras_object(
+            config["backbone"]
+        )
+        config["classification_head"] = keras.utils.deserialize_keras_object(
+            config["classification_head"]
+        )
+        return super().from_config(config)
+
     def get_config(self):
         return {
             "num_classes": self.num_classes,


### PR DESCRIPTION
#1663 accidentally removed `from_config` from the RetinaNet, which didn't break our CI but does break deserialization in TF/Keras 2.13, which broke our sync to G3.

I re-introduced it here.