### PR TITLE
Add YOLOV8 backbone presets to the global backbone registry

### DIFF
--- a/keras_cv/models/backbones/backbone_presets.py
+++ b/keras_cv/models/backbones/backbone_presets.py
@@ -22,6 +22,7 @@ from keras_cv.models.backbones.efficientnet_v2 import (
 from keras_cv.models.backbones.mobilenet_v3 import mobilenet_v3_backbone_presets
 from keras_cv.models.backbones.resnet_v1 import resnet_v1_backbone_presets
 from keras_cv.models.backbones.resnet_v2 import resnet_v2_backbone_presets
+from keras_cv.models.object_detection.yolo_v8 import yolo_v8_backbone_presets
 
 backbone_presets_no_weights = {
     **resnet_v1_backbone_presets.backbone_presets_no_weights,
@@ -30,6 +31,7 @@ backbone_presets_no_weights = {
     **csp_darknet_backbone_presets.backbone_presets_no_weights,
     **efficientnet_v2_backbone_presets.backbone_presets_no_weights,
     **densenet_backbone_presets.backbone_presets_no_weights,
+    **yolo_v8_backbone_presets.backbone_presets_no_weights,
 }
 
 backbone_presets_with_weights = {
@@ -39,6 +41,7 @@ backbone_presets_with_weights = {
     **csp_darknet_backbone_presets.backbone_presets_with_weights,
     **efficientnet_v2_backbone_presets.backbone_presets_with_weights,
     **densenet_backbone_presets.backbone_presets_with_weights,
+    **yolo_v8_backbone_presets.backbone_presets_with_weights,
 }
 
 backbone_presets = {


### PR DESCRIPTION
We didn't do this initially because we thought the YOLOV8 backbone wouldn't stick around for long, but that is no longer true.