### PR TITLE
Rename MaybeApply to RandomApply

### DIFF
--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -40,11 +40,11 @@ from keras_cv.layers.preprocessing.fourier_mix import FourierMix
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.jittered_resize import JitteredResize
-from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.mosaic import Mosaic
 from keras_cv.layers.preprocessing.posterization import Posterization
 from keras_cv.layers.preprocessing.rand_augment import RandAugment
+from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.random_aspect_ratio import RandomAspectRatio
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -40,7 +40,7 @@ from keras_cv.layers.preprocessing.fourier_mix import FourierMix
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.jittered_resize import JitteredResize
-from keras_cv.layers.preprocessing.maybe_apply import MaybeApply
+from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.mosaic import Mosaic
 from keras_cv.layers.preprocessing.posterization import Posterization

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -31,11 +31,11 @@ from keras_cv.layers.preprocessing.fourier_mix import FourierMix
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.jittered_resize import JitteredResize
-from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.mosaic import Mosaic
 from keras_cv.layers.preprocessing.posterization import Posterization
 from keras_cv.layers.preprocessing.rand_augment import RandAugment
+from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.random_aspect_ratio import RandomAspectRatio
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,

--- a/keras_cv/layers/preprocessing/__init__.py
+++ b/keras_cv/layers/preprocessing/__init__.py
@@ -31,7 +31,7 @@ from keras_cv.layers.preprocessing.fourier_mix import FourierMix
 from keras_cv.layers.preprocessing.grayscale import Grayscale
 from keras_cv.layers.preprocessing.grid_mask import GridMask
 from keras_cv.layers.preprocessing.jittered_resize import JitteredResize
-from keras_cv.layers.preprocessing.maybe_apply import MaybeApply
+from keras_cv.layers.preprocessing.random_apply import RandomApply
 from keras_cv.layers.preprocessing.mix_up import MixUp
 from keras_cv.layers.preprocessing.mosaic import Mosaic
 from keras_cv.layers.preprocessing.posterization import Posterization

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class MaybeApply(BaseImageAugmentationLayer):
+class RandomApply(BaseImageAugmentationLayer):
     """Apply provided layer to random elements in a batch.
 
     Args:
@@ -65,8 +65,8 @@ class MaybeApply(BaseImageAugmentationLayer):
     #         [0.288486  , 0.252975  ]]], dtype=float32)>
 
     # Apply the layer with 50% probability:
-    maybe_apply = MaybeApply(layer=zero_out, rate=0.5, seed=1234)
-    outputs = maybe_apply(images)
+    random_apply = RandomApply(layer=zero_out, rate=0.5, seed=1234)
+    outputs = random_apply(images)
     print(outputs[..., 0])
     # <tf.Tensor: shape=(5, 2, 2), dtype=float32, numpy=
     # array([[[0.        , 0.        ],

--- a/keras_cv/layers/serialization_test.py
+++ b/keras_cv/layers/serialization_test.py
@@ -181,8 +181,8 @@ class SerializationTest(tf.test.TestCase, parameterized.TestCase):
             },
         ),
         (
-            "MaybeApply",
-            cv_layers.MaybeApply,
+            "RandomApply",
+            cv_layers.RandomApply,
             {
                 "rate": 0.5,
                 "layer": None,

--- a/keras_cv/training/contrastive/simclr_trainer.py
+++ b/keras_cv/training/contrastive/simclr_trainer.py
@@ -74,11 +74,11 @@ class SimCLRAugmenter(keras.Sequential):
                     crop_area_factor=crop_area_factor,
                     aspect_ratio_factor=aspect_ratio_factor,
                 ),
-                preprocessing.MaybeApply(
+                preprocessing.RandomApply(
                     preprocessing.Grayscale(output_channels=3),
                     rate=grayscale_rate,
                 ),
-                preprocessing.MaybeApply(
+                preprocessing.RandomApply(
                     preprocessing.RandomColorJitter(
                         value_range=value_range,
                         brightness_factor=brightness_factor,


### PR DESCRIPTION
This PR renames the MaybeApply preprocessing layer to RandomApply to match standard naming conventions both within and external to keras_cv.

Fixes #1609

This PR would require updating guides in the keras-io repo. [Here](https://github.com/keras-team/keras-io/pull/1374) is the link to the PR for that makes those changes.

## Who can review?
@ianstenbit @LukeWood @jbischof @innat 