### PR TITLE
Remove a redundant check from IoULoss

### DIFF
--- a/keras_cv/losses/iou_loss.py
+++ b/keras_cv/losses/iou_loss.py
@@ -96,14 +96,6 @@ class IoULoss(keras.losses.Loss):
                 f"bounding boxes. Received y_true.shape[-1]={y_true.shape[-1]}."
             )
 
-        if y_true.shape[-2] < y_pred.shape[-2]:
-            raise ValueError(
-                "IoULoss expects number of boxes in y_pred to be equal to the "
-                "number of boxes in y_true. Received number of boxes in "
-                f"y_true={y_true.shape[-2]} "
-                f"and number of boxes in y_pred={y_pred.shape[-2]}."
-            )
-
         if y_true.shape[-2] != y_pred.shape[-2]:
             raise ValueError(
                 "IoULoss expects number of boxes in y_pred to be equal to the "


### PR DESCRIPTION
This was introduced in #1296 and is a duplicate of the check below which is more exhaustive.