### PR TITLE
Rationalize pyramid_level_inputs tests

### DIFF
--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -104,18 +104,24 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**2, input_size // 2**2, 128],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 256],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 512],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 1024],
+        )
 
     @parameterized.named_parameters(
         ("Tiny", csp_darknet_backbone.CSPDarkNetTinyBackbone),

--- a/keras_cv/models/backbones/densenet/densenet_backbone.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone.py
@@ -107,10 +107,10 @@ class DenseNetBackbone(Backbone):
                 growth_rate,
                 name=f"conv{index}",
             )
+            pyramid_level_inputs[f"P{index}"] = x.node.layer.name
             x = apply_transition_block(
                 x, compression_ratio, name=f"pool{index}"
             )
-            pyramid_level_inputs[f"P{index}"] = x.node.layer.name
 
         x = apply_dense_block(
             x,
@@ -118,6 +118,10 @@ class DenseNetBackbone(Backbone):
             growth_rate,
             name=f"conv{len(stackwise_num_repeats) + 1}",
         )
+        pyramid_level_inputs[
+            f"P{len(stackwise_num_repeats) + 1}"
+        ] = x.node.layer.name
+
         x = layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="bn"
         )(x)

--- a/keras_cv/models/backbones/densenet/densenet_backbone_test.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_test.py
@@ -106,7 +106,7 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**1, input_size // 2**1, 256],
+            [None, input_size // 2**2, input_size // 2**2, 256],
         )
         self.assertEquals(
             outputs["P3"].shape,

--- a/keras_cv/models/backbones/densenet/densenet_backbone_test.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_test.py
@@ -102,18 +102,24 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**1, input_size // 2**1, 256],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 512],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 1024],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 1024],
+        )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/densenet/densenet_backbone_test.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_test.py
@@ -92,24 +92,28 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    def test_create_backbone_model_from_alias_model(self):
-        model = DenseNet121Backbone(
-            include_rescaling=False,
-        )
+    def test_feature_pyramid_inputs(self):
+        model = DenseNet121Backbone()
         backbone_model = get_feature_extractor(
             model,
             model.pyramid_level_inputs.values(),
             model.pyramid_level_inputs.keys(),
         )
-        inputs = tf.keras.Input(shape=[256, 256, 3])
+        input_size = 256
+        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-
-        levels = ["P2", "P3", "P4"]
-        self.assertLen(outputs, 3)
-        self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P2"].shape, [None, 32, 32, 128])
-        self.assertEquals(outputs["P3"].shape, [None, 16, 16, 256])
-        self.assertEquals(outputs["P4"].shape, [None, 8, 8, 512])
+        expected_levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), expected_levels)
+        # Size for each feature map at Pn is represents a feature map 2^n
+        # times smaller in width and height than the input image.
+        for level in model.pyramid_level_inputs:
+            level_int = int(level[1:])
+            self.assertEquals(
+                outputs[level].shape[1], input_size / 2**level_int
+            )
+            self.assertEquals(
+                outputs[level].shape[2], input_size / 2**level_int
+            )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -150,18 +150,28 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P1", "P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P1", "P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P1"].shape,
+            [None, input_size // 2**1, input_size // 2**1, 24],
+        )
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**2, input_size // 2**2, 48],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 64],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 160],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 1280],
+        )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_test.py
@@ -27,20 +27,6 @@ from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
 )
 from keras_cv.utils.train import get_feature_extractor
 
-# from https://arxiv.org/pdf/1905.02244.pdf
-pyramid_level_input_shapes = {
-    "mobilenet_v3_small": {
-        "P3": [None, 28, 28, 24],
-        "P4": [None, 14, 14, 48],
-        "P5": [None, 7, 7, 96],
-    },
-    "mobilenet_v3_large": {
-        "P3": [None, 28, 28, 40],
-        "P4": [None, 14, 14, 112],
-        "P5": [None, 7, 7, 160],
-    },
-}
-
 
 class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
@@ -87,18 +73,28 @@ class MobileNetV3BackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P1", "P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P1", "P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P1"].shape,
+            [None, input_size // 2**1, input_size // 2**1, 16],
+        )
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**2, input_size // 2**2, 16],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 24],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 48],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 96],
+        )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -117,18 +117,24 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**2, input_size // 2**2, 256],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 512],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 1024],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 2048],
+        )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -107,43 +107,28 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    def test_create_backbone_model_from_alias_model(self):
-        model = ResNet50Backbone(
-            include_rescaling=False,
-        )
+    def test_feature_pyramid_inputs(self):
+        model = ResNet50Backbone()
         backbone_model = get_feature_extractor(
             model,
             model.pyramid_level_inputs.values(),
             model.pyramid_level_inputs.keys(),
         )
-        inputs = keras.Input(shape=[256, 256, 3])
+        input_size = 256
+        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        # Resnet50 backbone has 4 level of features (P2 ~ P5)
-        levels = ["P2", "P3", "P4", "P5"]
-        self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 2048])
-
-    def test_create_backbone_model_with_level_config(self):
-        model = ResNetBackbone(
-            stackwise_filters=[64, 128, 256, 512],
-            stackwise_blocks=[2, 2, 2, 2],
-            stackwise_strides=[1, 2, 2, 2],
-            include_rescaling=False,
-            input_shape=[256, 256, 3],
-        )
-        levels = ["P3", "P4"]
-        layer_names = [model.pyramid_level_inputs[level] for level in levels]
-        backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = keras.Input(shape=[256, 256, 3])
-        outputs = backbone_model(inputs)
-        self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
+        expected_levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), expected_levels)
+        # Size for each feature map at Pn is represents a feature map 2^n
+        # times smaller in width and height than the input image.
+        for level in model.pyramid_level_inputs:
+            level_int = int(level[1:])
+            self.assertEquals(
+                outputs[level].shape[1], input_size / 2**level_int
+            )
+            self.assertEquals(
+                outputs[level].shape[2], input_size / 2**level_int
+            )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -108,18 +108,24 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         input_size = 256
         inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        expected_levels = ["P2", "P3", "P4", "P5"]
-        self.assertEquals(list(outputs.keys()), expected_levels)
-        # Size for each feature map at Pn is represents a feature map 2^n
-        # times smaller in width and height than the input image.
-        for level in model.pyramid_level_inputs:
-            level_int = int(level[1:])
-            self.assertEquals(
-                outputs[level].shape[1], input_size / 2**level_int
-            )
-            self.assertEquals(
-                outputs[level].shape[2], input_size / 2**level_int
-            )
+        levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), levels)
+        self.assertEquals(
+            outputs["P2"].shape,
+            [None, input_size // 2**2, input_size // 2**2, 256],
+        )
+        self.assertEquals(
+            outputs["P3"].shape,
+            [None, input_size // 2**3, input_size // 2**3, 512],
+        )
+        self.assertEquals(
+            outputs["P4"].shape,
+            [None, input_size // 2**4, input_size // 2**4, 1024],
+        )
+        self.assertEquals(
+            outputs["P5"].shape,
+            [None, input_size // 2**5, input_size // 2**5, 2048],
+        )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -98,43 +98,28 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         restored_output = restored_model(self.input_batch)
         self.assertAllClose(model_output, restored_output)
 
-    def test_create_backbone_model_from_alias_model(self):
-        model = ResNet50V2Backbone(
-            include_rescaling=False,
-        )
+    def test_feature_pyramid_inputs(self):
+        model = ResNet50V2Backbone()
         backbone_model = get_feature_extractor(
             model,
             model.pyramid_level_inputs.values(),
             model.pyramid_level_inputs.keys(),
         )
-        inputs = keras.Input(shape=[256, 256, 3])
+        input_size = 256
+        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
-        # Resnet50 backbone has 4 level of features (P2 ~ P5)
-        levels = ["P2", "P3", "P4", "P5"]
-        self.assertLen(outputs, 4)
-        self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P2"].shape, [None, 64, 64, 256])
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
-        self.assertEquals(outputs["P5"].shape, [None, 8, 8, 2048])
-
-    def test_create_backbone_model_with_level_config(self):
-        model = ResNetV2Backbone(
-            stackwise_filters=[64, 128, 256, 512],
-            stackwise_blocks=[2, 2, 2, 2],
-            stackwise_strides=[1, 2, 2, 2],
-            include_rescaling=False,
-            input_shape=[256, 256, 3],
-        )
-        levels = ["P3", "P4"]
-        layer_names = [model.pyramid_level_inputs[level] for level in levels]
-        backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = keras.Input(shape=[256, 256, 3])
-        outputs = backbone_model(inputs)
-        self.assertLen(outputs, 2)
-        self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P3"].shape, [None, 32, 32, 512])
-        self.assertEquals(outputs["P4"].shape, [None, 16, 16, 1024])
+        expected_levels = ["P2", "P3", "P4", "P5"]
+        self.assertEquals(list(outputs.keys()), expected_levels)
+        # Size for each feature map at Pn is represents a feature map 2^n
+        # times smaller in width and height than the input image.
+        for level in model.pyramid_level_inputs:
+            level_int = int(level[1:])
+            self.assertEquals(
+                outputs[level].shape[1], input_size / 2**level_int
+            )
+            self.assertEquals(
+                outputs[level].shape[2], input_size / 2**level_int
+            )
 
     @parameterized.named_parameters(
         ("one_channel", 1),

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
@@ -18,7 +18,7 @@ from absl.testing import parameterized
 from tensorflow import keras
 from tensorflow.keras import optimizers
 
-from keras_cv.models import ResNet50V2Backbone
+from keras_cv.models import ResNet18V2Backbone
 from keras_cv.models.legacy.object_detection.faster_rcnn.faster_rcnn import (
     FasterRCNN,
 )
@@ -37,7 +37,7 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         model = FasterRCNN(
             num_classes=80,
             bounding_box_format="xyxy",
-            backbone=ResNet50V2Backbone(),
+            backbone=ResNet18V2Backbone(),
         )
         images = tf.random.normal(batch_shape)
         outputs = model(images, training=False)
@@ -54,7 +54,7 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         model = FasterRCNN(
             num_classes=80,
             bounding_box_format="xyxy",
-            backbone=ResNet50V2Backbone(),
+            backbone=ResNet18V2Backbone(),
         )
         images = tf.random.normal(batch_shape)
         outputs = model(images, training=True)
@@ -65,7 +65,7 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         model = FasterRCNN(
             num_classes=80,
             bounding_box_format="yxyx",
-            backbone=ResNet50V2Backbone(),
+            backbone=ResNet18V2Backbone(),
         )
         with self.assertRaisesRegex(ValueError, "only accepts"):
             model.compile(rpn_box_loss="binary_crossentropy")
@@ -81,7 +81,7 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         faster_rcnn = FasterRCNN(
             num_classes=20,
             bounding_box_format="xywh",
-            backbone=ResNet50V2Backbone(),
+            backbone=ResNet18V2Backbone(),
         )
 
         images, boxes = _create_bounding_box_dataset("xywh")


### PR DESCRIPTION
Our current testing our `pyramid_level_inputs` involves two fairly redundant tests that don't verify what we actually care about:
1. are the expected levels there
2. are they the expected shape

As a result, our current tests failed to catch incorrect `feature_pyramid_inputs` in our new DenseNet models. They current grab the tensor AFTER pooling when it should be the last tensor BEFORE pooling.