### PR TITLE
Reorganize MobileNetV3 Directory to be more browsable.

### DIFF
--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -30,14 +30,14 @@ from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone import (
 from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone import (
     CSPDarkNetXLBackbone,
 )
-from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
-    MobileNetV3Backbone,
-)
-from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_aliases import (
     MobileNetV3LargeBackbone,
 )
-from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_aliases import (
     MobileNetV3SmallBackbone,
+)
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+    MobileNetV3Backbone,
 )
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone import (
     ResNet18Backbone,

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_aliases.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_aliases.py
@@ -1,0 +1,104 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+    MobileNetV3Backbone,
+)
+from keras_cv.utils.python_utils import classproperty
+
+ALIAS_DOCSTRING = """MobileNetV3Backbone model with {num_layers} layers.
+
+    References:
+        - [Searching for MobileNetV3](https://arxiv.org/abs/1905.02244)
+        - [Based on the Original keras.applications MobileNetv3](https://github.com/keras-team/keras/blob/master/keras/applications/mobilenet_v3.py)
+
+    For transfer learning use cases, make sure to read the
+    [guide to transfer learning & fine-tuning](https://keras.io/guides/transfer_learning/).
+
+    Args:
+        include_rescaling: bool, whether to rescale the inputs. If set to
+            True, inputs will be passed through a `Rescaling(scale=1 / 255)`
+            layer. Defaults to True.
+        input_shape: optional shape tuple, defaults to (None, None, 3).
+        input_tensor: optional Keras tensor (i.e., output of `layers.Input()`)
+            to use as image input for the model.
+
+    Examples:
+    ```python
+    input_data = tf.ones(shape=(8, 224, 224, 3))
+
+    # Randomly initialized backbone
+    model = {name}Backbone()
+    output = model(input_data)
+    ```
+"""  # noqa: E501
+
+
+class MobileNetV3SmallBackbone(MobileNetV3Backbone):
+    def __new__(
+        cls,
+        include_rescaling=True,
+        input_shape=(None, None, 3),
+        input_tensor=None,
+        **kwargs,
+    ):
+        # Pack args in kwargs
+        kwargs.update(
+            {
+                "include_rescaling": include_rescaling,
+                "input_shape": input_shape,
+                "input_tensor": input_tensor,
+            }
+        )
+        return MobileNetV3Backbone.from_preset("mobilenetv3small", **kwargs)
+
+    @classproperty
+    def presets(cls):
+        """Dictionary of preset names and configurations."""
+        return {}
+
+
+class MobileNetV3LargeBackbone(MobileNetV3Backbone):
+    def __new__(
+        cls,
+        include_rescaling=True,
+        input_shape=(None, None, 3),
+        input_tensor=None,
+        **kwargs,
+    ):
+        # Pack args in kwargs
+        kwargs.update(
+            {
+                "include_rescaling": include_rescaling,
+                "input_shape": input_shape,
+                "input_tensor": input_tensor,
+            }
+        )
+        return MobileNetV3Backbone.from_preset("mobilenetv3large", **kwargs)
+
+    @classproperty
+    def presets(cls):
+        """Dictionary of preset names and configurations."""
+        return {}
+
+
+setattr(
+    MobileNetV3LargeBackbone,
+    "__doc__",
+    ALIAS_DOCSTRING.format(name="MobileNetV3Large", num_layers="28"),
+)
+setattr(
+    MobileNetV3SmallBackbone,
+    "__doc__",
+    ALIAS_DOCSTRING.format(name="MobileNetV3Small", num_layers="14"),
+)

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -18,11 +18,11 @@ import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
 
-from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
-    MobileNetV3Backbone,
-)
 from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_aliases import (
     MobileNetV3SmallBackbone,
+)
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+    MobileNetV3Backbone,
 )
 from keras_cv.utils.train import get_feature_extractor
 

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -21,7 +21,7 @@ from tensorflow import keras
 from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
     MobileNetV3Backbone,
 )
-from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
+from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_aliases import (
     MobileNetV3SmallBackbone,
 )
 from keras_cv.utils.train import get_feature_extractor


### PR DESCRIPTION
# What does this PR do?

I have a few minor complaints with our current backbone structure:

- the backbone files are massive
- finding the actual backbone class can be a bit annoying
- the aliases clog up the file but add very little information to code browsers.

In this PR I propose a solution to this.  This is two fold:

1.) move aliases to their own file:

self explanatory - seems strictly better from my perspective unless I'm missing something.

2.) move helpers below model declarations

This makes it super easy to find the actual modeling logic; which is what most of us reading this code care about!  If you want to answer "What is a MobileNetV3" its a lot easier to start reading the model than to start from the building blocks.  All tests pass; and there should be no logic delta due to this PR.  Only code browse-ability improvements.

---

If this PR looks good lets do this to the other models too.