### PR TITLE
Use `result` instead of `evaluate` in WaymoEvaluationCallback

### DIFF
--- a/keras_cv/callbacks/waymo_evaluation_callback.py
+++ b/keras_cv/callbacks/waymo_evaluation_callback.py
@@ -83,7 +83,7 @@ class WaymoEvaluationCallback(Callback):
         gt, preds = self._eval_dataset(self.val_data)
         self.evaluator.update_state(gt, preds)
 
-        metrics = self.evaluator.evaluate()
+        metrics = self.evaluator.result()
 
         metrics_dict = {
             "average_precision_vehicle_l1": metrics.average_precision[0],


### PR DESCRIPTION
`result` resets the state, while `evaluate` does not.

We _do_ want to reset the state when we evaluate the metric, so this was previously incorrect.

See upstream Waymo source here:
https://github.com/waymo-research/waymo-open-dataset/blob/master/src/waymo_open_dataset/metrics/python/wod_detection_evaluator.py#L88

I've verified this change in training runs of this model with Waymo -- without the change, the metrics are completely incorrect.