### PR TITLE
Mark the RetinaNetSmoke test as large, since #1725 is fixed

### DIFF
--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -232,8 +232,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose(model_output, restored_output)
 
 
-# TODO(jbischof): reduce back to "large" once #1725 fixed
-@pytest.mark.extra_large
+@pytest.mark.large
 class RetinaNetSmokeTest(tf.test.TestCase):
     def test_backbone_preset_weight_loading(self):
         # Check that backbone preset weights loaded correctly


### PR DESCRIPTION
This is passing on tf 2.11 as of #1824 so we can add it to our CI again