### PR TITLE
Fix __init__.py behavior for `legacy` folder

### DIFF
--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.models import legacy
 from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone import (
     CSPDarkNetBackbone,
 )
@@ -100,7 +101,6 @@ from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
 )
 from keras_cv.models.classification.image_classifier import ImageClassifier
-from keras_cv.models import legacy
 from keras_cv.models.object_detection.retinanet.retinanet import RetinaNet
 from keras_cv.models.object_detection.yolo_v8.yolo_v8_backbone import (
     YOLOV8Backbone,

--- a/keras_cv/models/__init__.py
+++ b/keras_cv/models/__init__.py
@@ -100,6 +100,7 @@ from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone import (
     ResNetV2Backbone,
 )
 from keras_cv.models.classification.image_classifier import ImageClassifier
+from keras_cv.models import legacy
 from keras_cv.models.object_detection.retinanet.retinanet import RetinaNet
 from keras_cv.models.object_detection.yolo_v8.yolo_v8_backbone import (
     YOLOV8Backbone,

--- a/keras_cv/models/legacy/object_detection/__init__.py
+++ b/keras_cv/models/legacy/object_detection/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/keras_cv/models/legacy/segmentation/__init__.py
+++ b/keras_cv/models/legacy/segmentation/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-


### PR DESCRIPTION
Currently get error

```
AttributeError: module 'keras_cv.models' has no attribute 'legacy'
```

when trying to use any of the models in the `keras_cv.models.legacy` namespace.