### PR TITLE
Mark RetinaNetSmokeTest "extra_large"

### DIFF
--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -226,7 +226,8 @@ class RetinaNetTest(tf.test.TestCase):
         self.assertEqual(serialized_1, serialized_2)
 
 
-@pytest.mark.large
+# TODO(jbischof): reduce back to "large" once #1725 fixed
+@pytest.mark.extra_large
 class RetinaNetSmokeTest(tf.test.TestCase):
     def test_backbone_preset_weight_loading(self):
         # Check that backbone preset weights loaded correctly


### PR DESCRIPTION
Our RetinaNet task preset throws on TF 2.11, which we officially support and use for GCB testing. Marking "extra_large" (manual runs only) until #1725 resolved. 