### PR TITLE
Fix bug in BoxCOCOMetrics

### DIFF
--- a/keras_cv/metrics/object_detection/box_coco_metrics.py
+++ b/keras_cv/metrics/object_detection/box_coco_metrics.py
@@ -173,7 +173,7 @@ class BoxCOCOMetrics(keras.metrics.Metric):
             y_true_classes = y_true["classes"]
             y_pred_boxes = y_pred["boxes"]
             y_pred_classes = y_pred["classes"]
-            y_pred_confidence = y_pred["classes"]
+            y_pred_confidence = y_pred["confidence"]
             eager_inputs = [
                 y_true_boxes,
                 y_true_classes,

--- a/keras_cv/metrics/object_detection/box_coco_metrics_test.py
+++ b/keras_cv/metrics/object_detection/box_coco_metrics_test.py
@@ -49,14 +49,14 @@ def load_samples(fname):
 
 
 golden_metrics = {
-    "MaP": 0.6194297,
+    "MaP": 0.61690974,
     "MaP@[IoU=50]": 1.0,
-    "MaP@[IoU=75]": 0.7079766,
-    "MaP@[area=small]": 0.6045385,
-    "MaP@[area=medium]": 0.6283987,
-    "MaP@[area=large]": 0.6143586,
-    "Recall@[max_detections=1]": 0.47537246,
-    "Recall@[max_detections=10]": 0.6450954,
+    "MaP@[IoU=75]": 0.70687747,
+    "MaP@[area=small]": 0.6041764,
+    "MaP@[area=medium]": 0.6262922,
+    "MaP@[area=large]": 0.61016285,
+    "Recall@[max_detections=1]": 0.47804594,
+    "Recall@[max_detections=10]": 0.6451851,
     "Recall@[max_detections=100]": 0.6484465,
     "Recall@[area=small]": 0.62842655,
     "Recall@[area=medium]": 0.65336424,


### PR DESCRIPTION
# What does this PR do?

Fixes what seems like a bug when calculating mAP metrics using box_coco_metrics.py. The update_state_fn was using the y_pred["classes"] instead of y_pred["confidence"]. 

I also updated the golden_metrics in box_coco_metrics_test.py to match the new values from the updated function. I'm not sure of the source of those golden metrics & whether its appropriate to update them to match my changes (!)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case. 
- [x] Did you write any new necessary tests? I modified the existing golden_metrics in box_coco_metrics_test.py

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.