### PR TITLE
Fix off-by-one issue with RetinaNet anchor generation

### DIFF
--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-
 import tensorflow as tf
 from tensorflow import keras
 
@@ -265,13 +263,13 @@ class _SingleAnchorGenerator:
         # `stride`, also for sizes where `image_width % stride != 0`.
         # [W]
         cx = tf.range(
-            0.5 * stride, math.ceil(image_width / stride) * stride, stride
+            0.5 * stride, tf.math.ceil(image_width / stride) * stride, stride
         )
         # make sure range of `cy` is within limit of `image_height` with
         # `stride`, also for sizes where `image_height % stride != 0`.
         # [H]
         cy = tf.range(
-            0.5 * stride, math.ceil(image_height / stride) * stride, stride
+            0.5 * stride, tf.math.ceil(image_height / stride) * stride, stride
         )
         # [H, W]
         cx_grid, cy_grid = tf.meshgrid(cx, cy)

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -294,6 +294,7 @@ class _SingleAnchorGenerator:
             x_min = tf.maximum(tf.minimum(x_min, image_width), 0.0)
             x_max = tf.maximum(tf.minimum(x_max, image_width), 0.0)
 
+        # [H * W * K, 4]
         return tf.cast(
             tf.concat([y_min, x_min, y_max, x_max], axis=-1), self.dtype
         )

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -294,6 +294,6 @@ class _SingleAnchorGenerator:
             x_min = tf.maximum(tf.minimum(x_min, image_width), 0.0)
             x_max = tf.maximum(tf.minimum(x_max, image_width), 0.0)
 
-        return = tf.cast(
+        return tf.cast(
             tf.concat([y_min, x_min, y_max, x_max], axis=-1), self.dtype
         )

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -294,12 +294,6 @@ class _SingleAnchorGenerator:
             x_min = tf.maximum(tf.minimum(x_min, image_width), 0.0)
             x_max = tf.maximum(tf.minimum(x_max, image_width), 0.0)
 
-        boxes = tf.cast(
+        return = tf.cast(
             tf.concat([y_min, x_min, y_max, x_max], axis=-1), self.dtype
         )
-
-        # If we clipped boxes, there may be some with an area of 0 which we
-        # should remove
-        areas = (y_max - y_min) * (x_max - x_min)
-        return boxes
-        return tf.boolean_mask(boxes, tf.squeeze(areas > 0))

--- a/keras_cv/layers/object_detection/anchor_generator_test.py
+++ b/keras_cv/layers/object_detection/anchor_generator_test.py
@@ -71,11 +71,12 @@ class AnchorGeneratorTest(tf.test.TestCase, parameterized.TestCase):
         boxes = anchor_generator(image=image)
         boxes = tf.concat(list(boxes.values()), axis=0)
 
-        expected_box_shapes = (
-            (image_shape[0] // tf.constant(strides))
-            * (image_shape[1] // tf.constant(strides))
+        expected_box_shapes = tf.cast(
+            tf.math.ceil(image_shape[0] / tf.constant(strides))
+            * tf.math.ceil(image_shape[1] / tf.constant(strides))
             * len(scales)
-            * len(aspect_ratios)
+            * len(aspect_ratios),
+            tf.int32,
         )
 
         sum_expected_shape = (expected_box_shapes.numpy().sum(), 4)
@@ -102,11 +103,12 @@ class AnchorGeneratorTest(tf.test.TestCase, parameterized.TestCase):
         boxes = anchor_generator(image_shape=image_shape)
         boxes = tf.concat(list(boxes.values()), axis=0)
 
-        expected_box_shapes = (
-            (image_shape[0] // tf.constant(strides))
-            * (image_shape[1] // tf.constant(strides))
+        expected_box_shapes = tf.cast(
+            tf.math.ceil(image_shape[0] / tf.constant(strides))
+            * tf.math.ceil(image_shape[1] / tf.constant(strides))
             * len(scales)
-            * len(aspect_ratios)
+            * len(aspect_ratios),
+            tf.int32,
         )
 
         sum_expected_shape = (expected_box_shapes.numpy().sum(), 4)

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn_test.py
@@ -28,10 +28,15 @@ from keras_cv.models.object_detection.__test_utils__ import (
 
 
 class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
+    # TODO(ianstenbit): Make FasterRCNN support shapes that are not multiples
+    # of 128, perhaps by adding a flag to the anchor generator for whether to
+    # include anchors centered outside of the image. (RetinaNet does use those,
+    # while FasterRCNN doesn't). For more context on why this is the case, see
+    # https://github.com/keras-team/keras-cv/pull/1882
     @parameterized.parameters(
-        ((2, 640, 480, 3),),
+        ((2, 640, 384, 3),),
         ((2, 512, 512, 3),),
-        ((2, 224, 224, 3),),
+        ((2, 128, 128, 3),),
     )
     def test_faster_rcnn_infer(self, batch_shape):
         model = FasterRCNN(
@@ -46,9 +51,9 @@ class FasterRCNNTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllEqual([2, 1000, 4], outputs[0].shape)
 
     @parameterized.parameters(
-        ((2, 640, 480, 3),),
+        ((2, 640, 384, 3),),
         ((2, 512, 512, 3),),
-        ((2, 224, 224, 3),),
+        ((2, 128, 128, 3),),
     )
     def test_faster_rcnn_train(self, batch_shape):
         model = FasterRCNN(


### PR DESCRIPTION
Currently, RetinaNet anchor generation is broken when input images have a size that doesn't line up with the `strides` of the AnchorGenerator. Therefore, using the default anchor generator, only images with a width and height that are a multiple of 128 work.

Fixes #1869, which uncovered this issue.

I've re-run the RetinaNet OD guide with this change, and it now works for image sizes that are not multiples of 128.