### PR TITLE
Exclude the `backbone` from Task model summaries

### DIFF
--- a/keras_cv/models/object_detection/retinanet/retinanet_presets.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_presets.py
@@ -33,7 +33,7 @@ retinanet_presets = {
             # performance.
             "num_classes": 20,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50-v3-no-duplicate-backbone.h5",  # noqa: E501
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50-v4.h5",  # noqa: E501
         "weights_hash": "961f6f9a03c869900d61ae74a9f0c31c6439b4f81f13593f5c16c4733061fbac",  # noqa: E501
     },
 }

--- a/keras_cv/models/object_detection/retinanet/retinanet_presets.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_presets.py
@@ -33,7 +33,7 @@ retinanet_presets = {
             # performance.
             "num_classes": 20,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50-v3.weights.h5",  # noqa: E501
-        "weights_hash": "84f51edc5d669109187b9c60edee1e55",
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/retinanet/pascal_voc/resnet50-v3-no-duplicate-backbone.h5",  # noqa: E501
+        "weights_hash": "961f6f9a03c869900d61ae74a9f0c31c6439b4f81f13593f5c16c4733061fbac",  # noqa: E501
     },
 }

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
@@ -33,7 +33,7 @@ yolo_v8_detector_presets = {
             "num_classes": 20,
             "fpn_depth": 2,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/yolov8/pascal_voc/yolov8_m_no_duplicate_backbone.h5",  # noqa: E501
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/yolov8/pascal_voc/yolov8_m_v1.h5",  # noqa: E501
         "weights_hash": "2891fbd66f71e0b9da0cb02ef3afbccb819e1b8f18204157f643f4ec058a71a8",  # noqa: E501
     },
 }

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
@@ -33,7 +33,7 @@ yolo_v8_detector_presets = {
             "num_classes": 20,
             "fpn_depth": 2,
         },
-        "weights_url": "https://storage.googleapis.com/keras-cv/models/yolov8/pascal_voc/yolov8_m.h5",  # noqa: E501
-        "weights_hash": "e641690aec205a3ca1ea730ea362ddc36c8b4a5abcebb6a23b18cbc9c091316d",  # noqa: E501
+        "weights_url": "https://storage.googleapis.com/keras-cv/models/yolov8/pascal_voc/yolov8_m_no_duplicate_backbone.h5",  # noqa: E501
+        "weights_hash": "2891fbd66f71e0b9da0cb02ef3afbccb819e1b8f18204157f643f4ec058a71a8",  # noqa: E501
     },
 }

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -152,6 +152,14 @@ class Task(keras.Model):
         model.load_weights(weights)
         return model
 
+    @property
+    def layers(self):
+        # Remove preprocessor from layers so it does not show up in the summary.
+        layers = super().layers
+        if hasattr(self, "_backbone") and self.backbone in layers:
+            layers.remove(self.backbone)
+        return layers
+
     def __init_subclass__(cls, **kwargs):
         # Use __init_subclass__ to set up a correct docstring for from_preset.
         super().__init_subclass__(**kwargs)

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -154,10 +154,16 @@ class Task(keras.Model):
 
     @property
     def layers(self):
-        # Remove preprocessor from layers so it does not show up in the summary.
+        # Some of our task models don't use the Backbone directly, but create
+        # a feature extractor from it. In these cases, we don't want to count
+        # the `backbone` as a layer, because it will be included in the model
+        # summary and saves weights despite not being part of the model graph.
         layers = super().layers
         if hasattr(self, "_backbone") and self.backbone in layers:
-            layers.remove(self.backbone)
+            # We know that the backbone is not part of the graph if it has no
+            # inbound nodes.
+            if len(self.backbone._inbound_nodes) == 0:
+                layers.remove(self.backbone)
         return layers
 
     def __init_subclass__(cls, **kwargs):


### PR DESCRIPTION
This is related to #1818.

In debugging that, I realized that we currently include the `backbone` in task model summaries twice (once as the feature extractor, and again as the "backbone" param that lives on the model but isn't connected to the graph.

This removes the disconnected backbone param from the summary, as it's not really relevant.