### PR TITLE
fix failed tests in resnet_v1 presets

### DIFF
--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
@@ -37,10 +37,6 @@ class ResNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
         self.input_batch = tf.ones(shape=(2, 224, 224, 3))
 
-    @parameterized.named_parameters(
-        ("preset_with_weights", "resnet50_imagenet"),
-        # ("preset_no_weights", "resnet50"),
-    )
     def test_backbone_output(self):
         model = ResNetBackbone.from_preset("resnet50")
         model(self.input_batch)
@@ -63,10 +59,9 @@ class ResNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
         # We should only update these numbers if we are updating a weights
         # file, or have found a discrepancy with the upstream source.
 
-        outputs = feature_extractor(tf.ones(1, 512, 512, 3))
+        outputs = feature_extractor(tf.ones((1, 512, 512, 3)))
         outputs = [outputs[i][0, 0, 0, :5] for i in extractor_levels]
         expected = [
-            [0.50249904, 0.35751498, 0.9474212, 1.0659311, 1.1105202],
             [0.65718395, 0.7209194, 0.39707005, 0.5164382, 0.73338735],
             [
                 1.0615100e00,

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
@@ -15,7 +15,6 @@
 
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
 
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
     ResNet50Backbone,
@@ -23,11 +22,10 @@ from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
     ResNetBackbone,
 )
-from keras_cv.utils.train import get_feature_extractor
 
 
 @pytest.mark.large
-class ResNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
+class ResNetPresetSmokeTest(tf.test.TestCase):
     """
     A smoke test for ResNet presets we run continuously.
     This only tests the smallest weights we have available. Run with:
@@ -44,36 +42,18 @@ class ResNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     def test_backbone_output_with_weights(self):
         model = ResNetBackbone.from_preset("resnet50_imagenet")
 
-        # initialize trainable networks
-        extractor_levels = [3, 4, 5]
-        extractor_layer_names = [
-            model.pyramid_level_inputs[i] for i in extractor_levels
-        ]
-        feature_extractor = get_feature_extractor(
-            model, extractor_layer_names, extractor_levels
-        )
-
         # The forward pass from a preset should be stable!
         # This test should catch cases where we unintentionally change our
         # network code in a way that would invalidate our preset weights.
         # We should only update these numbers if we are updating a weights
         # file, or have found a discrepancy with the upstream source.
 
-        outputs = feature_extractor(tf.ones((1, 512, 512, 3)))
-        outputs = [outputs[i][0, 0, 0, :5] for i in extractor_levels]
-        expected = [
-            [0.65718395, 0.7209194, 0.39707005, 0.5164382, 0.73338735],
-            [
-                1.0615100e00,
-                1.2732037e00,
-                4.2707797e-02,
-                6.3376129e-04,
-                1.0917966e00,
-            ],
-            [0.0, 0.0, 0.0, 0.05175382, 0.0],
-        ]
+        outputs = model(tf.ones(shape=(1, 512, 512, 3)))
+        expected = [0.0, 0.0, 0.0, 0.05175382, 0.0]
         # Keep a high tolerance, so we are robust to different hardware.
-        self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(
+            outputs[0, 0, 0, :5], expected, atol=0.01, rtol=0.01
+        )
 
     def test_applications_model_output(self):
         model = ResNet50Backbone()
@@ -100,7 +80,7 @@ class ResNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
 
 
 @pytest.mark.extra_large
-class ResNetPresetFullTest(tf.test.TestCase, parameterized.TestCase):
+class ResNetPresetFullTest(tf.test.TestCase):
     """
     Test the full enumeration of our preset.
     This every presets for ResNet and is only run manually.


### PR DESCRIPTION
The old tests breaks in TF 2.12. This PR fixes it in both 2.11 and 2.12.