### PR TITLE
CSP to be consistent with preset name

### DIFF
--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -28,7 +28,7 @@ from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone import (
     CSPDarkNetTinyBackbone,
 )
 from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone import (
-    CSPDarkNetXBackbone,
+    CSPDarkNetXLBackbone,
 )
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
     ResNet18Backbone,

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -390,7 +390,7 @@ setattr(
     CSPDarkNetXLBackbone,
     "__doc__",
     ALIAS_DOCSTRING.format(
-        name="X",
+        name="XL",
         stackwise_channels="[170, 340, 680, 1360]",
         stackwise_depth="[4, 12, 12, 4]",
     ),

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -326,7 +326,7 @@ class CSPDarkNetLBackbone(CSPDarkNetBackbone):
         return cls.presets
 
 
-class CSPDarkNetXBackbone(CSPDarkNetBackbone):
+class CSPDarkNetXLBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,
         include_rescaling=True,
@@ -342,7 +342,7 @@ class CSPDarkNetXBackbone(CSPDarkNetBackbone):
                 "input_tensor": input_tensor,
             }
         )
-        return CSPDarkNetBackbone.from_preset("csp_dark_net_l", **kwargs)
+        return CSPDarkNetBackbone.from_preset("csp_dark_net_xl", **kwargs)
 
     @classproperty
     def presets(cls):
@@ -387,7 +387,7 @@ setattr(
     ),
 )
 setattr(
-    CSPDarkNetXBackbone,
+    CSPDarkNetXLBackbone,
     "__doc__",
     ALIAS_DOCSTRING.format(
         name="X",

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -131,7 +131,7 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("S", csp_darknet_backbone.CSPDarkNetSBackbone),
         ("M", csp_darknet_backbone.CSPDarkNetMBackbone),
         ("L", csp_darknet_backbone.CSPDarkNetLBackbone),
-        ("X", csp_darknet_backbone.CSPDarkNetXBackbone),
+        ("X", csp_darknet_backbone.CSPDarkNetXLBackbone),
     )
     def test_specific_arch_forward_pass(self, arch_class):
         backbone = arch_class()

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -131,7 +131,7 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("S", csp_darknet_backbone.CSPDarkNetSBackbone),
         ("M", csp_darknet_backbone.CSPDarkNetMBackbone),
         ("L", csp_darknet_backbone.CSPDarkNetLBackbone),
-        ("X", csp_darknet_backbone.CSPDarkNetXLBackbone),
+        ("XL", csp_darknet_backbone.CSPDarkNetXLBackbone),
     )
     def test_specific_arch_forward_pass(self, arch_class):
         backbone = arch_class()


### PR DESCRIPTION
Change the `CSPDarkNetXBackbone` to `CSPDarkNetXLBackbone` to be consistent with the present name of `"csp_dark_net_xl"`.