### PR TITLE
Support the updated 3D data format in most 3D preprocessing KPLs

### DIFF
--- a/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
+++ b/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
@@ -261,7 +261,12 @@ def convert_from_model_format(inputs):
 
     box_tensors = [
         inputs["3d_boxes"]["boxes"],
-        tf.expand_dims(inputs["3d_boxes"]["classes"], axis=-1),
+        tf.expand_dims(
+            tf.cast(
+                inputs["3d_boxes"]["classes"], inputs["3d_boxes"]["boxes"].dtype
+            ),
+            axis=-1,
+        ),
         tf.expand_dims(
             tf.cast(
                 inputs["3d_boxes"]["mask"], inputs["3d_boxes"]["boxes"].dtype
@@ -273,7 +278,13 @@ def convert_from_model_format(inputs):
     # Special case for when we have a difficulty field
     if "difficulty" in inputs["3d_boxes"].keys():
         box_tensors.append(
-            tf.expand_dims(inputs["3d_boxes"]["difficulty"], axis=-1)
+            tf.expand_dims(
+                tf.cast(
+                    inputs["3d_boxes"]["difficulty"],
+                    inputs["3d_boxes"]["boxes"].dtype,
+                ),
+                axis=-1,
+            )
         )
 
     boxes = tf.concat(box_tensors, axis=-1)

--- a/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
+++ b/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
@@ -174,7 +174,6 @@ class BaseAugmentationLayer3D(keras.__internal__.layers.BaseRandomLayer):
                 BOUNDING_BOXES: bounding_boxes,
             }
             use_model_format = True
-            print("Using model format")
         else:
             point_clouds = inputs[POINT_CLOUDS]
             bounding_boxes = inputs[BOUNDING_BOXES]

--- a/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
+++ b/keras_cv/layers/preprocessing_3d/base_augmentation_layer_3d.py
@@ -167,7 +167,7 @@ class BaseAugmentationLayer3D(keras.__internal__.layers.BaseRandomLayer):
     def call(self, inputs):
         if "3d_boxes" in inputs.keys():
             # TODO(ianstenbit): Consider using the better format internally
-            # internally, instead of wrapping it at call time.
+            # (in the KPL implementations) instead of wrapping it at call time.
             point_clouds, bounding_boxes = convert_from_model_format(inputs)
             inputs = {
                 POINT_CLOUDS: point_clouds,

--- a/keras_cv/layers/preprocessing_3d/group_points_by_bounding_boxes.py
+++ b/keras_cv/layers/preprocessing_3d/group_points_by_bounding_boxes.py
@@ -243,6 +243,7 @@ class GroupPointsByBoundingBoxes(
         return result
 
     def call(self, inputs):
+        # TODO(ianstenbit): Support the model input format.
         point_clouds = inputs[POINT_CLOUDS]
         bounding_boxes = inputs[BOUNDING_BOXES]
         if point_clouds.shape.rank == 3 and bounding_boxes.shape.rank == 3:

--- a/keras_cv/layers/preprocessing_3d/input_format_test.py
+++ b/keras_cv/layers/preprocessing_3d/input_format_test.py
@@ -1,0 +1,111 @@
+# Copyright 2022 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import tensorflow as tf
+from absl.testing import parameterized
+
+from keras_cv.layers import preprocessing_3d
+from keras_cv.layers.preprocessing_3d import base_augmentation_layer_3d
+
+POINT_CLOUDS = base_augmentation_layer_3d.POINT_CLOUDS
+BOUNDING_BOXES = base_augmentation_layer_3d.BOUNDING_BOXES
+
+TEST_CONFIGURATIONS = [
+    (
+        "FrustrumRandomDroppingPoints",
+        preprocessing_3d.FrustumRandomDroppingPoints(
+            r_distance=0, theta_width=1, phi_width=1, drop_rate=0.5
+        ),
+    ),
+    (
+        "FrustrumRandomPointFeatureNoise",
+        preprocessing_3d.FrustumRandomPointFeatureNoise(
+            r_distance=10,
+            theta_width=np.pi,
+            phi_width=1.5 * np.pi,
+            max_noise_level=0.5,
+        ),
+    ),
+    (
+        "GlobalRandomDroppingPoints",
+        preprocessing_3d.GlobalRandomDroppingPoints(drop_rate=0.5),
+    ),
+    (
+        "GlobalRandomFlip",
+        preprocessing_3d.GlobalRandomFlip(),
+    ),
+    (
+        "GlobalRandomRotation",
+        preprocessing_3d.GlobalRandomRotation(
+            max_rotation_angle_x=1.0,
+            max_rotation_angle_y=1.0,
+            max_rotation_angle_z=1.0,
+        ),
+    ),
+    (
+        "GlobalRandomScaling",
+        preprocessing_3d.GlobalRandomScaling(
+            x_factor=(0.5, 1.5),
+            y_factor=(0.5, 1.5),
+            z_factor=(0.5, 1.5),
+        ),
+    ),
+    (
+        "GlobalRandomTranslation",
+        preprocessing_3d.GlobalRandomTranslation(
+            x_stddev=1.0, y_stddev=1.0, z_stddev=1.0
+        ),
+    ),
+    (
+        "RandomDropBox",
+        preprocessing_3d.RandomDropBox(
+            label_index=1, max_drop_bounding_boxes=4
+        ),
+    ),
+]
+
+
+def convert_to_model_format(inputs):
+    point_clouds = {
+        "point_xyz": inputs["point_clouds"][..., :3],
+        "point_feature": inputs["point_clouds"][..., 3:-1],
+        "point_mask": tf.cast(inputs["point_clouds"][..., -1], tf.bool),
+    }
+    boxes = {
+        "boxes": inputs["bounding_boxes"][..., :7],
+        "classes": inputs["bounding_boxes"][..., 7],
+        "difficulty": inputs["bounding_boxes"][..., -1],
+        "mask": tf.cast(inputs["bounding_boxes"][..., 8], tf.bool),
+    }
+    return {
+        "point_clouds": point_clouds,
+        "3d_boxes": boxes,
+    }
+
+
+class InputFormatTest(tf.test.TestCase, parameterized.TestCase):
+    @parameterized.named_parameters(*TEST_CONFIGURATIONS)
+    def test_equivalent_results_with_model_format(self, layer):
+        point_clouds = np.random.random(size=(3, 2, 50, 10)).astype("float32")
+        bounding_boxes = np.random.random(size=(3, 2, 10, 9)).astype("float32")
+        inputs = {POINT_CLOUDS: point_clouds, BOUNDING_BOXES: bounding_boxes}
+
+        tf.random.set_seed(123)
+        outputs_with_legacy_format = convert_to_model_format(layer(inputs))
+        tf.random.set_seed(123)
+        outputs_with_model_format = layer(convert_to_model_format(inputs))
+
+        self.assertAllClose(
+            outputs_with_legacy_format, outputs_with_model_format
+        )

--- a/keras_cv/layers/preprocessing_3d/random_copy_paste.py
+++ b/keras_cv/layers/preprocessing_3d/random_copy_paste.py
@@ -262,6 +262,7 @@ class RandomCopyPaste(base_augmentation_layer_3d.BaseAugmentationLayer3D):
         return result
 
     def call(self, inputs):
+        # TODO(ianstenbit): Support the model input format.
         point_clouds = inputs[POINT_CLOUDS]
         bounding_boxes = inputs[BOUNDING_BOXES]
         if point_clouds.shape.rank == 3 and bounding_boxes.shape.rank == 3:

--- a/keras_cv/layers/preprocessing_3d/swap_background.py
+++ b/keras_cv/layers/preprocessing_3d/swap_background.py
@@ -57,6 +57,7 @@ class SwapBackground(base_augmentation_layer_3d.BaseAugmentationLayer3D):
     """
 
     def __init__(self, **kwargs):
+        # TODO(ianstenbit): Support the model input format.
         super().__init__(**kwargs)
         self.auto_vectorize = False
 


### PR DESCRIPTION
There are a few that still need to be updated to use the new format.

This resolves a big ugly TODO in https://github.com/keras-team/keras-io/pull/1369, where we have to convert between formats after augmentation and before training the model. (This is the same API friction we previously had in 2D OD)

I added a new test to verify that the numerics are identical with both formats