### PR TITLE
Create `presets_without_weights` classproperty

### DIFF
--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -53,9 +53,16 @@ class Backbone(keras.Model):
 
     @classproperty
     def presets_with_weights(cls):
-        """Dictionary of preset names and configurations that include
-        weights."""
+        """Dictionary of preset names and configs that include weights."""
         return {}
+
+    @classproperty
+    def presets_without_weights(cls):
+        """Dictionary of preset names and configs that don't include weights."""
+        return {
+            preset: cls.presets[preset]
+            for preset in set(cls.presets) - set(cls.presets_with_weights)
+        }
 
     @classmethod
     def from_preset(
@@ -64,8 +71,7 @@ class Backbone(keras.Model):
         load_weights=None,
         **kwargs,
     ):
-        """Instantiate {{model_name}} model from preset architecture and
-        weights.
+        """Instantiate {{model_name}} model from preset config and weights.
 
         Args:
             preset: string. Must be one of "{{preset_names}}".

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -252,9 +252,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
 @pytest.mark.large
 class RetinaNetSmokeTest(tf.test.TestCase):
     def test_backbone_preset(self):
-        for preset in keras_cv.models.RetinaNet.presets:
-            if preset in keras_cv.models.RetinaNet.presets_with_weights:
-                continue
+        for preset in keras_cv.models.RetinaNet.presets_without_weights:
             model = keras_cv.models.RetinaNet.from_preset(
                 preset,
                 num_classes=20,


### PR DESCRIPTION
This property is already determined by the `presets` and `presets_with_weights` properties, so create programatically.

Providing this property can save boilerplate for users.