### PR TITLE
Make PyCOCOCallback support pure-dict format for training data

### DIFF
--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -16,6 +16,7 @@ from keras.callbacks import Callback
 
 from keras_cv import bounding_box
 from keras_cv.metrics.coco import compute_pycoco_metrics
+from keras_cv.models.object_detection.__internal__ import unpack_input
 
 
 class PyCOCOCallback(Callback):
@@ -51,10 +52,12 @@ class PyCOCOCallback(Callback):
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
 
-        def images_only(images, boxes):
+        def images_only(data):
+            images, boxes = unpack_input(data)
             return images
 
-        def boxes_only(images, boxes):
+        def boxes_only(data):
+            images, boxes = unpack_input(data)
             return boxes
 
         images_only_ds = self.val_data.map(images_only)

--- a/keras_cv/models/object_detection/__test_utils__.py
+++ b/keras_cv/models/object_detection/__test_utils__.py
@@ -47,7 +47,14 @@ def _create_bounding_box_dataset(
 
     if use_dictionary_box_format:
         return tf.data.Dataset.from_tensor_slices(
-            (xs, {"boxes": ys, "classes": y_classes, "num_dets": num_dets})
+            {
+                "images": xs,
+                "bounding_boxes": {
+                    "boxes": ys,
+                    "classes": y_classes,
+                    "num_dets": num_dets,
+                },
+            }
         ).batch(5, drop_remainder=True)
     else:
         return xs, {"boxes": ys, "classes": y_classes}


### PR DESCRIPTION
With this change, the normal OD training flow can now use the pure-dict format (the models' `train_step`s actually already support this).

I also updated the test dataset generator to use the pure-dict format as that's the one we should enforce.