### PR TITLE
bug fix for csp_darknet presets

### DIFF
--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -267,6 +267,12 @@ class CSPDarkNetSBackbone(CSPDarkNetBackbone):
         """Dictionary of preset names and configurations."""
         return {}
 
+    @classproperty
+    def presets_with_weights(cls):
+        """Dictionary of preset names and configurations that include
+        weights."""
+        return {}
+
 
 class CSPDarkNetMBackbone(CSPDarkNetBackbone):
     def __new__(
@@ -289,6 +295,12 @@ class CSPDarkNetMBackbone(CSPDarkNetBackbone):
     @classproperty
     def presets(cls):
         """Dictionary of preset names and configurations."""
+        return {}
+
+    @classproperty
+    def presets_with_weights(cls):
+        """Dictionary of preset names and configurations that include
+        weights."""
         return {}
 
 
@@ -347,6 +359,12 @@ class CSPDarkNetXLBackbone(CSPDarkNetBackbone):
     @classproperty
     def presets(cls):
         """Dictionary of preset names and configurations."""
+        return {}
+
+    @classproperty
+    def presets_with_weights(cls):
+        """Dictionary of preset names and configurations that include
+        weights."""
         return {}
 
 

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -137,6 +137,18 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         backbone = arch_class()
         backbone(tf.random.uniform(shape=[2, 256, 256, 3]))
 
+    @parameterized.named_parameters(
+        ("Tiny", csp_darknet_backbone.CSPDarkNetTinyBackbone),
+        ("S", csp_darknet_backbone.CSPDarkNetSBackbone),
+        ("M", csp_darknet_backbone.CSPDarkNetMBackbone),
+        ("L", csp_darknet_backbone.CSPDarkNetLBackbone),
+        ("XL", csp_darknet_backbone.CSPDarkNetXLBackbone),
+    )
+    def test_specific_arch_presets(self, arch_class):
+        self.assertDictEqual(
+            arch_class.presets, arch_class.presets_with_weights
+        )
+
 
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
Make sure the `.presets_with_weights()` for specific architectures are overridden.
Otherwise, it would return all the presets with weights from the base class.