### PR TITLE
Update the KerasCV bounding box output experience

### DIFF
--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -61,9 +61,10 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
 
     boxes = bounding_boxes.get("boxes")
     classes = bounding_boxes.get("classes")
+    confidence = bounding_boxes.get("confidence", None)
     num_detections = bounding_boxes.get("num_detections")
 
-    # Create a mask to select only the first N boxes from each batch
+    # Create a mask to selxect only the first N boxes from each batch
     mask = tf.repeat(
         tf.expand_dims(tf.range(tf.shape(boxes)[1]), axis=0),
         repeats=tf.shape(boxes)[0],
@@ -81,6 +82,10 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     result = bounding_boxes.copy()
     result["boxes"] = boxes
     result["classes"] = classes
+
+    if confidence:
+        confidence = tf.where(mask, confidence, -tf.ones_like(confidence))
+        result["confidence"] = confidence
 
     if output_ragged:
         return to_ragged(result)

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -74,17 +74,19 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
 
     classes = tf.where(mask, classes, -tf.ones_like(classes))
 
+    if confidence is not None:
+        confidence = tf.where(mask, confidence, -tf.ones_like(confidence))
+
     # reuse mask for boxes
     mask = tf.expand_dims(mask, axis=-1)
     mask = tf.repeat(mask, repeats=boxes.shape[-1], axis=-1)
     boxes = tf.where(mask, boxes, -tf.ones_like(boxes))
 
     result = bounding_boxes.copy()
+
     result["boxes"] = boxes
     result["classes"] = classes
-
-    if confidence:
-        confidence = tf.where(mask, confidence, -tf.ones_like(confidence))
+    if confidence is not None:
         result["confidence"] = confidence
 
     if output_ragged:

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -64,7 +64,7 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     confidence = bounding_boxes.get("confidence", None)
     num_detections = bounding_boxes.get("num_detections")
 
-    # Create a mask to selxect only the first N boxes from each batch
+    # Create a mask to select only the first N boxes from each batch
     mask = tf.repeat(
         tf.expand_dims(tf.range(tf.shape(boxes)[1]), axis=0),
         repeats=tf.shape(boxes)[0],

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -89,12 +89,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
             "boxes": tf.stack(
                 [tf.random.uniform((10, 4)), tf.random.uniform((10, 4))]
             ),
-            "confidence": tf.random.uniform(
-                (
-                    2,
-                    10,
-                )
-            ),
+            "confidence": tf.random.uniform((2, 10)),
             "num_detections": tf.constant([2, 3]),
             "classes": tf.stack(
                 [tf.random.uniform((10,)), tf.random.uniform((10,))]

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -83,3 +83,29 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         self.assertTrue(isinstance(result["boxes"], tf.RaggedTensor))
         self.assertEqual(result["boxes"][0].shape[0], 2)
         self.assertEqual(result["boxes"][1].shape[0], 3)
+
+    def test_correctly_masks_confidence(self):
+        bounding_boxes = {
+            "boxes": tf.stack(
+                [tf.random.uniform((10, 4)), tf.random.uniform((10, 4))]
+            ),
+            "confidence": tf.random.uniform(
+                (
+                    2,
+                    10,
+                )
+            ),
+            "num_detections": tf.constant([2, 3]),
+            "classes": tf.stack(
+                [tf.random.uniform((10,)), tf.random.uniform((10,))]
+            ),
+        }
+
+        result = bounding_box.mask_invalid_detections(
+            bounding_boxes, output_ragged=True
+        )
+        self.assertTrue(isinstance(result["boxes"], tf.RaggedTensor))
+        self.assertEqual(result["boxes"][0].shape[0], 2)
+        self.assertEqual(result["boxes"][1].shape[0], 3)
+        self.assertEqual(result["confidence"][0].shape[0], 2)
+        self.assertEqual(result["confidence"][1].shape[0], 3)

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -56,10 +56,14 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
 
     boxes = bounding_boxes.get("boxes")
     classes = bounding_boxes.get("classes")
+    confidence = bounding_boxes.get("confidence", None)
+
     mask = classes != sentinel
 
     boxes = tf.ragged.boolean_mask(boxes, mask)
     classes = tf.ragged.boolean_mask(classes, mask)
+    if confidence is not None:
+        confidence = tf.ragged.boolean_mask(confidence, mask)
 
     if isinstance(boxes, tf.Tensor):
         boxes = tf.RaggedTensor.from_tensor(boxes)
@@ -67,7 +71,15 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
     if isinstance(classes, tf.Tensor) and len(classes.shape) > 1:
         classes = tf.RaggedTensor.from_tensor(classes)
 
+    if confidence is not None:
+        if isinstance(confidence, tf.Tensor) and len(confidence.shape) > 1:
+            confidence = tf.RaggedTensor.from_tensor(confidence)
+
     result = bounding_boxes.copy()
     result["boxes"] = tf.cast(boxes, dtype)
     result["classes"] = tf.cast(classes, dtype)
+
+    if confidence is not None:
+        result["confidence"] = tf.cast(confidence, dtype)
+
     return result

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -23,13 +23,27 @@ class ToRaggedTest(tf.test.TestCase):
                 [[[0, 0, 0, 0], [0, 0, 0, 0]], [[2, 3, 4, 5], [0, 1, 2, 3]]]
             ),
             "classes": tf.constant([[-1, -1], [-1, 1]]),
+            "confidence": tf.constant([[0.5, 0.7], [0.23, 0.12]]),
         }
         bounding_boxes = bounding_box.to_ragged(bounding_boxes)
 
         self.assertEqual(bounding_boxes["boxes"][1].shape, [1, 4])
         self.assertEqual(bounding_boxes["classes"][1].shape, [1])
+        self.assertEqual(
+            bounding_boxes["confidence"][1].shape,
+            [
+                1,
+            ],
+        )
+
         self.assertEqual(bounding_boxes["classes"][0].shape, [0])
         self.assertEqual(bounding_boxes["boxes"][0].shape, [0, 4])
+        self.assertEqual(
+            bounding_boxes["confidence"][0].shape,
+            [
+                0,
+            ],
+        )
 
     def test_round_trip(self):
         original = {
@@ -40,6 +54,7 @@ class ToRaggedTest(tf.test.TestCase):
                 ]
             ),
             "classes": tf.constant([[1, -1], [-1, -1]]),
+            "confidence": tf.constant([[0.5, -1], [-1, -1]]),
         }
         bounding_boxes = bounding_box.to_ragged(original)
         bounding_boxes = bounding_box.to_dense(bounding_boxes, max_boxes=2)
@@ -48,6 +63,10 @@ class ToRaggedTest(tf.test.TestCase):
         self.assertEqual(bounding_boxes["classes"][1].shape, [2])
         self.assertEqual(bounding_boxes["classes"][0].shape, [2])
         self.assertEqual(bounding_boxes["boxes"][0].shape, [2, 4])
+        self.assertEqual(bounding_boxes["confidence"][0].shape, [2])
 
         self.assertAllEqual(bounding_boxes["boxes"], original["boxes"])
         self.assertAllEqual(bounding_boxes["classes"], original["classes"])
+        self.assertAllEqual(
+            bounding_boxes["confidence"], original["confidence"]
+        )

--- a/keras_cv/callbacks/pycoco_callback.py
+++ b/keras_cv/callbacks/pycoco_callback.py
@@ -60,22 +60,22 @@ class PyCOCOCallback(Callback):
 
         def boxes_only(data):
             images, boxes = unpack_input(data)
-            return boxes
+            return bounding_box.to_ragged(boxes)
 
         images_only_ds = self.val_data.map(images_only)
         y_pred = self.model.predict(images_only_ds)
-        box_pred = tf.convert_to_tensor(y_pred["boxes"])
-        cls_pred = tf.convert_to_tensor(y_pred["classes"])
-        confidence_pred = tf.convert_to_tensor(y_pred["confidence"])
-        valid_det = tf.convert_to_tensor(y_pred["num_detections"])
+        box_pred = y_pred["boxes"]
+        cls_pred = y_pred["classes"]
+        confidence_pred = y_pred["confidence"]
+        valid_det = y_pred["num_detections"]
 
         gt = [boxes for boxes in self.val_data.map(boxes_only)]
         gt_boxes = tf.concat(
-            [tf.RaggedTensor.from_tensor(boxes["boxes"]) for boxes in gt],
+            [boxes["boxes"] for boxes in gt],
             axis=0,
         )
         gt_classes = tf.concat(
-            [tf.RaggedTensor.from_tensor(boxes["classes"]) for boxes in gt],
+            [boxes["classes"] for boxes in gt],
             axis=0,
         )
 

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
@@ -38,8 +38,6 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         large number may trigger significant memory overhead, defaults to 100.
       max_detections_per_class: the maximum detections to consider per class
         after nms is applied, defaults to 100.
-      output_ragged: (Optional) Whether or not to output bounding boxes in
-        `RaggedTensor` format.  Defaults to True.
     """  # noqa: E501
 
     def __init__(
@@ -50,7 +48,6 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         confidence_threshold=0.5,
         max_detections=100,
         max_detections_per_class=100,
-        output_ragged=True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -60,7 +57,6 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         self.confidence_threshold = confidence_threshold
         self.max_detections = max_detections
         self.max_detections_per_class = max_detections_per_class
-        self.output_ragged = output_ragged
         self.built = True
 
     def call(self, box_prediction, class_prediction):
@@ -112,7 +108,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         }
         # this is required to comply with KerasCV bounding box format.
         return bounding_box.mask_invalid_detections(
-            bounding_boxes, output_ragged=self.output_ragged
+            bounding_boxes, output_ragged=True
         )
 
     def get_config(self):

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
@@ -112,7 +112,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         }
         # this is required to comply with KerasCV bounding box format.
         return bounding_box.mask_invalid_detections(
-            bounding_boxes, output_ragged=output_ragged
+            bounding_boxes, output_ragged=self.output_ragged
         )
 
     def get_config(self):

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
@@ -38,6 +38,8 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         large number may trigger significant memory overhead, defaults to 100.
       max_detections_per_class: the maximum detections to consider per class
         after nms is applied, defaults to 100.
+      output_ragged: (Optional) Whether or not to output bounding boxes in
+        `RaggedTensor` format.  Defaults to True.
     """  # noqa: E501
 
     def __init__(
@@ -48,6 +50,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         confidence_threshold=0.5,
         max_detections=100,
         max_detections_per_class=100,
+        output_ragged=True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -57,6 +60,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         self.confidence_threshold = confidence_threshold
         self.max_detections = max_detections
         self.max_detections_per_class = max_detections_per_class
+        self.output_ragged = output_ragged
         self.built = True
 
     def call(self, box_prediction, class_prediction):
@@ -107,7 +111,9 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
             "num_detections": valid_det,
         }
         # this is required to comply with KerasCV bounding box format.
-        return bounding_box.mask_invalid_detections(bounding_boxes)
+        return bounding_box.mask_invalid_detections(
+            bounding_boxes, output_ragged=output_ragged
+        )
 
     def get_config(self):
         config = {

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -35,6 +35,7 @@ def decode_predictions_output_shapes():
         bounding_box_format="xyxy",
         from_logits=True,
         max_detections=100,
+        output_ragged=False,
     )
 
     result = layer(box_prediction=box_pred, class_prediction=class_prediction)

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -35,7 +35,6 @@ def decode_predictions_output_shapes():
         bounding_box_format="xyxy",
         from_logits=True,
         max_detections=100,
-        output_ragged=False,
     )
 
     result = layer(box_prediction=box_pred, class_prediction=class_prediction)
@@ -45,6 +44,6 @@ def decode_predictions_output_shapes():
 class NmsPredictionDecoderTest(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
         result = decode_predictions_output_shapes()
-        self.assertEqual(result["boxes"].shape, [8, 100, 4])
-        self.assertEqual(result["classes"].shape, [8, 100])
-        self.assertEqual(result["confidence"].shape, [8, 100])
+        self.assertEqual(result["boxes"].shape, [8, None, 4])
+        self.assertEqual(result["classes"].shape, [8, None])
+        self.assertEqual(result["confidence"].shape, [8, None])


### PR DESCRIPTION
After some piloting and user feedback it is clear that the following are true:
- ragged outputs are less confusing than receiving a tensor of all -1s
- NMS wasn't filtering confidence, this is just a bad/inconsistent UX

I propose we update the behavior to output ragged boxes by default, as well as filter confidence scores by class ID.  This will overall improve consistency and UX.