### PR TITLE
Add batchwise parameter to RandomChoice

### DIFF
--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -53,10 +53,10 @@ class RandomChoice(BaseImageAugmentationLayer):
             boost, but can only be used if all the layers provided to the
             `layers` argument support auto vectorization.
         batchwise: (Optional) bool, whether to pass entire batches to the
-            underlying layer. When set to true, only a single random sample is
-            drawn to determine if the batch should be passed to the underlying
-            layer. This is useful when using `MixUp()`, `CutMix()`, `Mosaic()`,
-            etc.
+            underlying layer. When set to `True`, each batch is passed to a
+            single layer, instead of each sample to an independent layer. This
+            is useful when using `MixUp()`, `CutMix()`, `Mosaic()`, etc.
+            Defaults to `False`.
         seed: Integer. Used to create a random seed.
     """
 

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -52,7 +52,7 @@ class RandomChoice(BaseImageAugmentationLayer):
             apply the augmentations. This offers a significant performance
             boost, but can only be used if all the layers provided to the
             `layers` argument support auto vectorization.
-        batchwise: (Optional) bool, whether to pass entire batches to the
+        batchwise: Boolean, whether to pass entire batches to the
             underlying layer. When set to `True`, each batch is passed to a
             single layer, instead of each sample to an independent layer. This
             is useful when using `MixUp()`, `CutMix()`, `Mosaic()`, etc.

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -52,6 +52,11 @@ class RandomChoice(BaseImageAugmentationLayer):
             apply the augmentations. This offers a significant performance
             boost, but can only be used if all the layers provided to the
             `layers` argument support auto vectorization.
+        batchwise: (Optional) bool, whether to pass entire batches to the
+            underlying layer. When set to true, only a single random sample is
+            drawn to determine if the batch should be passed to the underlying
+            layer. This is useful when using `MixUp()`, `CutMix()`, `Mosaic()`,
+            etc.
         seed: Integer. Used to create a random seed.
     """
 
@@ -59,12 +64,14 @@ class RandomChoice(BaseImageAugmentationLayer):
         self,
         layers,
         auto_vectorize=False,
+        batchwise=False,
         seed=None,
         **kwargs,
     ):
         super().__init__(**kwargs, seed=seed, force_generator=True)
         self.layers = layers
         self.auto_vectorize = auto_vectorize
+        self.batchwise = batchwise
         self.seed = seed
 
     def _curry_call_layer(self, inputs, layer):
@@ -73,11 +80,16 @@ class RandomChoice(BaseImageAugmentationLayer):
 
         return call_layer
 
+    def _batch_augment(self, inputs):
+        if self.batchwise:
+            return self._augment(inputs)
+        else:
+            return super()._batch_augment(inputs)
+
     def _augment(self, inputs, *args, **kwargs):
         selected_op = self._random_generator.random_uniform(
             (), minval=0, maxval=len(self.layers), dtype=tf.int32
         )
-
         # Warning:
         # Do not replace the currying function with a lambda.
         # Originally we used a lambda, but due to Python's
@@ -105,6 +117,7 @@ class RandomChoice(BaseImageAugmentationLayer):
                 "layers": self.layers,
                 "auto_vectorize": self.auto_vectorize,
                 "seed": self.seed,
+                "batchwise": self.batchwise,
             }
         )
         return config

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -73,7 +73,6 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
         }
         pipeline(xs)
 
-
     def test_calls_layer_augmentation_single_image(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -60,6 +60,8 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
         os = pipeline(xs)
 
         self.assertAllClose(xs + 1, os)
+        # Ensure the layer is only called once for the entire batch
+        self.assertEqual(layer.call_counter, 1)
 
     def test_works_with_cutmix_mixup(self):
         pipeline = layers.RandomChoice(

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -61,6 +61,17 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
+    def test_works_with_cutmix_mixup(self):
+        pipeline = layers.RandomChoice(
+            layers=[layers.CutMix(), layers.MixUp()], batchwise=True
+        )
+        xs = {
+            "images": tf.random.uniform((4, 5, 5, 3), 0, 100, dtype=tf.float32),
+            "labels": tf.random.uniform((4, 10), 0, 1, dtype=tf.float32),
+        }
+        pipeline(xs)
+
+
     def test_calls_layer_augmentation_single_image(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -53,6 +53,14 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
+    def test_batchwise(self):
+        layer = AddOneToInputs()
+        pipeline = layers.RandomChoice(layers=[layer], batchwise=True)
+        xs = tf.random.uniform((4, 5, 5, 3), 0, 100, dtype=tf.float32)
+        os = pipeline(xs)
+
+        self.assertAllClose(xs + 1, os)
+
     def test_calls_layer_augmentation_single_image(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])


### PR DESCRIPTION
# What does this PR do?

Adds a batchwise parameter to RandomChoice for use with `CutMix`, `MixUp`, etc

Usage:

```
pipeline = layers.RandomChoice(
    layers=[layers.CutMix(), layers.MixUp()], batchwise=True
)
xs = {
    "images": tf.random.uniform((4, 5, 5, 3), 0, 100, dtype=tf.float32),
    "labels": tf.random.uniform((4, 10), 0, 1, dtype=tf.float32),
}
pipeline(xs)
```