### PR TITLE
Support for `tf.data.Dataset` added in `plot_image_gallery`, removed hard dependency on `rows` and `cols` params

### DIFF
--- a/examples/visualization/plot_image_gallery.py
+++ b/examples/visualization/plot_image_gallery.py
@@ -1,8 +1,8 @@
 """
 Title: Plot an image gallery
-Author: [lukewood](https://lukewood.xyz)
+Author: [lukewood](https://lukewood.xyz), updated by [Suvaditya Mukherjee](https://twitter.com/halcyonrayes)
 Date created: 2022/10/16
-Last modified: 2022/05/31
+Last modified: 2022/06/24
 Description: Visualize ground truth and predicted bounding boxes for a given
              dataset.
 """
@@ -22,8 +22,6 @@ train_ds = tfds.load(
     shuffle_files=True,
 )
 
-train_ds = train_ds.ragged_batch(16)
-
 keras_cv.visualization.plot_image_gallery(
     train_ds,
     value_range=(0, 255),
@@ -34,13 +32,9 @@ keras_cv.visualization.plot_image_gallery(
 If you want to use plain NumPy arrays, you can do that too:
 """
 
-# Prepare some NumPy arrays from random noise
+# Prepare some sample NumPy arrays from random noise
 
-samples = []
-for sample in train_ds.take(20):
-    samples.append(sample["image"].numpy())
-
-samples = np.array(samples, dtype="object")
+samples = np.random.randint(0, 255, (20, 224, 224, 3))
 
 keras_cv.visualization.plot_image_gallery(
     samples, value_range=(0, 255), scale=3, rows=4, cols=5

--- a/examples/visualization/plot_image_gallery.py
+++ b/examples/visualization/plot_image_gallery.py
@@ -1,6 +1,7 @@
 """
 Title: Plot an image gallery
-Author: [lukewood](https://lukewood.xyz), updated by [Suvaditya Mukherjee](https://twitter.com/halcyonrayes)
+Author: [lukewood](https://lukewood.xyz), updated by
+[Suvaditya Mukherjee](https://twitter.com/halcyonrayes)
 Date created: 2022/10/16
 Last modified: 2022/06/24
 Description: Visualize ground truth and predicted bounding boxes for a given

--- a/examples/visualization/plot_image_gallery.py
+++ b/examples/visualization/plot_image_gallery.py
@@ -12,7 +12,7 @@ Plotting images from a TensorFlow dataset is easy with KerasCV. Behold:
 """
 
 import tensorflow_datasets as tfds
-
+import numpy as np
 import keras_cv
 
 train_ds = tfds.load(
@@ -28,4 +28,20 @@ keras_cv.visualization.plot_image_gallery(
     train_ds,
     value_range=(0, 255),
     scale=3,
+)
+
+"""
+If you want to use plain NumPy arrays, you can do that too:
+"""
+
+# Prepare some NumPy arrays from random noise
+
+samples = []
+for sample in train_ds.take(20):
+    samples.append(sample["image"].numpy())
+
+samples = np.array(samples, dtype="object")
+
+keras_cv.visualization.plot_image_gallery(
+    samples, value_range=(0, 255), scale=3, rows=4, cols=5
 )

--- a/examples/visualization/plot_image_gallery.py
+++ b/examples/visualization/plot_image_gallery.py
@@ -2,7 +2,7 @@
 Title: Plot an image gallery
 Author: [lukewood](https://lukewood.xyz)
 Date created: 2022/10/16
-Last modified: 2022/10/16
+Last modified: 2022/05/31
 Description: Visualize ground truth and predicted bounding boxes for a given
              dataset.
 """
@@ -11,7 +11,6 @@ Description: Visualize ground truth and predicted bounding boxes for a given
 Plotting images from a TensorFlow dataset is easy with KerasCV. Behold:
 """
 
-import tensorflow as tf
 import tensorflow_datasets as tfds
 
 import keras_cv
@@ -23,18 +22,10 @@ train_ds = tfds.load(
     shuffle_files=True,
 )
 
-
-def unpackage_tfds_inputs(inputs):
-    return inputs["image"]
-
-
-train_ds = train_ds.map(unpackage_tfds_inputs)
-train_ds = train_ds.apply(tf.data.experimental.dense_to_ragged_batch(16))
+train_ds = train_ds.ragged_batch(16)
 
 keras_cv.visualization.plot_image_gallery(
-    next(iter(train_ds.take(1))),
+    train_ds,
     value_range=(0, 255),
     scale=3,
-    rows=2,
-    cols=2,
 )

--- a/examples/visualization/plot_image_gallery.py
+++ b/examples/visualization/plot_image_gallery.py
@@ -11,8 +11,9 @@ Description: Visualize ground truth and predicted bounding boxes for a given
 Plotting images from a TensorFlow dataset is easy with KerasCV. Behold:
 """
 
-import tensorflow_datasets as tfds
 import numpy as np
+import tensorflow_datasets as tfds
+
 import keras_cv
 
 train_ds = tfds.load(

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -47,7 +47,8 @@ def _extract_image_batch(images, num_images, batch_size):
     else:
         if len(images.shape) != 4:
             raise ValueError(
-                "`plot_images_gallery()` requires you to batch your `np.array` samples together."
+                "`plot_images_gallery()` requires you to "
+                "batch your `np.array` samples together."
             )
         else:
             num_samples = (
@@ -90,14 +91,17 @@ def plot_image_gallery(
     ![example gallery](https://i.imgur.com/r0ndse0.png)
 
     Args:
-        images: a Tensor, `tf.data.Dataset` or NumPy array containing images to show in the
-            gallery. Note: If using a `tf.data.Dataset`, images should be
-            present in the `FeaturesDict` under the key `image`.
+        images: a Tensor, `tf.data.Dataset` or NumPy array containing images
+            to show in the gallery. Note: If using a `tf.data.Dataset`,
+            images should be present in the `FeaturesDict` under
+            the key `image`.
         value_range: value range of the images. Common examples include
             `(0, 255)` and `(0, 1)`.
         scale: how large to scale the images in the gallery
-        rows: (Optional) number of rows in the gallery to show. Required if inputs are unbatched.
-        cols: (Optional) number of columns in the gallery to show. Required if inputs are unbatched.
+        rows: (Optional) number of rows in the gallery to show.
+            Required if inputs are unbatched.
+        cols: (Optional) number of columns in the gallery to show.
+            Required if inputs are unbatched.
         path: (Optional) path to save the resulting gallery to.
         show: (Optional) whether to show the gallery of images.
         transparent: (Optional) whether to give the image a transparent

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -62,8 +62,8 @@ def plot_image_gallery(
         value_range: value range of the images. Common examples include
             `(0, 255)` and `(0, 1)`.
         scale: how large to scale the images in the gallery
-        rows: (Optional) number of rows in the gallery to show.
-        cols: (Optional) number of columns in the gallery to show.
+        rows: (Optional) number of rows in the gallery to show. Required if inputs are unbatched.
+        cols: (Optional) number of columns in the gallery to show. Required if inputs are unbatched.
         path: (Optional) path to save the resulting gallery to.
         show: (Optional) whether to show the gallery of images.
         transparent: (Optional) whether to give the image a transparent
@@ -93,7 +93,7 @@ def plot_image_gallery(
         return inputs["image"]
 
     # Calculate appropriate number of rows and columns
-    if rows is None and cols is None:
+    if rows is None or cols is None:
         if isinstance(images, tf.data.Dataset):
             sample = next(iter(images.take(1)))
             sample_shape = sample["image"].shape
@@ -113,7 +113,8 @@ def plot_image_gallery(
                 batch_size = sample_shape[0]
             else:
                 raise ValueError(
-                    f"Passed '`{type(images)}`' does not appear to be batched. Please batch using the `.batch()."
+                    f"`plot_image_gallery` received unbatched images and `cols` and `rows` "
+                    "were both `None`. Either images should be batched, or `cols` and `rows` should be specified."
                 )
 
     elif rows is not None and cols is not None:
@@ -136,7 +137,7 @@ def plot_image_gallery(
             images = images[:batch_size, ...]
     else:
         raise ValueError(
-            "plot_image_gallery() expects `tf.data.Dataset` to be batched if rows and cols are not specified."
+            "plot_image_gallery() expects `tf.data.Dataset` to be batched if rows or cols are not specified."
         )
 
     rows = int(math.ceil(batch_size**0.5))

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import keras_cv
 import tensorflow as tf
 from keras_cv import utils
@@ -27,10 +26,10 @@ except:
 def plot_image_gallery(
     images,
     value_range,
+    scale=2,
     rows=None,
     cols=None,
     batch_size=8,
-    scale=2,
     path=None,
     show=None,
     transparent=True,
@@ -66,6 +65,8 @@ def plot_image_gallery(
         scale: how large to scale the images in the gallery
         rows: (Optional) number of rows in the gallery to show.
         cols: (Optional) number of columns in the gallery to show.
+        batch_size: (Optional) batch size of a given `tf.data.Dataset` instance.
+            Defaults to 8. Only required when using a `tf.data.Dataset` instance.
         path: (Optional) path to save the resulting gallery to.
         show: (Optional) whether to show the gallery of images.
         transparent: (Optional) whether to give the image a transparent

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import math
-import keras_cv
+
 import numpy as np
 import tensorflow as tf
+
+import keras_cv
 from keras_cv import utils
 from keras_cv.utils import assert_matplotlib_installed
 

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -58,7 +58,7 @@ def plot_image_gallery(
     ![example gallery](https://i.imgur.com/r0ndse0.png)
 
     Args:
-        images: a Tensor or NumPy array containing images to show in the
+        images: a Tensor, `tf.data.Dataset` or NumPy array containing images to show in the
             gallery.
         value_range: value range of the images. Common examples include
             `(0, 255)` and `(0, 1)`.


### PR DESCRIPTION
# What does this PR do?

This PR is meant to add support for using `tf.data.Dataset` instances directly with `keras_cv.visualization.plot_image_gallery` instead of the user having to manually convert the dataset and then perform processing. It still supports NumPy arrays or Tensors as it used to.

Also, handled a possible future deprecation of removing `plt.tight_layout()` by making use of `plt.subplot(...,layout='tight')` as per [this warning in Matplotlib](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#discouraged-figure-parameters-tight-layout-and-constrained-layout)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->

cc: @ianstenbit (as discussed previously) @jbischof @tanzhenyu 