### PR TITLE
Add saving tests for object detection

### DIFF
--- a/keras_cv/models/object_detection/retinanet/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retinanet/feature_pyramid.py
@@ -34,9 +34,9 @@ class FeaturePyramid(keras.layers.Layer):
 
     def call(self, inputs, training=False):
         if isinstance(inputs, dict):
-            c3_output = inputs[3]
-            c4_output = inputs[4]
-            c5_output = inputs[5]
+            c3_output = inputs["3"]
+            c4_output = inputs["4"]
+            c5_output = inputs["5"]
         else:
             c3_output, c4_output, c5_output = inputs
         p3_output = self.conv_c3_1x1(c3_output, training=training)

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -532,9 +532,23 @@ class RetinaNet(Task):
             "backbone": keras.utils.serialize_keras_object(self.backbone),
             "label_encoder": self.label_encoder,
             "prediction_decoder": self._prediction_decoder,
-            "classification_head": self.classification_head,
-            "box_head": self.box_head,
+            "classification_head": keras.utils.serialize_keras_object(
+                self.classification_head
+            ),
+            "box_head": keras.utils.serialize_keras_object(self.box_head),
         }
+
+    @classmethod
+    def from_config(cls, config):
+        config.update(
+            {
+                "box_head": keras.layers.deserialize(config["box_head"]),
+                "classification_head": keras.layers.deserialize(
+                    config["classification_head"]
+                ),
+            }
+        )
+        return super().from_config(config)
 
     @classproperty
     def presets(cls):

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -163,9 +163,10 @@ class RetinaNet(Task):
             box_variance=BOX_VARIANCE,
         )
 
-        extractor_levels = [3, 4, 5]
+        # Using strings to keep the TF saving flow happy.
+        extractor_levels = ["3", "4", "5"]
         extractor_layer_names = [
-            backbone.pyramid_level_inputs[i] for i in extractor_levels
+            backbone.pyramid_level_inputs[int(i)] for i in extractor_levels
         ]
         feature_extractor = get_feature_extractor(
             backbone, extractor_layer_names, extractor_levels

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -541,14 +541,14 @@ class RetinaNet(Task):
 
     @classmethod
     def from_config(cls, config):
-        config.update(
-            {
-                "box_head": keras.layers.deserialize(config["box_head"]),
-                "classification_head": keras.layers.deserialize(
-                    config["classification_head"]
-                ),
-            }
-        )
+        if "box_head" in config and isinstance(config["box_head"], dict):
+            config["box_head"] = keras.layers.deserialize(config["box_head"])
+        if "classification_head" in config and isinstance(
+            config["classification_head"], dict
+        ):
+            config["classification_head"] = keras.layers.deserialize(
+                config["classification_head"]
+            )
         return super().from_config(config)
 
     @classproperty

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import os
 
 import pytest

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -28,12 +28,6 @@ from keras_cv.models.object_detection.__test_utils__ import (
 
 
 class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
-    def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
-        self.dataset = tf.data.Dataset.from_tensor_slices(
-            (self.input_batch, tf.one_hot(tf.ones((2,), dtype="int32"), 2))
-        ).batch(4)
-
     @pytest.fixture(autouse=True)
     def cleanup_global_session(self):
         # Code before yield runs before the test
@@ -225,7 +219,8 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
             bounding_box_format="xywh",
             backbone=keras_cv.models.ResNet18V2Backbone(),
         )
-        model_output = model(self.input_batch)
+        input_batch = tf.ones(shape=(2, 224, 224, 3))
+        model_output = model(input_batch)
         save_path = os.path.join(self.get_temp_dir(), filename)
         model.save(save_path, save_format=save_format)
         restored_model = keras.models.load_model(save_path)
@@ -234,7 +229,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         self.assertIsInstance(restored_model, keras_cv.models.RetinaNet)
 
         # Check that output matches.
-        restored_output = restored_model(self.input_batch)
+        restored_output = restored_model(input_batch)
         self.assertAllClose(model_output, restored_output)
 
 

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -214,20 +214,6 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         for w1, w2 in zip(original_fpn_weights, fpn_after_fit):
             self.assertNotAllClose(w1, w2)
 
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_serialization(self):
-        model = keras_cv.models.RetinaNet(
-            num_classes=20,
-            bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet18V2Backbone(),
-        )
-        serialized_1 = keras.utils.serialize_keras_object(model)
-        restored = keras.utils.deserialize_keras_object(
-            copy.deepcopy(serialized_1)
-        )
-        serialized_2 = keras.utils.serialize_keras_object(restored)
-        self.assertEqual(serialized_1, serialized_2)
-
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import copy
+import os
 
 import pytest
 import tensorflow as tf
+from absl.testing import parameterized
 from tensorflow import keras
 from tensorflow.keras import optimizers
 
@@ -25,7 +27,13 @@ from keras_cv.models.object_detection.__test_utils__ import (
 )
 
 
-class RetinaNetTest(tf.test.TestCase):
+class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
+    def setUp(self):
+        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.dataset = tf.data.Dataset.from_tensor_slices(
+            (self.input_batch, tf.one_hot(tf.ones((2,), dtype="int32"), 2))
+        ).batch(4)
+
     @pytest.fixture(autouse=True)
     def cleanup_global_session(self):
         # Code before yield runs before the test
@@ -40,7 +48,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
         retinanet.compile(
             classification_loss="focal",
@@ -48,7 +56,7 @@ class RetinaNetTest(tf.test.TestCase):
             optimizer="adam",
         )
 
-        # TODO(lukewood) uncomment when using keras_cv.models.ResNet50
+        # TODO(lukewood) uncomment when using keras_cv.models.ResNet18
         # self.assertIsNotNone(retinanet.backbone.get_layer(name="rescaling"))
         # TODO(lukewood): test compile with the FocalLoss class
 
@@ -57,7 +65,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
         images = tf.random.uniform((2, 512, 512, 3))
         _ = retinanet(images)
@@ -67,7 +75,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
 
         with self.assertRaisesRegex(
@@ -88,7 +96,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
 
         retinanet.compile(
@@ -106,7 +114,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format=bounding_box_format,
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
         retinanet.backbone.trainable = False
         retinanet.compile(
@@ -133,7 +141,7 @@ class RetinaNetTest(tf.test.TestCase):
         retina_net = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
 
         retina_net.compile(
@@ -163,7 +171,7 @@ class RetinaNetTest(tf.test.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format=bounding_box_format,
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
 
         retinanet.compile(
@@ -211,7 +219,7 @@ class RetinaNetTest(tf.test.TestCase):
         model = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.ResNet18V2Backbone(),
         )
         serialized_1 = keras.utils.serialize_keras_object(model)
         restored = keras.utils.deserialize_keras_object(
@@ -219,6 +227,29 @@ class RetinaNetTest(tf.test.TestCase):
         )
         serialized_2 = keras.utils.serialize_keras_object(restored)
         self.assertEqual(serialized_1, serialized_2)
+
+    @parameterized.named_parameters(
+        ("tf_format", "tf", "model"),
+        ("keras_format", "keras_v3", "model.keras"),
+    )
+    @pytest.mark.large  # Saving is slow, so mark these large.
+    def test_saved_model(self, save_format, filename):
+        model = keras_cv.models.RetinaNet(
+            num_classes=20,
+            bounding_box_format="xywh",
+            backbone=keras_cv.models.ResNet18V2Backbone(),
+        )
+        model_output = model(self.input_batch)
+        save_path = os.path.join(self.get_temp_dir(), filename)
+        model.save(save_path, save_format=save_format)
+        restored_model = keras.models.load_model(save_path)
+
+        # Check we got the real object back.
+        self.assertIsInstance(restored_model, keras_cv.models.RetinaNet)
+
+        # Check that output matches.
+        restored_output = restored_model(self.input_batch)
+        self.assertAllClose(model_output, restored_output)
 
 
 # TODO(jbischof): reduce back to "large" once #1725 fixed

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -396,9 +396,10 @@ class YOLOV8Detector(Task):
         prediction_decoder=None,
         **kwargs,
     ):
-        extractor_levels = [3, 4, 5]
+        # Using strings to keep the TF saving flow happy.
+        extractor_levels = ["3", "4", "5"]
         extractor_layer_names = [
-            backbone.pyramid_level_inputs[i] for i in extractor_levels
+            backbone.pyramid_level_inputs[int(i)] for i in extractor_levels
         ]
         feature_extractor = get_feature_extractor(
             backbone, extractor_layer_names, extractor_levels

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import os
 
 import pytest

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
@@ -86,23 +86,6 @@ class YOLOV8DetectorTest(tf.test.TestCase, parameterized.TestCase):
         ):
             yolo.compile(box_loss="iou", classification_loss="bad_loss")
 
-    @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_serialization(self):
-        model = keras_cv.models.YOLOV8Detector(
-            num_classes=20,
-            bounding_box_format="xywh",
-            fpn_depth=1,
-            backbone=keras_cv.models.YOLOV8Backbone.from_preset(
-                "yolo_v8_xs_backbone"
-            ),
-        )
-        serialized_1 = keras.utils.serialize_keras_object(model)
-        restored = keras.utils.deserialize_keras_object(
-            copy.deepcopy(serialized_1)
-        )
-        serialized_2 = keras.utils.serialize_keras_object(restored)
-        self.assertEqual(serialized_1, serialized_2)
-
     @parameterized.named_parameters(
         ("tf_format", "tf", "model"),
         ("keras_format", "keras_v3", "model.keras"),

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_test.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import copy
+import os
 
 import pytest
 import tensorflow as tf
+from absl.testing import parameterized
 from tensorflow import keras
 
 import keras_cv
@@ -27,7 +29,7 @@ from keras_cv.models.object_detection.yolo_v8.yolo_v8_detector_presets import (
 )
 
 
-class YOLOV8DetectorTest(tf.test.TestCase):
+class YOLOV8DetectorTest(tf.test.TestCase, parameterized.TestCase):
     @pytest.mark.large  # Fit is slow, so mark these large.
     def test_fit(self):
         bounding_box_format = "xywh"
@@ -100,6 +102,33 @@ class YOLOV8DetectorTest(tf.test.TestCase):
         )
         serialized_2 = keras.utils.serialize_keras_object(restored)
         self.assertEqual(serialized_1, serialized_2)
+
+    @parameterized.named_parameters(
+        ("tf_format", "tf", "model"),
+        ("keras_format", "keras_v3", "model.keras"),
+    )
+    @pytest.mark.large  # Saving is slow, so mark these large.
+    def test_saved_model(self, save_format, filename):
+        model = keras_cv.models.YOLOV8Detector(
+            num_classes=20,
+            bounding_box_format="xywh",
+            fpn_depth=1,
+            backbone=keras_cv.models.YOLOV8Backbone.from_preset(
+                "yolo_v8_xs_backbone"
+            ),
+        )
+        xs, _ = _create_bounding_box_dataset("xywh")
+        model_output = model(xs)
+        save_path = os.path.join(self.get_temp_dir(), filename)
+        model.save(save_path, save_format=save_format)
+        restored_model = keras.models.load_model(save_path)
+
+        # Check we got the real object back.
+        self.assertIsInstance(restored_model, keras_cv.models.YOLOV8Detector)
+
+        # Check that output matches.
+        restored_output = restored_model(xs)
+        self.assertAllClose(model_output, restored_output)
 
 
 @pytest.mark.large


### PR DESCRIPTION
Fixes #1812.

Currently we only have serialization tests for OD models. This is a much lower threshold and it seems that saving does not work.

The fix is to properly serialize all subclasses and to use string keys for `pyramid_level_inputs`. We do this post hoc here but the correct long term fix is to change the format of this method (#1820).

Also move to `ResNet18Backbone` for `RetinaNet` tests to improve speed.

Ran `pytest keras_cv/models/object_detection/retinanet/ --run_extra_large` before merging.