### PR TITLE
Change pyramid_level_inputs to have string keys

### DIFF
--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -158,18 +158,19 @@ class Backbone(keras.Model):
     def pyramid_level_inputs(self):
         """Intermediate model outputs for feature extraction.
 
-        Format is a dictionary with int as key and layer name as value.
-        The int key represent the level of the feature output. A typical feature
-        pyramid has five levels corresponding to scales P3, P4, P5, P6, P7 in
-        the backbone. Scale Pn represents a feature map 2^n times smaller in
-        width and height than the input image.
+        Format is a dictionary with string as key and layer name as value.
+        The string key represents the level of the feature output. A typical
+        feature pyramid has five levels corresponding to scales P3, P4, P5,
+        P6, P7 in the backbone. Scale Pn represents a feature map 2^n times
+        smaller in width and height than the input image.
+        String keys are necessary to make Tensorflow saving flow happy.
 
         Example:
         ```python
         {
-            3: 'v2_stack_1_block4_out',
-            4: 'v2_stack_2_block6_out',
-            5: 'v2_stack_3_block3_out',
+            'P3': 'v2_stack_1_block4_out',
+            'P4': 'v2_stack_2_block6_out',
+            'P5': 'v2_stack_3_block3_out',
         }
         ```
         """

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -160,10 +160,9 @@ class Backbone(keras.Model):
 
         Format is a dictionary with string as key and layer name as value.
         The string key represents the level of the feature output. A typical
-        feature pyramid has five levels corresponding to scales P3, P4, P5,
-        P6, P7 in the backbone. Scale Pn represents a feature map 2^n times
-        smaller in width and height than the input image.
-        String keys are necessary to make Tensorflow saving flow happy.
+        feature pyramid has five levels corresponding to scales "P3", "P4",
+        "P5", "P6", "P7" in the backbone. Scale Pn represents a feature map 2^n
+        times smaller in width and height than the input image.
 
         Example:
         ```python

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -144,7 +144,7 @@ class CSPDarkNetBackbone(Backbone):
                 residual=(index != len(stackwise_depth) - 1),
                 name=f"dark{index + 2}_csp",
             )(x)
-            pyramid_level_inputs["P" + str(index + 2)] = x.node.layer.name
+            pyramid_level_inputs[f"P{index + 2}"] = x.node.layer.name
 
         super().__init__(inputs=inputs, outputs=x, **kwargs)
         self.pyramid_level_inputs = pyramid_level_inputs

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -144,7 +144,7 @@ class CSPDarkNetBackbone(Backbone):
                 residual=(index != len(stackwise_depth) - 1),
                 name=f"dark{index + 2}_csp",
             )(x)
-            pyramid_level_inputs[index + 2] = x.node.layer.name
+            pyramid_level_inputs["P" + str(index + 2)] = x.node.layer.name
 
         super().__init__(inputs=inputs, outputs=x, **kwargs)
         self.pyramid_level_inputs = pyramid_level_inputs

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -106,8 +106,9 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         inputs = keras.Input(shape=[224, 224, 3])
         outputs = backbone_model(inputs)
         # CSPDarkNet backbone has 4 level of features (P2 ~ P5)
+        levels = ["P2", "P3", "P4", "P5"]
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P2"].shape, [None, 56, 56, 128])
         self.assertEquals(outputs["P3"].shape, [None, 28, 28, 256])
         self.assertEquals(outputs["P4"].shape, [None, 14, 14, 512])
@@ -120,14 +121,12 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=True,
         )
         levels = ["P3", "P4"]
-        layer_names = [
-            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
-        ]
+        layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 96])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 192])
 

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -105,13 +105,13 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         inputs = keras.Input(shape=[224, 224, 3])
         outputs = backbone_model(inputs)
-        # CSPDarkNet backbone has 4 level of features (2 ~ 5)
+        # CSPDarkNet backbone has 4 level of features (P2 ~ P5)
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), [2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 56, 56, 128])
-        self.assertEquals(outputs[3].shape, [None, 28, 28, 256])
-        self.assertEquals(outputs[4].shape, [None, 14, 14, 512])
-        self.assertEquals(outputs[5].shape, [None, 7, 7, 1024])
+        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(outputs["P2"].shape, [None, 56, 56, 128])
+        self.assertEquals(outputs["P3"].shape, [None, 28, 28, 256])
+        self.assertEquals(outputs["P4"].shape, [None, 14, 14, 512])
+        self.assertEquals(outputs["P5"].shape, [None, 7, 7, 1024])
 
     def test_create_backbone_model_with_level_config(self):
         model = csp_darknet_backbone.CSPDarkNetBackbone(
@@ -119,15 +119,17 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             stackwise_depth=[1, 3, 3, 1],
             include_rescaling=True,
         )
-        levels = [3, 4]
-        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        levels = ["P3", "P4"]
+        layer_names = [
+            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
+        ]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 96])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 192])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 96])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 192])
 
     @parameterized.named_parameters(
         ("Tiny", csp_darknet_backbone.CSPDarkNetTinyBackbone),

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
@@ -257,7 +257,7 @@ class EfficientNetV2Backbone(Backbone):
         self.activation = activation
         self.input_tensor = input_tensor
         self.pyramid_level_inputs = {
-            "P" + str(i + 1): name
+            f"P{i + 1}": name
             for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_kernel_sizes = stackwise_kernel_sizes

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
@@ -257,7 +257,8 @@ class EfficientNetV2Backbone(Backbone):
         self.activation = activation
         self.input_tensor = input_tensor
         self.pyramid_level_inputs = {
-            i + 1: name for i, name in enumerate(pyramid_level_inputs)
+            "P" + str(i + 1): name
+            for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_kernel_sizes = stackwise_kernel_sizes
         self.stackwise_num_repeats = stackwise_num_repeats

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
@@ -257,8 +257,7 @@ class EfficientNetV2Backbone(Backbone):
         self.activation = activation
         self.input_tensor = input_tensor
         self.pyramid_level_inputs = {
-            f"P{i + 1}": name
-            for i, name in enumerate(pyramid_level_inputs)
+            f"P{i + 1}": name for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_kernel_sizes = stackwise_kernel_sizes
         self.stackwise_num_repeats = stackwise_num_repeats

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
@@ -48,12 +48,14 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
             input_shape=[256, 256, 3],
         )
-        levels = [3, 4]
-        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        levels = ["P3", "P4"]
+        layer_names = [
+            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
+        ]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = tf.keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape[:3], [None, 32, 32])
-        self.assertEquals(outputs[4].shape[:3], [None, 16, 16])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(outputs["P3"].shape[:3], [None, 32, 32])
+        self.assertEquals(outputs["P4"].shape[:3], [None, 16, 16])

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
@@ -49,13 +49,11 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
             input_shape=[256, 256, 3],
         )
         levels = ["P3", "P4"]
-        layer_names = [
-            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
-        ]
+        layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = tf.keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P3"].shape[:3], [None, 32, 32])
         self.assertEquals(outputs["P4"].shape[:3], [None, 16, 16])

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -152,8 +152,9 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # EfficientNetV2S backbone has 4 level of features (P1 ~ P5)
+        levels = ["P1", "P2", "P3", "P4", "P5"]
         self.assertLen(outputs, 5)
-        self.assertEquals(list(outputs.keys()), ["P1", "P2", "P3", "P4", "P5"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P2"].shape, [None, 64, 64, 48])
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 64])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 160])
@@ -181,14 +182,12 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=True,
         )
         levels = ["P3", "P4"]
-        layer_names = [
-            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
-        ]
+        layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 64])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 160])
 

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -151,13 +151,13 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
-        # EfficientNetV2S backbone has 4 level of features (1 ~ 5)
+        # EfficientNetV2S backbone has 4 level of features (P1 ~ P5)
         self.assertLen(outputs, 5)
-        self.assertEquals(list(outputs.keys()), [1, 2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 64, 64, 48])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 64])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 160])
-        self.assertEquals(outputs[5].shape, [None, 8, 8, 1280])
+        self.assertEquals(list(outputs.keys()), ["P1", "P2", "P3", "P4", "P5"])
+        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 48])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 64])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 160])
+        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 1280])
 
     def test_create_backbone_model_with_level_config(self):
         model = EfficientNetV2Backbone(
@@ -180,15 +180,17 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             depth_coefficient=1.0,
             include_rescaling=True,
         )
-        levels = [3, 4]
-        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        levels = ["P3", "P4"]
+        layer_names = [
+            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
+        ]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 64])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 160])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 64])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 160])
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
@@ -313,7 +313,8 @@ class MobileNetV3Backbone(Backbone):
         super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         self.pyramid_level_inputs = {
-            i + 1: name for i, name in enumerate(pyramid_level_inputs)
+            "P" + str(i + 1): name
+            for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_expansion = stackwise_expansion
         self.stackwise_filters = stackwise_filters

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
@@ -313,8 +313,7 @@ class MobileNetV3Backbone(Backbone):
         super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         self.pyramid_level_inputs = {
-            f"P{i + 1}": name
-            for i, name in enumerate(pyramid_level_inputs)
+            f"P{i + 1}": name for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_expansion = stackwise_expansion
         self.stackwise_filters = stackwise_filters

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
@@ -313,7 +313,7 @@ class MobileNetV3Backbone(Backbone):
         super().__init__(inputs=inputs, outputs=x, **kwargs)
 
         self.pyramid_level_inputs = {
-            "P" + str(i + 1): name
+            f"P{i + 1}": name
             for i, name in enumerate(pyramid_level_inputs)
         }
         self.stackwise_expansion = stackwise_expansion

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -30,14 +30,14 @@ from keras_cv.utils.train import get_feature_extractor
 # from https://arxiv.org/pdf/1905.02244.pdf
 pyramid_level_input_shapes = {
     "mobilenet_v3_small": {
-        3: [None, 28, 28, 24],
-        4: [None, 14, 14, 48],
-        5: [None, 7, 7, 96],
+        "P3": [None, 28, 28, 24],
+        "P4": [None, 14, 14, 48],
+        "P5": [None, 7, 7, 96],
     },
     "mobilenet_v3_large": {
-        3: [None, 28, 28, 40],
-        4: [None, 14, 14, 112],
-        5: [None, 7, 7, 160],
+        "P3": [None, 28, 28, 40],
+        "P4": [None, 14, 14, 112],
+        "P5": [None, 7, 7, 160],
     },
 }
 
@@ -86,7 +86,7 @@ class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
         metadata["config"]["input_shape"] = [224, 224, 3]
         model = MobileNetV3Backbone.from_config(metadata["config"])
 
-        levels = [3, 4, 5]
+        levels = ["P3", "P4", "P5"]
         layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = tf.keras.Input(shape=[224, 224, 3])
@@ -94,7 +94,7 @@ class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # confirm the shapes of the pyramid level input
         self.assertLen(outputs, len(levels))
-        self.assertEquals(list(outputs.keys()), [3, 4, 5])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4", "P5"])
         for level in levels:
             self.assertEquals(
                 outputs[level].shape, pyramid_level_input_shapes[preset][level]

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -94,7 +94,7 @@ class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # confirm the shapes of the pyramid level input
         self.assertLen(outputs, len(levels))
-        self.assertEquals(list(outputs.keys()), ["P3", "P4", "P5"])
+        self.assertEquals(list(outputs.keys()), levels)
         for level in levels:
             self.assertEquals(
                 outputs[level].shape, pyramid_level_input_shapes[preset][level]

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
@@ -315,7 +315,7 @@ class ResNetBackbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs["P" + str(stack_index + 2)] = x.node.layer.name
+            pyramid_level_inputs[f"P{stack_index + 2}"] = x.node.layer.name
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
@@ -315,7 +315,7 @@ class ResNetBackbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[stack_index + 2] = x.node.layer.name
+            pyramid_level_inputs["P" + str(stack_index + 2)] = x.node.layer.name
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -118,13 +118,13 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
-        # Resnet50 backbone has 4 level of features (2 ~ 5)
+        # Resnet50 backbone has 4 level of features (P2 ~ P5)
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), [2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs[5].shape, [None, 8, 8, 2048])
+        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
+        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 2048])
 
     def test_create_backbone_model_with_level_config(self):
         model = ResNetBackbone(
@@ -134,15 +134,17 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
             input_shape=[256, 256, 3],
         )
-        levels = [3, 4]
-        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        levels = ["P3", "P4"]
+        layer_names = [
+            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
+        ]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -119,8 +119,9 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # Resnet50 backbone has 4 level of features (P2 ~ P5)
+        levels = ["P2", "P3", "P4", "P5"]
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
@@ -135,14 +136,12 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             input_shape=[256, 256, 3],
         )
         levels = ["P3", "P4"]
-        layer_names = [
-            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
-        ]
+        layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
 

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -356,7 +356,7 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[stack_index + 2] = x.node.layer.name
+            pyramid_level_inputs["P" + str(stack_index + 2)] = x.node.layer.name
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -356,7 +356,7 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs["P" + str(stack_index + 2)] = x.node.layer.name
+            pyramid_level_inputs[f"P{stack_index + 2}"] = x.node.layer.name
 
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -110,8 +110,9 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         # Resnet50 backbone has 4 level of features (P2 ~ P5)
+        levels = ["P2", "P3", "P4", "P5"]
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
@@ -126,14 +127,12 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             input_shape=[256, 256, 3],
         )
         levels = ["P3", "P4"]
-        layer_names = [
-            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
-        ]
+        layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
         self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
 

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -109,13 +109,13 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
-        # Resnet50 backbone has 4 level of features (2 ~ 5)
+        # Resnet50 backbone has 4 level of features (P2 ~ P5)
         self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), [2, 3, 4, 5])
-        self.assertEquals(outputs[2].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs[5].shape, [None, 8, 8, 2048])
+        self.assertEquals(list(outputs.keys()), ["P2", "P3", "P4", "P5"])
+        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
+        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 2048])
 
     def test_create_backbone_model_with_level_config(self):
         model = ResNetV2Backbone(
@@ -125,15 +125,17 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
             input_shape=[256, 256, 3],
         )
-        levels = [3, 4]
-        layer_names = [model.pyramid_level_inputs[level] for level in [3, 4]]
+        levels = ["P3", "P4"]
+        layer_names = [
+            model.pyramid_level_inputs[level] for level in ["P3", "P4"]
+        ]
         backbone_model = get_feature_extractor(model, layer_names, levels)
         inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), [3, 4])
-        self.assertEquals(outputs[3].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs[4].shape, [None, 16, 16, 1024])
+        self.assertEquals(list(outputs.keys()), ["P3", "P4"])
+        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
+        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
@@ -76,11 +76,11 @@ class FeaturePyramid(keras.layers.Layer):
         p2_output = self.conv_c2_3x3(p2_output)
 
         return {
-            2: p2_output,
-            3: p3_output,
-            4: p4_output,
-            5: p5_output,
-            6: p6_output,
+            "P2": p2_output,
+            "P3": p3_output,
+            "P4": p4_output,
+            "P5": p5_output,
+            "P6": p6_output,
         }
 
     def get_config(self):
@@ -290,10 +290,16 @@ class FasterRCNN(keras.Model):
         aspect_ratios = [0.5, 1.0, 2.0]
         self.anchor_generator = anchor_generator or AnchorGenerator(
             bounding_box_format="yxyx",
-            sizes={2: 32.0, 3: 64.0, 4: 128.0, 5: 256.0, 6: 512.0},
+            sizes={
+                "P2": 32.0,
+                "P3": 64.0,
+                "P4": 128.0,
+                "P5": 256.0,
+                "P6": 512.0,
+            },
             scales=scales,
             aspect_ratios=aspect_ratios,
-            strides={i: 2**i for i in range(2, 7)},
+            strides={f"P{i}": 2**i for i in range(2, 7)},
             clip_boxes=True,
         )
         self.rpn_head = RPNHead(

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
@@ -248,8 +248,8 @@ class FasterRCNN(keras.Model):
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
         backbone: Optional `keras.Model`. Must implement the
-            `pyramid_level_inputs` property with keys P2, P3, P4, and P5 and layer
-            names as values. If `None`, defaults to
+            `pyramid_level_inputs` property with keys "P2", "P3", "P4", and "P5"
+            and layer names as values. If `None`, defaults to
             `keras_cv.models.ResNet50Backbone()`.
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`. It is
             used in the model to match ground truth boxes and labels with

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
@@ -53,10 +53,10 @@ class FeaturePyramid(keras.layers.Layer):
         self.upsample_2x = keras.layers.UpSampling2D(2)
 
     def call(self, inputs, training=None):
-        c2_output = inputs[2]
-        c3_output = inputs[3]
-        c4_output = inputs[4]
-        c5_output = inputs[5]
+        c2_output = inputs["P2"]
+        c3_output = inputs["P3"]
+        c4_output = inputs["P4"]
+        c5_output = inputs["P5"]
 
         c6_output = self.conv_c6_pool(c5_output)
         p6_output = c6_output
@@ -248,7 +248,7 @@ class FasterRCNN(keras.Model):
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
         backbone: Optional `keras.Model`. Must implement the
-            `pyramid_level_inputs` property with keys 2, 3, 4, and 5 and layer
+            `pyramid_level_inputs` property with keys P2, P3, P4, and P5 and layer
             names as values. If `None`, defaults to
             `keras_cv.models.ResNet50Backbone()`.
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`. It is
@@ -316,7 +316,7 @@ class FasterRCNN(keras.Model):
         self.roi_pooler = _ROIAligner(bounding_box_format="yxyx")
         self.rcnn_head = rcnn_head or RCNNHead(num_classes)
         self.backbone = backbone or keras_cv.models.ResNet50Backbone()
-        extractor_levels = [2, 3, 4, 5]
+        extractor_levels = ["P2", "P3", "P4", "P5"]
         extractor_layer_names = [
             self.backbone.pyramid_level_inputs[i] for i in extractor_levels
         ]

--- a/keras_cv/models/object_detection/retinanet/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retinanet/feature_pyramid.py
@@ -49,4 +49,10 @@ class FeaturePyramid(keras.layers.Layer):
         p5_output = self.conv_c5_3x3(p5_output, training=training)
         p6_output = self.conv_c6_3x3(c5_output, training=training)
         p7_output = self.conv_c7_3x3(tf.nn.relu(p6_output), training=training)
-        return p3_output, p4_output, p5_output, p6_output, p7_output
+        return {
+            "P3": p3_output,
+            "P4": p4_output,
+            "P5": p5_output,
+            "P6": p6_output,
+            "P7": p7_output,
+        }

--- a/keras_cv/models/object_detection/retinanet/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retinanet/feature_pyramid.py
@@ -34,9 +34,9 @@ class FeaturePyramid(keras.layers.Layer):
 
     def call(self, inputs, training=False):
         if isinstance(inputs, dict):
-            c3_output = inputs["3"]
-            c4_output = inputs["4"]
-            c5_output = inputs["5"]
+            c3_output = inputs["P3"]
+            c4_output = inputs["P4"]
+            c5_output = inputs["P5"]
         else:
             c3_output, c4_output, c5_output = inputs
         p3_output = self.conv_c3_1x1(c3_output, training=training)

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -192,7 +192,7 @@ class RetinaNet(Task):
         batch_size = tf.shape(images)[0]
         cls_pred = []
         box_pred = []
-        for feature in features:
+        for feature in features.values():
             box_pred.append(tf.reshape(box_head(feature), [batch_size, -1, 4]))
             cls_pred.append(
                 tf.reshape(

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -94,7 +94,7 @@ class RetinaNet(Task):
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
         backbone: `keras.Model`. Must implement the `pyramid_level_inputs`
-            property with keys 3, 4, and 5 and layer names as values. A somewhat
+            property with keys P3, P4, and P5 and layer names as values. A somewhat
             sensible backbone to use in many cases is the:
             `keras_cv.models.ResNetBackbone.from_preset("resnet50_imagenet")`
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`. If
@@ -163,10 +163,9 @@ class RetinaNet(Task):
             box_variance=BOX_VARIANCE,
         )
 
-        # Using strings to keep the TF saving flow happy.
-        extractor_levels = ["3", "4", "5"]
+        extractor_levels = ["P3", "P4", "P5"]
         extractor_layer_names = [
-            backbone.pyramid_level_inputs[int(i)] for i in extractor_levels
+            backbone.pyramid_level_inputs[i] for i in extractor_levels
         ]
         feature_extractor = get_feature_extractor(
             backbone, extractor_layer_names, extractor_levels

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -192,7 +192,9 @@ class RetinaNet(Task):
         batch_size = tf.shape(images)[0]
         cls_pred = []
         box_pred = []
-        for feature in features.values():
+        pyramid_levels = ["P3", "P4", "P5", "P6", "P7"]
+        for pyramid_level in pyramid_levels:
+            feature = features[pyramid_level]
             box_pred.append(tf.reshape(box_head(feature), [batch_size, -1, 4]))
             cls_pred.append(
                 tf.reshape(

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -94,8 +94,8 @@ class RetinaNet(Task):
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
         backbone: `keras.Model`. Must implement the `pyramid_level_inputs`
-            property with keys P3, P4, and P5 and layer names as values. A somewhat
-            sensible backbone to use in many cases is the:
+            property with keys "P3", "P4", and "P5" and layer names as values.
+            A somewhat sensible backbone to use in many cases is the:
             `keras_cv.models.ResNetBackbone.from_preset("resnet50_imagenet")`
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`. If
             provided, the anchor generator will be passed to both the

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone.py
@@ -180,7 +180,7 @@ class YOLOV8Backbone(Backbone):
                     activation=activation,
                     name=f"{stack_name}_spp_fast",
                 )
-            pyramid_level_inputs["P" + str(stack_id + 2)] = x.node.layer.name
+            pyramid_level_inputs[f"P{stack_id + 2}"] = x.node.layer.name
 
         super().__init__(inputs=inputs, outputs=x, **kwargs)
         self.pyramid_level_inputs = pyramid_level_inputs

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone.py
@@ -151,7 +151,7 @@ class YOLOV8Backbone(Backbone):
         )
 
         """ blocks """
-        pyramid_level_inputs = {1: x.node.layer.name}
+        pyramid_level_inputs = {"P1": x.node.layer.name}
         for stack_id, (channel, depth) in enumerate(
             zip(stackwise_channels, stackwise_depth)
         ):
@@ -180,7 +180,7 @@ class YOLOV8Backbone(Backbone):
                     activation=activation,
                     name=f"{stack_name}_spp_fast",
                 )
-            pyramid_level_inputs[stack_id + 2] = x.node.layer.name
+            pyramid_level_inputs["P" + str(stack_id + 2)] = x.node.layer.name
 
         super().__init__(inputs=inputs, outputs=x, **kwargs)
         self.pyramid_level_inputs = pyramid_level_inputs

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -324,8 +324,8 @@ class YOLOV8Detector(Task):
 
     Args:
         backbone: `keras.Model`, must implement the `pyramid_level_inputs`
-            property with keys P2, P3, and P4 and layer names as values. A
-            sensible backbone to use is the `keras_cv.models.YOLOV8Backbone`.
+            property with keys "P2", "P3", and "P4" and layer names as values.
+            A sensible backbone to use is the `keras_cv.models.YOLOV8Backbone`.
         num_classes: integer, the number of classes in your dataset excluding the
             background class. Classes should be represented by integers in the
             range [0, num_classes).

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -324,7 +324,7 @@ class YOLOV8Detector(Task):
 
     Args:
         backbone: `keras.Model`, must implement the `pyramid_level_inputs`
-            property with keys 2, 3, and 4 and layer names as values. A
+            property with keys P2, P3, and P4 and layer names as values. A
             sensible backbone to use is the `keras_cv.models.YOLOV8Backbone`.
         num_classes: integer, the number of classes in your dataset excluding the
             background class. Classes should be represented by integers in the
@@ -396,10 +396,9 @@ class YOLOV8Detector(Task):
         prediction_decoder=None,
         **kwargs,
     ):
-        # Using strings to keep the TF saving flow happy.
-        extractor_levels = ["3", "4", "5"]
+        extractor_levels = ["P3", "P4", "P5"]
         extractor_layer_names = [
-            backbone.pyramid_level_inputs[int(i)] for i in extractor_levels
+            backbone.pyramid_level_inputs[i] for i in extractor_levels
         ]
         feature_extractor = get_feature_extractor(
             backbone, extractor_layer_names, extractor_levels


### PR DESCRIPTION
This PR changes the data type of the keys in the pyramid_level_inputs dictionary from int to string since int keys do not seem to work nicely with TensorFlow model saving flow.

Fixes #1820 

## Who can review?
@jbischof @ianstenbit 