### PR TITLE
Add "feature_pyramid" as parameter inside RetinaNet __init__

### DIFF
--- a/keras_cv/models/object_detection/retinanet/feature_pyramid.py
+++ b/keras_cv/models/object_detection/retinanet/feature_pyramid.py
@@ -49,10 +49,4 @@ class FeaturePyramid(keras.layers.Layer):
         p5_output = self.conv_c5_3x3(p5_output, training=training)
         p6_output = self.conv_c6_3x3(c5_output, training=training)
         p7_output = self.conv_c7_3x3(tf.nn.relu(p6_output), training=training)
-        return {
-            "P3": p3_output,
-            "P4": p4_output,
-            "P5": p5_output,
-            "P6": p6_output,
-            "P7": p7_output,
-        }
+        return p3_output, p4_output, p5_output, p6_output, p7_output

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -119,6 +119,10 @@ class RetinaNet(Task):
             default `prediction_decoder` layer is a
             `keras_cv.layers.MultiClassNonMaxSuppression` layer, which uses
             a Non-Max Suppression for box pruning.
+        feature_pyramid: (Optional) A `keras.layers.Layer` that is
+            responsible for extracting features from intermediate backbone
+            layers. If not provided, the reference implementation from
+            the paper will be used.
         classification_head: (Optional) A `keras.Layer` that performs
             classification of the bounding boxes. If not provided, a simple
             ConvNet with 3 layers will be used.
@@ -135,6 +139,7 @@ class RetinaNet(Task):
         anchor_generator=None,
         label_encoder=None,
         prediction_decoder=None,
+        feature_pyramid=None,
         classification_head=None,
         box_head=None,
         **kwargs,
@@ -169,7 +174,7 @@ class RetinaNet(Task):
         feature_extractor = get_feature_extractor(
             backbone, extractor_layer_names, extractor_levels
         )
-        feature_pyramid = FeaturePyramid()
+        feature_pyramid = feature_pyramid or FeaturePyramid()
 
         prior_probability = keras.initializers.Constant(
             -np.log((1 - 0.01) / 0.01)

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -122,8 +122,8 @@ class RetinaNet(Task):
             a Non-Max Suppression for box pruning.
         feature_pyramid: (Optional) A `keras.layers.Layer` that produces
             a list of 4D feature maps (batch dimension included)
-            when called on the `backbone`. If not provided, the reference
-            implementation from the paper will be used.
+            when called on the pyramid-level outputs of the `backbone`.
+            If not provided, the reference implementation from the paper will be used.
         classification_head: (Optional) A `keras.Layer` that performs
             classification of the bounding boxes. If not provided, a simple
             ConvNet with 3 layers will be used.

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -93,8 +93,8 @@ class RetinaNet(Task):
             Refer
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
-        backbone: `keras.Model`. If the default `feature_pyramid` is used, 
-            must implement the `pyramid_level_inputs` property with keys "P3", "P4", 
+        backbone: `keras.Model`. If the default `feature_pyramid` is used,
+            must implement the `pyramid_level_inputs` property with keys "P3", "P4",
             and "P5" and layer names as values. A somewhat sensible backbone
             to use in many cases is the:
             `keras_cv.models.ResNetBackbone.from_preset("resnet50_imagenet")`
@@ -122,7 +122,7 @@ class RetinaNet(Task):
             a Non-Max Suppression for box pruning.
         feature_pyramid: (Optional) A `keras.layers.Layer` that produces
             a list of 4D feature maps (batch dimension included)
-            when called on the `backbone`. If not provided, the reference 
+            when called on the `backbone`. If not provided, the reference
             implementation from the paper will be used.
         classification_head: (Optional) A `keras.Layer` that performs
             classification of the bounding boxes. If not provided, a simple

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -93,9 +93,10 @@ class RetinaNet(Task):
             Refer
             [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
             for more details on supported bounding box formats.
-        backbone: `keras.Model`. Must implement the `pyramid_level_inputs`
-            property with keys "P3", "P4", and "P5" and layer names as values.
-            A somewhat sensible backbone to use in many cases is the:
+        backbone: `keras.Model`. If the default `feature_pyramid` is used, 
+            must implement the `pyramid_level_inputs` property with keys "P3", "P4", 
+            and "P5" and layer names as values. A somewhat sensible backbone
+            to use in many cases is the:
             `keras_cv.models.ResNetBackbone.from_preset("resnet50_imagenet")`
         anchor_generator: (Optional) a `keras_cv.layers.AnchorGenerator`. If
             provided, the anchor generator will be passed to both the
@@ -119,10 +120,10 @@ class RetinaNet(Task):
             default `prediction_decoder` layer is a
             `keras_cv.layers.MultiClassNonMaxSuppression` layer, which uses
             a Non-Max Suppression for box pruning.
-        feature_pyramid: (Optional) A `keras.layers.Layer` that is
-            responsible for extracting features from intermediate backbone
-            layers. If not provided, the reference implementation from
-            the paper will be used.
+        feature_pyramid: (Optional) A `keras.layers.Layer` that produces
+            a list of 4D feature maps (batch dimension included)
+            when called on the `backbone`. If not provided, the reference 
+            implementation from the paper will be used.
         classification_head: (Optional) A `keras.Layer` that performs
             classification of the bounding boxes. If not provided, a simple
             ConvNet with 3 layers will be used.
@@ -196,9 +197,7 @@ class RetinaNet(Task):
         batch_size = tf.shape(images)[0]
         cls_pred = []
         box_pred = []
-        pyramid_levels = ["P3", "P4", "P5", "P6", "P7"]
-        for pyramid_level in pyramid_levels:
-            feature = features[pyramid_level]
+        for feature in features:
             box_pred.append(tf.reshape(box_head(feature), [batch_size, -1, 4]))
             cls_pred.append(
                 tf.reshape(


### PR DESCRIPTION
Fixes #1884. 

This PR adds a "feature_pyramid" parameter so that users can use their own custom FPN inside the RetinaNet meta-architecture. 