### PR TITLE
Handle new import path for private Keras modules in 2.13

### DIFF
--- a/keras_cv/models/legacy/weights.py
+++ b/keras_cv/models/legacy/weights.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 import tensorflow as tf
-from keras.utils import data_utils
+from keras import utils
 
 
 def parse_weights(weights, include_top, model_type):
@@ -19,7 +19,7 @@ def parse_weights(weights, include_top, model_type):
         return weights
     if weights.startswith("gs://"):
         weights = weights.replace("gs://", "https://storage.googleapis.com/")
-        return data_utils.get_file(
+        return utils.get_file(
             origin=weights,
             cache_subdir="models",
         )
@@ -30,7 +30,7 @@ def parse_weights(weights, include_top, model_type):
     if weights in WEIGHTS_CONFIG[model_type]:
         if not include_top:
             weights = weights + "-notop"
-        return data_utils.get_file(
+        return utils.get_file(
             origin=f"{BASE_PATH}/{model_type}/{weights}.h5",
             cache_subdir="models",
             file_hash=WEIGHTS_CONFIG[model_type][weights],

--- a/keras_cv/models/object_detection/predict_utils.py
+++ b/keras_cv/models/object_detection/predict_utils.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from keras.engine.training import _minimum_control_deps
-from keras.engine.training import reduce_per_replica
-from keras.utils import tf_utils
-
+from keras.src.engine.training import reduce_per_replica
+from keras.src.engine.training import _minimum_control_deps
+from keras.src.utils import tf_utils
 
 def make_predict_function(model, force=False):
     if model.predict_function is not None and not force:

--- a/keras_cv/models/object_detection/predict_utils.py
+++ b/keras_cv/models/object_detection/predict_utils.py
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 import tensorflow as tf
-from keras.src.engine.training import reduce_per_replica
-from keras.src.engine.training import _minimum_control_deps
-from keras.src.utils import tf_utils
+
+import keras
+if hasattr(keras, "src"):
+    from keras.src.engine.training import reduce_per_replica
+    from keras.src.engine.training import _minimum_control_deps
+    from keras.src.utils import tf_utils
+else:
+    from keras.engine.training import reduce_per_replica
+    from keras.engine.training import _minimum_control_deps
+    from keras.utils import tf_utils
 
 def make_predict_function(model, force=False):
     if model.predict_function is not None and not force:

--- a/keras_cv/models/object_detection/predict_utils.py
+++ b/keras_cv/models/object_detection/predict_utils.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import keras
 import tensorflow as tf
 
-import keras
 if hasattr(keras, "src"):
-    from keras.src.engine.training import reduce_per_replica
     from keras.src.engine.training import _minimum_control_deps
+    from keras.src.engine.training import reduce_per_replica
     from keras.src.utils import tf_utils
 else:
-    from keras.engine.training import reduce_per_replica
     from keras.engine.training import _minimum_control_deps
+    from keras.engine.training import reduce_per_replica
     from keras.utils import tf_utils
+
 
 def make_predict_function(model, force=False):
     if model.predict_function is not None and not force:

--- a/keras_cv/models/object_detection/predict_utils.py
+++ b/keras_cv/models/object_detection/predict_utils.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import keras
 import tensorflow as tf
 
-if hasattr(keras, "src"):
+try:
     from keras.src.engine.training import _minimum_control_deps
     from keras.src.engine.training import reduce_per_replica
     from keras.src.utils import tf_utils
-else:
+except ImportError:
     from keras.engine.training import _minimum_control_deps
     from keras.engine.training import reduce_per_replica
     from keras.utils import tf_utils


### PR DESCRIPTION
With 2.13, we can't import these private API symbols directly but instead have to use `keras.src`.

This change keeps support for 2.12 while also enabling the `keras.src` path for 2.13