### PR TITLE
Test legacy on GCB

### DIFF
--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -34,7 +34,7 @@ local unittest = base.BaseTest {
     |||
   ],
   command: [
-    'pytest --ignore keras_cv/models/legacy/ --run_large --durations 0',
+    'pytest --run_large --durations 0',
     'keras_cv',
   ],
 };

--- a/cloudbuild/unit_test_jobs.jsonnet
+++ b/cloudbuild/unit_test_jobs.jsonnet
@@ -27,7 +27,6 @@ local unittest = base.BaseTest {
       bazel-5.4.0 build keras_cv/custom_ops:all --verbose_failures
       cp bazel-bin/keras_cv/custom_ops/*.so keras_cv/custom_ops/
       export TEST_CUSTOM_OPS=true
-      export INTEGRATION=true
 
       # Run whatever is in `command` here.
       ${@:0}

--- a/keras_cv/models/legacy/README.md
+++ b/keras_cv/models/legacy/README.md
@@ -1,8 +1,8 @@
 # Legacy folder
 
 These are models that we intend to migrate to the unified KerasNLP/KerasCV API 
-but have not yet had the opportunity. We have verified that unit tests and 
-pretrained weights are working, but will only check this manually going forward.
+but have not yet had the opportunity. Units tests in this folder are run on
+every PR.
 
 Do not use legacy models unless they fill a short term need and you are
 comfortable moving to the new API once they are migrated. Anything which we

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
 from tensorflow.keras import optimizers
 
-import keras_cv
 from keras_cv.models import ResNet50V2Backbone
 from keras_cv.models.legacy.object_detection.faster_rcnn.faster_rcnn import (
     FasterRCNN,

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
@@ -79,14 +79,9 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
                 )
             )
 
-    @pytest.mark.skipif(
-        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
-        reason="Takes a long time to run, only runs when INTEGRATION "
-        "environment variable is set. To run the test please run: \n"
-        "`INTEGRATION=true pytest keras_cv/",
-    )
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_faster_rcnn_with_dictionary_input_format(self):
-        faster_rcnn = keras_cv.models.FasterRCNN(
+        faster_rcnn = FasterRCNN(
             num_classes=20,
             bounding_box_format="xywh",
             backbone=ResNet50V2Backbone(),

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import os
 
 import pytest
 import tensorflow as tf
@@ -53,12 +52,7 @@ class RetinaNetTest(tf.test.TestCase):
         # self.assertIsNotNone(retinanet.backbone.get_layer(name="rescaling"))
         # TODO(lukewood): test compile with the FocalLoss class
 
-    @pytest.mark.skipif(
-        "INTEGRATION" not in os.environ or os.environ["INTEGRATION"] != "true",
-        reason="Takes a long time to run, only runs when INTEGRATION "
-        "environment variable is set. To run the test please run: \n"
-        "`INTEGRATION=true pytest keras_cv/",
-    )
+    @pytest.mark.large  # Fit is slow, so mark these large.
     def test_retinanet_call(self):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=20,


### PR DESCRIPTION
Part of #1738 

We should keep monitoring legacy tests on GCB at least. These tests are small and since we plan to migrate the code soon we don't actually want it to be broken.

We can also remove the `"INTEGRATION"` pytest tag, which is now replaced by `"large"`. That's a lot less boilerplate!