### PR TITLE
Segmentation map in Resizing layer

### DIFF
--- a/examples/layers/preprocessing/segmentation/resize_demo.py
+++ b/examples/layers/preprocessing/segmentation/resize_demo.py
@@ -1,0 +1,66 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""resize_demo.py shows how to use the Resizing preprocessing layer.
+
+Uses the oxford iiit pet_dataset.  In this script the pets
+are loaded, then are passed through the preprocessing layers.
+Finally, they are shown using matplotlib.
+"""
+import tensorflow as tf
+import tensorflow_datasets as tfds
+
+from keras_cv.layers import preprocessing
+from keras_cv.visualization import plot_image_gallery
+
+
+def load_data():
+    ds = tfds.load(
+        name="oxford_iiit_pet",
+        split="train",
+    )
+    return ds.map(
+        lambda inputs: {
+            "images":  tf.cast(inputs["image"], dtype=tf.float32) / 255.0,
+            "segmentation_masks": inputs["segmentation_mask"] - 1}
+        )
+
+
+def map_fn_for_visualization(inputs):
+    masks = tf.cast(inputs["segmentation_masks"], dtype=tf.float32) / 2.0
+    
+    images = tf.expand_dims(inputs["images"], axis=0)
+    masks = tf.expand_dims(masks, axis=0)
+
+    masks = tf.repeat(masks, repeats=3, axis=-1)
+    image_masks = tf.concat([images, masks], axis=2)
+    return image_masks[0]
+
+
+def main():
+    ds = load_data()
+    resize = preprocessing.Resizing(height=128, width=128)
+    ds = ds.map(resize, num_parallel_calls=tf.data.AUTOTUNE)
+    ds = ds.map(map_fn_for_visualization).batch(8)
+    plot_image_gallery(
+        next(iter(ds.take(1))),
+        value_range=(0, 1),
+        scale=3,
+        rows=2,
+        cols=4,
+        path="resize.png"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/layers/preprocessing/segmentation/resize_demo.py
+++ b/examples/layers/preprocessing/segmentation/resize_demo.py
@@ -31,34 +31,83 @@ def load_data():
     )
     return ds.map(
         lambda inputs: {
-            "images":  tf.cast(inputs["image"], dtype=tf.float32) / 255.0,
-            "segmentation_masks": inputs["segmentation_mask"] - 1}
-        )
+            "images": tf.cast(inputs["image"], dtype=tf.float32) / 255.0,
+            "segmentation_masks": inputs["segmentation_mask"] - 1,
+        }
+    )
 
 
 def map_fn_for_visualization(inputs):
     masks = tf.cast(inputs["segmentation_masks"], dtype=tf.float32) / 2.0
-    
+
     images = tf.expand_dims(inputs["images"], axis=0)
     masks = tf.expand_dims(masks, axis=0)
 
     masks = tf.repeat(masks, repeats=3, axis=-1)
+    print(images.dtype)
+    print(masks.dtype)
     image_masks = tf.concat([images, masks], axis=2)
     return image_masks[0]
 
 
 def main():
     ds = load_data()
-    resize = preprocessing.Resizing(height=128, width=128)
-    ds = ds.map(resize, num_parallel_calls=tf.data.AUTOTUNE)
-    ds = ds.map(map_fn_for_visualization).batch(8)
+    resize = preprocessing.Resizing(
+        256,
+        256,
+        interpolation="bilinear",
+        crop_to_aspect_ratio=False,
+        pad_to_aspect_ratio=False,
+        bounding_box_format=None,
+    )
+    resize_crop = preprocessing.Resizing(
+        256,
+        256,
+        interpolation="bilinear",
+        crop_to_aspect_ratio=True,
+        pad_to_aspect_ratio=False,
+        bounding_box_format=None,
+    )
+    resize_pad = preprocessing.Resizing(
+        256,
+        256,
+        interpolation="bilinear",
+        crop_to_aspect_ratio=False,
+        pad_to_aspect_ratio=True,
+        bounding_box_format=None,
+    )
+
+    ds_resize = ds.map(resize, num_parallel_calls=tf.data.AUTOTUNE)
+    ds_crop = ds.map(resize_crop, num_parallel_calls=tf.data.AUTOTUNE)
+    ds_pad = ds.map(resize_pad, num_parallel_calls=tf.data.AUTOTUNE)
+
+    ds_resize = ds_resize.map(map_fn_for_visualization).batch(8)
+    ds_crop = ds_crop.map(map_fn_for_visualization).batch(8)
+    ds_pad = ds_pad.map(map_fn_for_visualization).batch(8)
+
     plot_image_gallery(
-        next(iter(ds.take(1))),
+        next(iter(ds_resize.take(1))),
         value_range=(0, 1),
         scale=3,
         rows=2,
         cols=4,
-        path="resize.png"
+        path="resize.png",
+    )
+    plot_image_gallery(
+        next(iter(ds_crop.take(1))),
+        value_range=(0, 1),
+        scale=3,
+        rows=2,
+        cols=4,
+        path="resize_crop.png",
+    )
+    plot_image_gallery(
+        next(iter(ds_pad.take(1))),
+        value_range=(0, 1),
+        scale=3,
+        rows=2,
+        cols=4,
+        path="resize_pad.png",
     )
 
 

--- a/examples/layers/preprocessing/segmentation/resize_demo.py
+++ b/examples/layers/preprocessing/segmentation/resize_demo.py
@@ -44,8 +44,6 @@ def map_fn_for_visualization(inputs):
     masks = tf.expand_dims(masks, axis=0)
 
     masks = tf.repeat(masks, repeats=3, axis=-1)
-    print(images.dtype)
-    print(masks.dtype)
     image_masks = tf.concat([images, masks], axis=2)
     return image_masks[0]
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -257,7 +257,6 @@ class Resizing(BaseImageAugmentationLayer):
 
         size_as_shape = tf.TensorShape((self.height, self.width))
         shape = size_as_shape + inputs["images"].shape[-1:]
-        seg_map_shape = size_as_shape + inputs["segmentation_maps"].shape[-1:]
         img_spec = tf.TensorSpec(shape, self.compute_dtype)
         fn_output_signature = {"images": img_spec}
 
@@ -268,6 +267,7 @@ class Resizing(BaseImageAugmentationLayer):
 
         segmentation_maps = inputs.get("segmentation_maps", None)
         if segmentation_maps is not None:
+            seg_map_shape = size_as_shape + inputs["segmentation_maps"].shape[-1:]
             seg_map_spec = tf.TensorSpec(seg_map_shape, self.compute_dtype)
             fn_output_signature["segmentation_maps"] = seg_map_spec
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -172,7 +172,7 @@ class Resizing(BaseImageAugmentationLayer):
 
         if segmentation_maps is not None:
             segmentation_maps = tf.image.resize(
-                segmentation_maps, size=size, method="nearest"
+                segmentation_maps, size=size, method=self._interpolation_method
             )
 
         inputs["images"] = images
@@ -246,7 +246,7 @@ class Resizing(BaseImageAugmentationLayer):
                 segmentation_maps = tf.image.resize(
                     segmentation_maps,
                     size=(target_height, target_width),
-                    method="nearest",
+                    method=self._interpolation_method,
                 )
                 segmentation_maps = tf.image.pad_to_bounding_box(
                     segmentation_maps, 0, 0, self.height, self.width

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -267,7 +267,9 @@ class Resizing(BaseImageAugmentationLayer):
 
         segmentation_maps = inputs.get("segmentation_maps", None)
         if segmentation_maps is not None:
-            seg_map_shape = size_as_shape + inputs["segmentation_maps"].shape[-1:]
+            seg_map_shape = (
+                size_as_shape + inputs["segmentation_maps"].shape[-1:]
+            )
             seg_map_spec = tf.TensorSpec(seg_map_shape, self.compute_dtype)
             fn_output_signature["segmentation_maps"] = seg_map_spec
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
-
 import tensorflow as tf
 from tensorflow import keras
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -321,7 +321,7 @@ class Resizing(BaseImageAugmentationLayer):
             if isinstance(segmentation_maps, tf.RaggedTensor):
                 size_as_shape = tf.TensorShape(size)
                 shape = size_as_shape + segmentation_maps.shape[-1:]
-                spec = tf.TensorSpec(shape, tf.int32)
+                spec = tf.TensorSpec(shape, input_dtype)
                 segmentation_maps = tf.map_fn(
                     resize_with_crop_to_aspect,
                     segmentation_maps,

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -253,7 +253,11 @@ class Resizing(BaseImageAugmentationLayer):
                     method="nearest",
                 )
                 segmentation_masks = tf.image.pad_to_bounding_box(
-                    segmentation_masks, 0, 0, self.height, self.width
+                    tf.cast(segmentation_masks, dtype="float32"),
+                    0,
+                    0,
+                    self.height,
+                    self.width,
                 )
                 inputs["segmentation_masks"] = segmentation_masks
 
@@ -308,7 +312,9 @@ class Resizing(BaseImageAugmentationLayer):
             if isinstance(x, tf.RaggedTensor):
                 x = x.to_tensor()
             return keras.preprocessing.image.smart_resize(
-                x, size=size, interpolation=interpolation_method,
+                x,
+                size=size,
+                interpolation=interpolation_method,
             )
 
         if isinstance(images, tf.RaggedTensor):
@@ -317,7 +323,7 @@ class Resizing(BaseImageAugmentationLayer):
             spec = tf.TensorSpec(shape, input_dtype)
             map_fn = partial(
                 resize_with_crop_to_aspect_images,
-                interpolation_method=self._interpolation_method
+                interpolation_method=self._interpolation_method,
             )
             images = tf.map_fn(
                 map_fn,
@@ -339,7 +345,7 @@ class Resizing(BaseImageAugmentationLayer):
                 spec = tf.TensorSpec(shape, input_dtype)
                 map_fn = partial(
                     resize_with_crop_to_aspect_images,
-                    interpolation_method="nearest"
+                    interpolation_method="nearest",
                 )
                 segmentation_masks = tf.map_fn(
                     map_fn,
@@ -347,11 +353,9 @@ class Resizing(BaseImageAugmentationLayer):
                     fn_output_signature=spec,
                 )
             else:
-                segmentation_masks = (
-                    resize_with_crop_to_aspect_images(
-                        segmentation_masks,
-                        interpolation_method="nearest",
-                    )
+                segmentation_masks = resize_with_crop_to_aspect_images(
+                    segmentation_masks,
+                    interpolation_method="nearest",
                 )
 
             inputs["segmentation_masks"] = segmentation_masks

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -155,7 +155,9 @@ class Resizing(BaseImageAugmentationLayer):
             inputs["bounding_boxes"] = outputs["bounding_boxes"]
 
         if segmentation_masks is not None:
-            segmentation_masks = tf.squeeze(outputs["segmentation_masks"], axis=0)
+            segmentation_masks = tf.squeeze(
+                outputs["segmentation_masks"], axis=0
+            )
             inputs["segmentation_masks"] = segmentation_masks
 
         return inputs
@@ -306,7 +308,7 @@ class Resizing(BaseImageAugmentationLayer):
             return keras.preprocessing.image.smart_resize(
                 x, size=size, interpolation=self._interpolation_method
             )
-        
+
         def resize_with_crop_to_aspect_segmentation_masks(x):
             if isinstance(x, tf.RaggedTensor):
                 x = x.to_tensor()
@@ -319,7 +321,9 @@ class Resizing(BaseImageAugmentationLayer):
             shape = size_as_shape + images.shape[-1:]
             spec = tf.TensorSpec(shape, input_dtype)
             images = tf.map_fn(
-                resize_with_crop_to_aspect_images, images, fn_output_signature=spec
+                resize_with_crop_to_aspect_images,
+                images,
+                fn_output_signature=spec,
             )
         else:
             images = resize_with_crop_to_aspect_images(images)
@@ -337,8 +341,10 @@ class Resizing(BaseImageAugmentationLayer):
                     fn_output_signature=spec,
                 )
             else:
-                segmentation_masks = resize_with_crop_to_aspect_segmentation_masks(
-                    segmentation_masks
+                segmentation_masks = (
+                    resize_with_crop_to_aspect_segmentation_masks(
+                        segmentation_masks
+                    )
                 )
 
             inputs["segmentation_masks"] = segmentation_masks

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -309,10 +309,9 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
 
     def test_resize_with_mask(self):
         input_images = np.random.normal(size=(2, 4, 4, 3))
-        seg_masks = (
-            np.random.uniform(low=0.0, high=3.0, size=(2, 4, 4, 3))
-            .astype("int32")
-        )
+        seg_masks = np.random.uniform(
+            low=0.0, high=3.0, size=(2, 4, 4, 3)
+        ).astype("int32")
         inputs = {
             "images": input_images,
             "segmentation_masks": seg_masks,
@@ -323,13 +322,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
 
         expected_output_images = tf.image.resize(input_images, size=(2, 2))
         expected_output_seg_masks = tf.image.resize(
-            seg_masks,
-            size=(2, 2),
-            method="nearest"
+            seg_masks, size=(2, 2), method="nearest"
         )
 
         self.assertAllEqual(expected_output_images, outputs["images"])
         self.assertAllEqual(
-            expected_output_seg_masks,
-            outputs["segmentation_masks"]
+            expected_output_seg_masks, outputs["segmentation_masks"]
         )

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -306,3 +306,30 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual(
             outputs["images"][1][:, -8:, :], tf.zeros((16, 8, 3))
         )
+
+    def test_resize_with_mask(self):
+        input_images = np.random.normal(size=(2, 4, 4, 3))
+        seg_masks = (
+            np.random.uniform(low=0.0, high=3.0, size=(2, 4, 4, 3))
+            .astype("int32")
+        )
+        inputs = {
+            "images": input_images,
+            "segmentation_masks": seg_masks,
+        }
+
+        layer = cv_layers.Resizing(2, 2)
+        outputs = layer(inputs)
+
+        expected_output_images = tf.image.resize(input_images, size=(2, 2))
+        expected_output_seg_masks = tf.image.resize(
+            seg_masks,
+            size=(2, 2),
+            method="nearest"
+        )
+
+        self.assertAllEqual(expected_output_images, outputs["images"])
+        self.assertAllEqual(
+            expected_output_seg_masks,
+            outputs["segmentation_masks"]
+        )

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -82,7 +82,7 @@ TEST_CONFIGURATIONS = [
         {"factor": 0.5, "value_range": (0, 255)},
     ),
     ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
-    ("Resizing", preprocessing.Resizing, {"height": 512, "width": 512})
+    ("Resizing", preprocessing.Resizing, {"height": 512, "width": 512}),
 ]
 
 

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -82,6 +82,7 @@ TEST_CONFIGURATIONS = [
         {"factor": 0.5, "value_range": (0, 255)},
     ),
     ("Solarization", preprocessing.Solarization, {"value_range": (0, 255)}),
+    ("Resizing", preprocessing.Resizing, {"height": 512, "width": 512})
 ]
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #1830 (issue)

Demo added by @ariG23498  

## Resize

![](https://user-images.githubusercontent.com/36856589/243755942-2162084a-e8b1-4f9f-b967-04af2ad32f20.png)

## Crop

![](https://user-images.githubusercontent.com/36856589/243755975-bd4c8bff-b42a-4a04-aa58-5b08451a3c37.png)

## Pad

![](https://user-images.githubusercontent.com/36856589/243756007-accadc13-7fe1-405c-9e70-483c7c073cc9.png)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

@ianstenbit @LukeWood @jbischof 