### PR TITLE
Add force output functionality to VectorizedBaseImageAugmentationLayer

### DIFF
--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -516,3 +516,35 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
         )
 
         # assertion is at VectorizedAssertionLayer's methods
+
+    def test_converts_ragged_to_dense_images(self):
+        images = tf.ragged.stack(
+            [
+                np.random.random(size=(8, 8, 3)).astype("float32"),
+                np.random.random(size=(16, 8, 3)).astype("float32"),
+            ]
+        )
+        add_layer = VectorizedRandomAddLayer(fixed_value=0.5)
+        add_layer.force_output_dense_images = True
+        result = add_layer(images)
+        self.assertTrue(isinstance(result, tf.Tensor))
+
+    def test_converts_ragged_to_dense_segmention_masks(self):
+        images = tf.ragged.stack(
+            [
+                np.random.random(size=(8, 8, 3)).astype("float32"),
+                np.random.random(size=(16, 8, 3)).astype("float32"),
+            ]
+        )
+        segmentation_masks = tf.ragged.stack(
+            [
+                np.random.randint(0, 10, size=(8, 8, 1)).astype("float32"),
+                np.random.randint(0, 10, size=(16, 8, 1)).astype("float32"),
+            ]
+        )
+        add_layer = VectorizedRandomAddLayer(fixed_value=0.5)
+        add_layer.force_output_dense_segmentation_masks = True
+        result = add_layer(
+            {"images": images, "segmentation_masks": segmentation_masks}
+        )
+        self.assertTrue(isinstance(result["segmentation_masks"], tf.Tensor))


### PR DESCRIPTION
# What does this PR do?

Fixes #1692 

This PR adds `self.force_output_dense_images` and `self.force_output_dense_segmentation_masks` to VectorizedBaseImageAugmentationLayer. With these changes, we can now ensure that vectorized KPLs produce dense outputs.

2 unit tests are also added.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?
@LukeWood @ianstenbit 