### PR TITLE
Mark saving & fitting tests "large" and test `models/` on CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         TEST_CUSTOM_OPS: true
       run: |
-        pytest keras_cv/ --ignore keras_cv/models
+        pytest keras_cv/ --ignore keras_cv/models/legacy/
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,7 +43,7 @@ jobs:
       env:
         TEST_CUSTOM_OPS: true
       run: |
-        pytest keras_cv/ --ignore keras_cv/models/legacy/
+        pytest keras_cv/ --ignore keras_cv/models/legacy/ --durations 0
   format:
     name: Check the code format
     runs-on: ubuntu-latest

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -31,6 +31,7 @@ class PyCOCOCallbackTest(tf.test.TestCase):
         yield
         keras.backend.clear_session()
 
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_model_fit_retinanet(self):
         model = keras_cv.models.RetinaNet(
             num_classes=10,

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -50,6 +51,7 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = csp_darknet_backbone.CSPDarkNetBackbone(
             stackwise_channels=[48, 96, 192, 384],
@@ -74,6 +76,7 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_alias_model(self, save_format, filename):
         model = csp_darknet_backbone.CSPDarkNetLBackbone()
         model_output = model(self.input_batch)

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import pytest
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import pytest
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -85,6 +86,7 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = EfficientNetV2Backbone(
             stackwise_kernel_sizes=[3, 3, 3, 3, 3, 3],
@@ -122,6 +124,7 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_alias_model(self, save_format, filename):
         model = EfficientNetV2SBackbone()
         model_output = model(self.input_batch)

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -61,6 +62,7 @@ class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = MobileNetV3SmallBackbone()
         model_output = model(self.input_batch)

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import pytest
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -66,6 +67,7 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = ResNetBackbone(
             stackwise_filters=[64, 128, 256, 512],
@@ -89,6 +91,7 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_alias_model(self, save_format, filename):
         model = ResNet50Backbone()
         model_output = model(self.input_batch)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import pytest
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 import tensorflow as tf
 from absl.testing import parameterized
@@ -57,6 +58,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = ResNetV2Backbone(
             stackwise_filters=[64, 128, 256, 512],
@@ -80,6 +82,7 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_alias_model(self, save_format, filename):
         model = ResNet50V2Backbone()
         model_output = model(self.input_batch)

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import pytest
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -41,10 +41,10 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @pytest.mark.large  # Fit is slow, so mark these large.
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_classifier_fit(self, jit_compile):
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -41,6 +41,7 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
+    @pytest.mark.large  # Fit is slow, so mark these large.
     @parameterized.named_parameters(
         ("jit_compile_false", False), ("jit_compile_true", True)
     )
@@ -80,6 +81,7 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),
     )
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self, save_format, filename):
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),

--- a/keras_cv/models/legacy/models_test.py
+++ b/keras_cv/models/legacy/models_test.py
@@ -162,6 +162,7 @@ class ModelsTest:
         model = keras.Model(inputs=inputs, outputs=[backbone_output])
         model.compile()
 
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def _test_model_serialization(self, app, _, args, save_format, filename):
         model = app(include_rescaling=True, include_top=False, **args)
         input_batch = tf.ones(shape=(16, 224, 224, 3))

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -210,9 +210,8 @@ class RetinaNetTest(tf.test.TestCase):
         for w1, w2 in zip(original_fpn_weights, fpn_after_fit):
             self.assertNotAllClose(w1, w2)
 
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_serialization(self):
-        # TODO(haifengj): Reuse test code from
-        # ModelTest._test_model_serialization.
         model = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -134,6 +134,7 @@ class RetinaNetTest(tf.test.TestCase):
         # box_head
         self.assertIn("prediction_head_1/conv2d_12/kernel:0", variable_names)
 
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_no_nans(self):
         retina_net = keras_cv.models.RetinaNet(
             num_classes=2,
@@ -162,6 +163,7 @@ class RetinaNetTest(tf.test.TestCase):
         for weight in weights:
             self.assertFalse(tf.math.reduce_any(tf.math.is_nan(weight)))
 
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_weights_change(self):
         bounding_box_format = "xywh"
         retinanet = keras_cv.models.RetinaNet(

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
@@ -28,6 +28,7 @@ from keras_cv.models.object_detection.yolo_v8.yolo_v8_detector_presets import (
 
 
 class YOLOV8DetectorTest(tf.test.TestCase):
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_fit(self):
         bounding_box_format = "xywh"
         yolo = keras_cv.models.YOLOV8Detector(
@@ -83,6 +84,7 @@ class YOLOV8DetectorTest(tf.test.TestCase):
         ):
             yolo.compile(box_loss="iou", classification_loss="bad_loss")
 
+    @pytest.mark.large  # Saving is slow, so mark these large.
     def test_serialization(self):
         model = keras_cv.models.YOLOV8Detector(
             num_classes=20,


### PR DESCRIPTION
Part of #1738

Saving and fit tests are in aggreggate the most of our testing time. Mark these as `"large"` and only run on GCB.

We can then run the rest of the tests in `keras_cv/models` as part of our CI.

