### PR TITLE
Port preprocessing layers and bounding box utils to Keras Core [try 2]

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,7 @@ jobs:
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
-        pip install keras-core/
+        python keras_core/pip_build.py --install
         pip install "jax[cpu]"
     - name: Test with pytest
       env:
@@ -84,7 +84,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         git clone git@github.com:keras-team/keras-core.git
-        pip install keras-core/
+        python keras_core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,12 +27,11 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+        ssh-key: ${{ secrets.KERAS_CORE }}
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.KERAS_CORE }}'
         git clone git@github.com:keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
@@ -66,11 +65,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+        ssh-key: ${{ secrets.KERAS_CORE }}
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.KERAS_CORE }}'
         git clone git@github.com:keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://www.github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,7 +43,7 @@ jobs:
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
         pip install -r keras-core/requirements.txt
-        python keras-core/pip_build.py --install
+        pip install keras-core/
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false
@@ -90,7 +90,7 @@ jobs:
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
         pip install -r keras-core/requirements.txt
-        python keras-core/pip_build.py --install
+        pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,7 @@ jobs:
         pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
-        pip install keras-core/requirements.txt
+        pip install -r keras-core/requirements.txt
         python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
@@ -89,7 +89,7 @@ jobs:
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
-        pip install keras-core/requirements.txt
+        pip install -r keras-core/requirements.txt
         python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,7 @@ jobs:
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
-        python keras_core/pip_build.py --install
+        python keras-core/pip_build.py --install
         pip install "jax[cpu]"
     - name: Test with pytest
       env:
@@ -84,7 +84,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         git clone git@github.com:keras-team/keras-core.git
-        python keras_core/pip_build.py --install
+        python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,8 +27,15 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-        ssh-key: ${{ secrets.KERAS_CORE }}
+    - name: Setup SSH Keys and known_hosts
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
     - name: Install dependencies
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
@@ -65,8 +72,15 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-        ssh-key: ${{ secrets.KERAS_CORE }}
+    - name: Setup SSH Keys and known_hosts
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
     - name: Install dependencies
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
         git clone git@github.com:keras-team/keras-core.git

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,6 +38,7 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
+        pip install torch>=2.0.1+cpu
         pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
@@ -88,8 +89,8 @@ jobs:
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
-        python keras-core/pip_build.py --install
         pip install namex
+        python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,10 +38,11 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
+        pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
+        pip install namex
         python keras-core/pip_build.py --install
-        pip install "jax[cpu]"
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false
@@ -83,12 +84,13 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
-        git clone git@github.com:keras-team/keras-core.git
-        python keras-core/pip_build.py --install
-        pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
+        git clone git@github.com:keras-team/keras-core.git
+        python keras-core/pip_build.py --install
+        pip install namex
+        pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false # TODO(ianstenbit): test custom ops, or figure out what our story is here

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://www.github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://www.github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://ianstenbit:${{ secrets.GITHUB_TOKEN }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://ianstenbit:${{ secrets.GITHUB_TOKEN }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://github.com/keras-team/keras-core.git
+        git clone https://www.github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,7 @@ jobs:
         pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
-        pip install namex
+        pip install namex rich
         python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
@@ -89,7 +89,7 @@ jobs:
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
-        pip install namex
+        pip install namex rich
         python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,7 @@ jobs:
         pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
-        pip install namex rich
+        pip install keras-core/requirements.txt
         python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
@@ -89,7 +89,7 @@ jobs:
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
-        pip install namex rich
+        pip install keras-core/requirements.txt
         python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,9 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.KERAS_CORE }}'
+        git clone git@github.com:keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +69,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.KERAS_CORE }}'
+        git clone git@github.com:keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -78,6 +78,7 @@ jobs:
         TEST_CUSTOM_OPS: false # TODO(ianstenbit): test custom ops, or figure out what our story is here
         KERAS_CV_MULTI_BACKEND: true
         KERAS_BACKEND: ${{ matrix.backend }}
+        JAX_ENABLE_X64: true
       run: |
         pytest --run_large keras_cv/bounding_box \
                keras_cv/layers/preprocessing \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.GITHUB_TOKEN }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.GITHUB_TOKEN }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,7 +43,7 @@ jobs:
         pip install -e ".[tests]" --progress-bar off --upgrade
         git clone git@github.com:keras-team/keras-core.git
         pip install -r keras-core/requirements.txt
-        pip install keras-core/
+        python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false
@@ -90,7 +90,7 @@ jobs:
         pip install torchvision>=0.15.1
         git clone git@github.com:keras-team/keras-core.git
         pip install -r keras-core/requirements.txt
-        pip install keras-core/
+        python keras-core/pip_build.py --install
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,14 +7,14 @@ on:
     types: [created]
 jobs:
   test:
-    name: Test the code
+    name: Test the code with tf.keras
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -29,27 +29,68 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow-cpu==2.11.0
+        pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-    - name: Build custom ops for tests
-      run: |
-        python build_deps/configure.py
-        bazel build keras_cv/custom_ops:all
-        cp bazel-bin/keras_cv/custom_ops/*.so keras_cv/custom_ops/
+        git clone https://github.com/keras-team/keras-core.git
+        pip install keras-core/
+        pip install "jax[cpu]"
     - name: Test with pytest
       env:
-        TEST_CUSTOM_OPS: true
+        TEST_CUSTOM_OPS: false
       run: |
         pytest keras_cv/ --ignore keras_cv/models/legacy/ --durations 0
+  multibackend:
+    name: Test the code with Keras Core
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -m pip install --upgrade pip setuptools
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        pip install tensorflow==2.12.0
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        pip install keras-core/
+        pip install -e ".[tests]" --progress-bar off --upgrade
+        pip install "jax[cpu]"
+        pip install torch>=2.0.1+cpu
+        pip install torchvision>=0.15.1
+    - name: Test with pytest
+      env:
+        TEST_CUSTOM_OPS: false # TODO(ianstenbit): test custom ops, or figure out what our story is here
+        KERAS_CV_MULTI_BACKEND: true
+        KERAS_BACKEND: ${{ matrix.backend }}
+      run: |
+        pytest --run_large keras_cv/bounding_box \
+               keras_cv/layers/preprocessing \
+               --durations 0
   format:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -75,4 +116,3 @@ jobs:
         extensions: 'h,c,cpp,hpp,cc'
         clangFormatVersion: 14
         style: google
-  

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pip install tensorflow==2.12.0
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone https://${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install "jax[cpu]"
     - name: Test with pytest
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tensorflow==2.12.0
-        git clone https://${{ secrets.PAT }}@github.com/keras-team/keras-core.git
+        git clone https://ianstenbit:${{ secrets.PAT }}@github.com/keras-team/keras-core.git
         pip install keras-core/
         pip install -e ".[tests]" --progress-bar off --upgrade
         pip install "jax[cpu]"

--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    # When using torch and tensorflow, torch needs to be imported first,
+    # otherwise it will segfault upon import.
+    import torch
+
+    del torch
+except ImportError:
+    pass
+
 # isort:off
 from keras_cv import version_check
 

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Keras backend module.
+
 This module adds a temporarily Keras API surface that is fully under KerasCV
 control. This allows us to switch between `keras_core` and `tf.keras`, as well
 as add shims to support older version of `tf.keras`.

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -11,6 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Keras backend module.
+This module adds a temporarily Keras API surface that is fully under KerasCV
+control. This allows us to switch between `keras_core` and `tf.keras`, as well
+as add shims to support older version of `tf.keras`.
+- `config`: check which backend is being run.
+- `keras`: The full `keras` API (via `keras_core` or `tf.keras`).
+- `ops`: `keras_core.ops`, always tf-backed if using `tf.keras`.
+"""
+
 from keras_cv.backend.config import multi_backend
 
 # Keys are of the form: "module.where.attr.exists->module.where.to.alias"
@@ -58,6 +68,7 @@ else:
     # TF Keras doesn't have this rename.
     keras.activations.silu = keras.activations.swish
 
+from keras_cv.backend import config  # noqa: E402
 from keras_cv.backend import ops  # noqa: E402
 from keras_cv.backend import tf_ops  # noqa: E402
 

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -23,9 +23,7 @@ _KERAS_CORE_ALIASES = {
         "serialize_keras_object",
         "get_registered_object",
     ],
-    "utils.file_utils->utils": ["get_file"],
     "saving->models": ["load_model"],
-    "utils.naming->backend": ["get_uid"],
 }
 
 

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -59,6 +59,9 @@ else:
 
     # TF Keras doesn't have this rename.
     keras.activations.silu = keras.activations.swish
+    keras.mixed_precision.set_dtype_policy = (
+        keras.mixed_precision.set_global_policy
+    )
 
 from keras_cv.backend import ops  # noqa: E402
 from keras_cv.backend import tf_ops  # noqa: E402

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -1,0 +1,72 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.backend.config import multi_backend
+
+# Keys are of the form: "module.where.attr.exists->module.where.to.alias"
+# Value are of the form: ["attr1", "attr2", ...] or
+#                        [("attr1_original_name", "attr1_alias_name")]
+_KERAS_CORE_ALIASES = {
+    "saving->utils": [
+        "register_keras_serializable",
+        "deserialize_keras_object",
+        "serialize_keras_object",
+        "get_registered_object",
+    ],
+    "utils.file_utils->utils": ["get_file"],
+    "saving->layers": [
+        ("serialize_keras_object", "serialize"),
+        ("deserialize_keras_object", "deserialize"),
+    ],
+    "saving->models": ["load_model"],
+    "utils.naming->backend": ["get_uid"],
+}
+
+
+if multi_backend():
+    import keras_core as keras
+
+    # add aliases
+    for key, value in _KERAS_CORE_ALIASES.items():
+        src, _, dst = key.partition("->")
+        src = src.split(".")
+        dst = dst.split(".")
+
+        src_mod, dst_mod = keras, keras
+
+        # navigate to where we want to alias the attributes
+        for mod in src:
+            src_mod = getattr(src_mod, mod)
+        for mod in dst:
+            dst_mod = getattr(dst_mod, mod)
+
+        # add an alias for each attribute
+        for attr in value:
+            if isinstance(attr, tuple):
+                src_attr, dst_attr = attr
+            else:
+                src_attr, dst_attr = attr, attr
+            attr_val = getattr(src_mod, src_attr)
+            setattr(dst_mod, dst_attr, attr_val)
+else:
+    from tensorflow import keras
+
+    # TF Keras doesn't have this rename.
+    keras.activations.silu = keras.activations.swish
+
+from keras_cv.backend import ops  # noqa: E402
+from keras_cv.backend import tf_ops  # noqa: E402
+
+
+def supports_ragged():
+    return not multi_backend()

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -57,9 +57,6 @@ else:
 
     # TF Keras doesn't have this rename.
     keras.activations.silu = keras.activations.swish
-    keras.mixed_precision.set_dtype_policy = (
-        keras.mixed_precision.set_global_policy
-    )
 
 from keras_cv.backend import ops  # noqa: E402
 from keras_cv.backend import tf_ops  # noqa: E402

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -24,10 +24,6 @@ _KERAS_CORE_ALIASES = {
         "get_registered_object",
     ],
     "utils.file_utils->utils": ["get_file"],
-    "saving->layers": [
-        ("serialize_keras_object", "serialize"),
-        ("deserialize_keras_object", "deserialize"),
-    ],
     "saving->models": ["load_model"],
     "utils.naming->backend": ["get_uid"],
 }

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -17,18 +17,20 @@ from keras_cv.backend.config import multi_backend
 # Value are of the form: ["attr1", "attr2", ...] or
 #                        [("attr1_original_name", "attr1_alias_name")]
 _KERAS_CORE_ALIASES = {
-    "saving->utils": [
+    "utils->saving": [
         "register_keras_serializable",
         "deserialize_keras_object",
         "serialize_keras_object",
         "get_registered_object",
     ],
-    "saving->models": ["load_model"],
+    "models->saving": ["load_model"],
 }
 
 
 if multi_backend():
     import keras_core as keras
+else:
+    from tensorflow import keras
 
     # add aliases
     for key, value in _KERAS_CORE_ALIASES.items():
@@ -52,8 +54,6 @@ if multi_backend():
                 src_attr, dst_attr = attr, attr
             attr_val = getattr(src_mod, src_attr)
             setattr(dst_mod, dst_attr, attr_val)
-else:
-    from tensorflow import keras
 
     # TF Keras doesn't have this rename.
     keras.activations.silu = keras.activations.swish

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -61,6 +61,13 @@ if "KERAS_CV_MULTI_BACKEND" in os.environ:
     if os.environ["KERAS_CV_MULTI_BACKEND"]:
         _MULTI_BACKEND = True
 
+if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"] in [
+    "jax",
+    "torch",
+    "tensorflow",
+]:
+    _MULTI_BACKEND = True
+
 
 def multi_backend():
     return _MULTI_BACKEND

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -1,0 +1,66 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+
+_MULTI_BACKEND = False
+
+# Set Keras base dir path given KERAS_HOME env variable, if applicable.
+# Otherwise either ~/.keras or /tmp.
+if "KERAS_HOME" in os.environ:
+    _keras_dir = os.environ.get("KERAS_HOME")
+else:
+    _keras_base_dir = os.path.expanduser("~")
+    if not os.access(_keras_base_dir, os.W_OK):
+        _keras_base_dir = "/tmp"
+    _keras_dir = os.path.join(_keras_base_dir, ".keras")
+
+# Attempt to read KerasCV config file.
+_config_path = os.path.expanduser(os.path.join(_keras_dir, "keras-cv.json"))
+if os.path.exists(_config_path):
+    try:
+        with open(_config_path) as f:
+            _config = json.load(f)
+    except ValueError:
+        _config = {}
+    _MULTI_BACKEND = _config.get("multi_backend", _MULTI_BACKEND)
+
+# Save config file, if possible.
+if not os.path.exists(_keras_dir):
+    try:
+        os.makedirs(_keras_dir)
+    except OSError:
+        # Except permission denied and potential race conditions
+        # in multi-threaded environments.
+        pass
+
+if not os.path.exists(_config_path):
+    _config = {
+        "multi_backend": _MULTI_BACKEND,
+    }
+    try:
+        with open(_config_path, "w") as f:
+            f.write(json.dumps(_config, indent=4))
+    except IOError:
+        # Except permission denied.
+        pass
+
+# Set Keras backend based on KERAS_CV_MULTI_BACKEND flag, if applicable.
+if "KERAS_CV_MULTI_BACKEND" in os.environ:
+    if os.environ["KERAS_CV_MULTI_BACKEND"]:
+        _MULTI_BACKEND = True
+
+
+def multi_backend():
+    return _MULTI_BACKEND

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -61,11 +61,7 @@ if "KERAS_CV_MULTI_BACKEND" in os.environ:
     if os.environ["KERAS_CV_MULTI_BACKEND"]:
         _MULTI_BACKEND = True
 
-if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"] in [
-    "jax",
-    "torch",
-    "tensorflow",
-]:
+if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
     _MULTI_BACKEND = True
 
 

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -14,9 +14,10 @@
 from keras_cv.backend.config import multi_backend
 
 if multi_backend():
-    from keras_core.backend import convert_to_numpy  # noqa: F403, F401
-    from keras_core.backend import vectorized_map  # noqa: F403, F401
-    from keras_core.ops import *  # noqa: F403, F401
-    from keras_core.utils.image_utils import smart_resize  # noqa: F403, F401
+    from keras_core.src.backend import vectorized_map  # noqa: F403, F401
+    from keras_core.src.ops import *  # noqa: F403, F401
+    from keras_core.src.utils.image_utils import (  # noqa: F403, F401
+        smart_resize,
+    )
 else:
     from keras_cv.backend.tf_ops import *  # noqa: F403, F401

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -16,7 +16,7 @@ from keras_cv.backend.config import multi_backend
 if multi_backend():
     from keras_core.backend import convert_to_numpy  # noqa: F403, F401
     from keras_core.backend import vectorized_map  # noqa: F403, F401
-    from keras_core.operations import *  # noqa: F403, F401
+    from keras_core.ops import *  # noqa: F403, F401
     from keras_core.utils.image_utils import smart_resize  # noqa: F403, F401
 else:
     from keras_cv.backend.tf_ops import *  # noqa: F403, F401

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -1,0 +1,22 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.backend.config import multi_backend
+
+if multi_backend():
+    from keras_core.backend import convert_to_numpy  # noqa: F403, F401
+    from keras_core.backend import vectorized_map  # noqa: F403, F401
+    from keras_core.operations import *  # noqa: F403, F401
+    from keras_core.utils.image_utils import smart_resize  # noqa: F403, F401
+else:
+    from keras_cv.backend.tf_ops import *  # noqa: F403, F401

--- a/keras_cv/backend/scope.py
+++ b/keras_cv/backend/scope.py
@@ -30,7 +30,7 @@ _IN_TF_DATA_SCOPE = 0
 def tf_data(function):
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
-        if multi_backend() and keras.utils.backend_utils.in_tf_graph():
+        if multi_backend() and keras.src.utils.backend_utils.in_tf_graph():
             with TFDataScope():
                 return function(*args, **kwargs)
         else:

--- a/keras_cv/backend/scope.py
+++ b/keras_cv/backend/scope.py
@@ -1,0 +1,49 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import functools
+
+from keras_cv import backend
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend import tf_ops
+from keras_cv.backend.config import multi_backend
+
+_ORIGINAL_OPS = copy.copy(backend.ops.__dict__)
+_ORIGINAL_SUPPORTS_RAGGED = backend.supports_ragged
+
+
+def tf_data(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        if multi_backend() and keras.utils.backend_utils.in_tf_graph():
+            with TFDataScope():
+                return function(*args, **kwargs)
+        else:
+            return function(*args, **kwargs)
+
+    return wrapper
+
+
+class TFDataScope:
+    def __enter__(self):
+        for k, v in ops.__dict__.items():
+            if k in tf_ops.__dict__:
+                setattr(ops, k, getattr(tf_ops, k))
+        backend.supports_ragged = lambda: True
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        for k, v in ops.__dict__.items():
+            setattr(ops, k, _ORIGINAL_OPS[k])
+        backend.supports_ragged = _ORIGINAL_SUPPORTS_RAGGED

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -11,11 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from keras_core.backend.tensorflow import *  # noqa: F403, F401
-from keras_core.backend.tensorflow.core import *  # noqa: F403, F401
-from keras_core.backend.tensorflow.math import *  # noqa: F403, F401
-from keras_core.backend.tensorflow.nn import *  # noqa: F403, F401
-from keras_core.backend.tensorflow.numpy import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow import (  # noqa: F403, F401
+    convert_to_numpy,
+)
+from keras_core.src.backend.tensorflow.core import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.math import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.nn import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.numpy import *  # noqa: F403, F401
 
 # Some TF APIs where the numpy API doesn't support raggeds that we need
 from tensorflow import concat as concatenate  # noqa: F403, F401
@@ -26,5 +29,3 @@ from tensorflow import split  # noqa: F403, F401
 from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
     smart_resize,
 )
-
-convert_to_numpy = lambda x: x.numpy() if is_tensor(x) else x  # noqa: F405

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -1,0 +1,30 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_core.backend.tensorflow import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.core import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.math import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.nn import *  # noqa: F403, F401
+from keras_core.backend.tensorflow.numpy import *  # noqa: F403, F401
+
+# Some TF APIs where the numpy API doesn't support raggeds that we need
+from tensorflow import concat as concatenate  # noqa: F403, F401
+from tensorflow import range as arange  # noqa: F403, F401
+from tensorflow import reduce_max as max  # noqa: F403, F401
+from tensorflow import reshape  # noqa: F403, F401
+from tensorflow import split  # noqa: F403, F401
+from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
+    smart_resize,
+)
+
+convert_to_numpy = lambda x: x.numpy() if is_tensor(x) else x  # noqa: F405

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -31,11 +31,11 @@ ALL_AXES = 4
 
 
 def _encode_box_to_deltas(
-    anchors: any,
-    boxes: any,
+    anchors,
+    boxes,
     anchor_format: str,
     box_format: str,
-    variance: any = None,
+    variance=None,
     image_shape=None,
 ):
     """Converts bounding_boxes from `center_yxhw` to delta format."""
@@ -72,11 +72,11 @@ def _encode_box_to_deltas(
 
 
 def _decode_deltas_to_boxes(
-    anchors: any,
-    boxes_delta: any,
+    anchors,
+    boxes_delta,
     anchor_format: str,
     box_format: str,
-    variance: any = None,
+    variance=None,
     image_shape=None,
 ):
     """Converts bounding_boxes from delta format to `center_yxhw`."""

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -8,17 +8,17 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF any KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Converter functions for working with bounding box formats."""
 
-from typing import List
-from typing import Optional
-from typing import Union
 
 import tensorflow as tf
-from tensorflow import keras
+
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend.scope import tf_data
 
 
 # Internal exception to propagate the fact images was not passed to a converter
@@ -27,23 +27,22 @@ class RequiresImagesException(Exception):
     pass
 
 
-ALL_AXES = [1, 1, 1, 1]
+ALL_AXES = 4
 
 
 def _encode_box_to_deltas(
-    anchors: tf.Tensor,
-    boxes: tf.Tensor,
+    anchors: any,
+    boxes: any,
     anchor_format: str,
     box_format: str,
-    variance: Optional[Union[List[float], tf.Tensor]] = None,
+    variance: any = None,
     image_shape=None,
 ):
     """Converts bounding_boxes from `center_yxhw` to delta format."""
     if variance is not None:
-        if tf.is_tensor(variance):
-            var_len = variance.get_shape().as_list()[-1]
-        else:
-            var_len = len(variance)
+        variance = ops.convert_to_tensor(variance, "float32")
+        var_len = variance.shape[-1]
+
         if var_len != 4:
             raise ValueError(f"`variance` must be length 4, got {variance}")
     encoded_anchors = convert_format(
@@ -55,15 +54,15 @@ def _encode_box_to_deltas(
     boxes = convert_format(
         boxes, source=box_format, target="center_yxhw", image_shape=image_shape
     )
-    anchor_dimensions = tf.maximum(
+    anchor_dimensions = ops.maximum(
         encoded_anchors[..., 2:], keras.backend.epsilon()
     )
-    box_dimensions = tf.maximum(boxes[..., 2:], keras.backend.epsilon())
+    box_dimensions = ops.maximum(boxes[..., 2:], keras.backend.epsilon())
     # anchors be unbatched, boxes can either be batched or unbatched.
-    boxes_delta = tf.concat(
+    boxes_delta = ops.concatenate(
         [
             (boxes[..., :2] - encoded_anchors[..., :2]) / anchor_dimensions,
-            tf.math.log(box_dimensions / anchor_dimensions),
+            ops.log(box_dimensions / anchor_dimensions),
         ],
         axis=-1,
     )
@@ -73,22 +72,20 @@ def _encode_box_to_deltas(
 
 
 def _decode_deltas_to_boxes(
-    anchors: tf.Tensor,
-    boxes_delta: tf.Tensor,
+    anchors: any,
+    boxes_delta: any,
     anchor_format: str,
     box_format: str,
-    variance: Optional[Union[List[float], tf.Tensor]] = None,
+    variance: any = None,
     image_shape=None,
 ):
     """Converts bounding_boxes from delta format to `center_yxhw`."""
     if variance is not None:
-        if tf.is_tensor(variance):
-            var_len = variance.get_shape().as_list()[-1]
-        else:
-            var_len = len(variance)
+        variance = ops.convert_to_tensor(variance, "float32")
+        var_len = variance.shape[-1]
+
         if var_len != 4:
             raise ValueError(f"`variance` must be length 4, got {variance}")
-    tf.nest.assert_same_structure(anchors, boxes_delta)
 
     def decode_single_level(anchor, box_delta):
         encoded_anchor = convert_format(
@@ -100,11 +97,11 @@ def _decode_deltas_to_boxes(
         if variance is not None:
             box_delta = box_delta * variance
         # anchors be unbatched, boxes can either be batched or unbatched.
-        box = tf.concat(
+        box = ops.concatenate(
             [
                 box_delta[..., :2] * encoded_anchor[..., 2:]
                 + encoded_anchor[..., :2],
-                tf.math.exp(box_delta[..., 2:]) * encoded_anchor[..., 2:],
+                ops.exp(box_delta[..., 2:]) * encoded_anchor[..., 2:],
             ],
             axis=-1,
         )
@@ -126,29 +123,29 @@ def _decode_deltas_to_boxes(
 
 
 def _center_yxhw_to_xyxy(boxes, images=None, image_shape=None):
-    y, x, height, width = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    y, x, height, width = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [x - width / 2.0, y - height / 2.0, x + width / 2.0, y + height / 2.0],
         axis=-1,
     )
 
 
 def _center_xywh_to_xyxy(boxes, images=None, image_shape=None):
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [x - width / 2.0, y - height / 2.0, x + width / 2.0, y + height / 2.0],
         axis=-1,
     )
 
 
 def _xywh_to_xyxy(boxes, images=None, image_shape=None):
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([x, y, x + width, y + height], axis=-1)
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([x, y, x + width, y + height], axis=-1)
 
 
 def _xyxy_to_center_yxhw(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             (top + bottom) / 2.0,
             (left + right) / 2.0,
@@ -161,8 +158,8 @@ def _xyxy_to_center_yxhw(boxes, images=None, image_shape=None):
 
 def _rel_xywh_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             image_width * x,
             image_height * y,
@@ -178,8 +175,8 @@ def _xyxy_no_op(boxes, images=None, image_shape=None):
 
 
 def _xyxy_to_xywh(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [left, top, right - left, bottom - top],
         axis=-1,
     )
@@ -187,21 +184,21 @@ def _xyxy_to_xywh(boxes, images=None, image_shape=None):
 
 def _xyxy_to_rel_xywh(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
     left, right = (
         left / image_width,
         right / image_width,
     )
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right - left, bottom - top],
         axis=-1,
     )
 
 
 def _xyxy_to_center_xywh(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             (left + right) / 2.0,
             (top + bottom) / 2.0,
@@ -214,14 +211,14 @@ def _xyxy_to_center_xywh(boxes, images=None, image_shape=None):
 
 def _rel_xyxy_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(
+    left, top, right, bottom = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left * image_width, right * image_width
     top, bottom = top * image_height, bottom * image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
@@ -229,50 +226,50 @@ def _rel_xyxy_to_xyxy(boxes, images=None, image_shape=None):
 
 def _xyxy_to_rel_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(
+    left, top, right, bottom = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left / image_width, right / image_width
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
 
 
 def _yxyx_to_xyxy(boxes, images=None, image_shape=None):
-    y1, x1, y2, x2 = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([x1, y1, x2, y2], axis=-1)
+    y1, x1, y2, x2 = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([x1, y1, x2, y2], axis=-1)
 
 
 def _rel_yxyx_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    top, left, bottom, right = tf.split(
+    top, left, bottom, right = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left * image_width, right * image_width
     top, bottom = top * image_height, bottom * image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
 
 
 def _xyxy_to_yxyx(boxes, images=None, image_shape=None):
-    x1, y1, x2, y2 = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([y1, x1, y2, x2], axis=-1)
+    x1, y1, x2, y2 = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([y1, x1, y2, x2], axis=-1)
 
 
 def _xyxy_to_rel_yxyx(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
     left, right = left / image_width, right / image_width
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [top, left, bottom, right],
         axis=-1,
     )
@@ -301,6 +298,7 @@ FROM_XYXY_CONVERTERS = {
 }
 
 
+@tf_data
 def convert_format(
     boxes, source, target, images=None, image_shape=None, dtype="float32"
 ):
@@ -350,12 +348,12 @@ def convert_format(
     ```
 
     Args:
-        boxes: tf.Tensor representing bounding boxes in the format specified in
+        boxes: tensor representing bounding boxes in the format specified in
             the `source` parameter. `boxes` can optionally have extra
             dimensions stacked on the final axis to store metadata. boxes
-            should be a 3D Tensor, with the shape `[batch_size, num_boxes, 4]`.
+            should be a 3D tensor, with the shape `[batch_size, num_boxes, 4]`.
             Alternatively, boxes can be a dictionary with key 'boxes' containing
-            a Tensor matching the aforementioned spec.
+            a tensor matching the aforementioned spec.
         source:One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.
             Used to specify the original format of the `boxes` parameter.
         target:One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.
@@ -367,7 +365,7 @@ def convert_format(
             dimensions. Required when transforming from a rel format to a
             non-rel format.
         dtype: the data type to use when transforming the boxes, defaults to
-            `tf.float32`.
+            `"float32"`.
     """
     if isinstance(boxes, dict):
         boxes["boxes"] = convert_format(
@@ -380,7 +378,7 @@ def convert_format(
         )
         return boxes
 
-    if boxes.shape[-1] != 4:
+    if boxes.shape[-1] is not None and boxes.shape[-1] != 4:
         raise ValueError(
             "Expected `boxes` to be a Tensor with a final dimension of "
             f"`4`. Instead, got `boxes.shape={boxes.shape}`."
@@ -408,7 +406,7 @@ def convert_format(
             f"{FROM_XYXY_CONVERTERS.keys()}. Got target={target}"
         )
 
-    boxes = tf.cast(boxes, dtype)
+    boxes = ops.cast(boxes, dtype)
     if source == target:
         return boxes
 
@@ -462,10 +460,10 @@ def _format_inputs(boxes, images):
                 "len(boxes.shape)=3 AND len(images.shape)=4."
             )
         if not images_include_batch:
-            images = tf.expand_dims(images, axis=0)
+            images = ops.expand_dims(images, axis=0)
 
     if not boxes_includes_batch:
-        return tf.expand_dims(boxes, axis=0), images, True
+        return ops.expand_dims(boxes, axis=0), images, True
     return boxes, images, False
 
 
@@ -483,7 +481,7 @@ def _validate_image_shape(image_shape):
         return
 
     # tensor
-    if isinstance(image_shape, tf.Tensor):
+    if ops.is_tensor(image_shape):
         if len(image_shape.shape) > 1:
             raise ValueError(
                 "image_shape.shape should be (3), but got "
@@ -505,7 +503,7 @@ def _validate_image_shape(image_shape):
 
 def _format_outputs(boxes, squeeze):
     if squeeze:
-        return tf.squeeze(boxes, axis=0)
+        return ops.squeeze(boxes, axis=0)
     return boxes
 
 
@@ -515,15 +513,13 @@ def _image_shape(images, image_shape, boxes):
 
     if image_shape is None:
         if not isinstance(images, tf.RaggedTensor):
-            image_shape = tf.shape(images)
+            image_shape = ops.shape(images)
             height, width = image_shape[1], image_shape[2]
         else:
-            height = tf.reshape(images.row_lengths(), (-1, 1))
-            width = tf.reshape(
-                tf.reduce_max(images.row_lengths(axis=2), 1), (-1, 1)
-            )
-            height = tf.expand_dims(height, axis=-1)
-            width = tf.expand_dims(width, axis=-1)
+            height = ops.reshape(images.row_lengths(), (-1, 1))
+            width = ops.reshape(ops.max(images.row_lengths(axis=2), 1), (-1, 1))
+            height = ops.expand_dims(height, axis=-1)
+            width = ops.expand_dims(width, axis=-1)
     else:
         height, width = image_shape[0], image_shape[1]
-    return tf.cast(height, boxes.dtype), tf.cast(width, boxes.dtype)
+    return ops.cast(height, boxes.dtype), ops.cast(width, boxes.dtype)

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF any KIND, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Converter functions for working with bounding box formats."""

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -103,10 +103,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_converters_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -157,10 +154,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_ragged_bounding_box(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -172,10 +166,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_ragged_bounding_box_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -187,10 +178,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_ragged_bounding_box_with_image_shape(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -205,10 +193,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_dense_bounding_box_with_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -15,40 +15,36 @@
 import itertools
 
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import backend
 from keras_cv import bounding_box
 
-xyxy_box = tf.constant(
-    [[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype=tf.float32
+xyxy_box = np.array([[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype="float32")
+yxyx_box = np.array([[[20, 10, 120, 110], [30, 20, 130, 120]]], dtype="float32")
+rel_xyxy_box = np.array(
+    [[[0.01, 0.02, 0.11, 0.12], [0.02, 0.03, 0.12, 0.13]]], dtype="float32"
 )
-yxyx_box = tf.constant(
-    [[[20, 10, 120, 110], [30, 20, 130, 120]]], dtype=tf.float32
+rel_xyxy_box_ragged_images = np.array(
+    [[[0.10, 0.20, 1.1, 1.20], [0.40, 0.6, 2.40, 2.6]]], dtype="float32"
 )
-rel_xyxy_box = tf.constant(
-    [[[0.01, 0.02, 0.11, 0.12], [0.02, 0.03, 0.12, 0.13]]], dtype=tf.float32
+rel_yxyx_box = np.array(
+    [[[0.02, 0.01, 0.12, 0.11], [0.03, 0.02, 0.13, 0.12]]], dtype="float32"
 )
-rel_xyxy_box_ragged_images = tf.constant(
-    [[[0.10, 0.20, 1.1, 1.20], [0.40, 0.6, 2.40, 2.6]]], dtype=tf.float32
+rel_yxyx_box_ragged_images = np.array(
+    [[[0.2, 0.1, 1.2, 1.1], [0.6, 0.4, 2.6, 2.4]]], dtype="float32"
 )
-rel_yxyx_box = tf.constant(
-    [[[0.02, 0.01, 0.12, 0.11], [0.03, 0.02, 0.13, 0.12]]], dtype=tf.float32
+center_xywh_box = np.array(
+    [[[60, 70, 100, 100], [70, 80, 100, 100]]], dtype="float32"
 )
-rel_yxyx_box_ragged_images = tf.constant(
-    [[[0.2, 0.1, 1.2, 1.1], [0.6, 0.4, 2.6, 2.4]]], dtype=tf.float32
+xywh_box = np.array([[[10, 20, 100, 100], [20, 30, 100, 100]]], dtype="float32")
+rel_xywh_box = np.array(
+    [[[0.01, 0.02, 0.1, 0.1], [0.02, 0.03, 0.1, 0.1]]], dtype="float32"
 )
-center_xywh_box = tf.constant(
-    [[[60, 70, 100, 100], [70, 80, 100, 100]]], dtype=tf.float32
-)
-xywh_box = tf.constant(
-    [[[10, 20, 100, 100], [20, 30, 100, 100]]], dtype=tf.float32
-)
-rel_xywh_box = tf.constant(
-    [[[0.01, 0.02, 0.1, 0.1], [0.02, 0.03, 0.1, 0.1]]], dtype=tf.float32
-)
-rel_xywh_box_ragged_images = tf.constant(
-    [[[0.1, 0.2, 1, 1], [0.4, 0.6, 2, 2]]], dtype=tf.float32
+rel_xywh_box_ragged_images = np.array(
+    [[[0.1, 0.2, 1, 1], [0.4, 0.6, 2, 2]]], dtype="float32"
 )
 
 ragged_images = tf.ragged.constant(
@@ -56,9 +52,9 @@ ragged_images = tf.ragged.constant(
     ragged_rank=2,
 )
 
-images = tf.ones([2, 1000, 1000, 3])
+images = np.ones([2, 1000, 1000, 3])
 
-ragged_classes = tf.ragged.constant([[0], [0]], dtype=tf.float32)
+ragged_classes = tf.ragged.constant([[0], [0]], dtype="float32")
 
 boxes = {
     "xyxy": xyxy_box,
@@ -107,6 +103,10 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_converters_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -157,6 +157,10 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_bounding_box(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -168,6 +172,10 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_bounding_box_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -179,6 +187,10 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_bounding_box_with_image_shape(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -193,6 +205,10 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_dense_bounding_box_with_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -19,7 +19,6 @@ import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv import backend
 from keras_cv import bounding_box
 
 xyxy_box = np.array([[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype="float32")

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -102,7 +102,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_converters_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -153,7 +153,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -165,7 +165,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -177,7 +177,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box_with_image_shape(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -192,7 +192,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_dense_bounding_box_with_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])

--- a/keras_cv/bounding_box/ensure_tensor_test.py
+++ b/keras_cv/bounding_box/ensure_tensor_test.py
@@ -15,25 +15,18 @@
 import tensorflow as tf
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class BoundingBoxEnsureTensorTest(tf.test.TestCase):
     def test_convert_list(self):
         boxes = {"boxes": [[0, 1, 2, 3]], "classes": [0]}
         output = bounding_box.ensure_tensor(boxes)
-        self.assertFalse(
-            any([isinstance(boxes[k], tf.Tensor) for k in boxes.keys()])
-        )
-        self.assertTrue(
-            all([isinstance(output[k], tf.Tensor) for k in output.keys()])
-        )
+        self.assertFalse(any([ops.is_tensor(boxes[k]) for k in boxes.keys()]))
+        self.assertTrue(all([ops.is_tensor(output[k]) for k in output.keys()]))
 
     def test_confidence(self):
         boxes = {"boxes": [[0, 1, 2, 3]], "classes": [0], "confidence": [0.245]}
         output = bounding_box.ensure_tensor(boxes)
-        self.assertFalse(
-            any([isinstance(boxes[k], tf.Tensor) for k in boxes.keys()])
-        )
-        self.assertTrue(
-            all([isinstance(output[k], tf.Tensor) for k in output.keys()])
-        )
+        self.assertFalse(any([ops.is_tensor(boxes[k]) for k in boxes.keys()]))
+        self.assertTrue(all([ops.is_tensor(output[k]) for k in output.keys()]))

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -14,9 +14,9 @@
 """Contains functions to compute ious of bounding boxes."""
 import math
 
-import tensorflow as tf
-
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
 def _compute_area(box):
@@ -28,10 +28,8 @@ def _compute_area(box):
     Returns:
       a float Tensor of [N] or [batch_size, N]
     """
-    y_min, x_min, y_max, x_max = tf.split(
-        box[..., :4], num_or_size_splits=4, axis=-1
-    )
-    return tf.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
+    y_min, x_min, y_max, x_max = ops.split(box[..., :4], 4, axis=-1)
+    return ops.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
 
 
 def _compute_intersection(boxes1, boxes2):
@@ -43,25 +41,21 @@ def _compute_intersection(boxes1, boxes2):
     Returns:
       a [N, M] or [batch_size, N, M] float Tensor.
     """
-    y_min1, x_min1, y_max1, x_max1 = tf.split(
-        boxes1[..., :4], num_or_size_splits=4, axis=-1
-    )
-    y_min2, x_min2, y_max2, x_max2 = tf.split(
-        boxes2[..., :4], num_or_size_splits=4, axis=-1
-    )
+    y_min1, x_min1, y_max1, x_max1 = ops.split(boxes1[..., :4], 4, axis=-1)
+    y_min2, x_min2, y_max2, x_max2 = ops.split(boxes2[..., :4], 4, axis=-1)
     boxes2_rank = len(boxes2.shape)
     perm = [1, 0] if boxes2_rank == 2 else [0, 2, 1]
     # [N, M] or [batch_size, N, M]
-    intersect_ymax = tf.minimum(y_max1, tf.transpose(y_max2, perm))
-    intersect_ymin = tf.maximum(y_min1, tf.transpose(y_min2, perm))
-    intersect_xmax = tf.minimum(x_max1, tf.transpose(x_max2, perm))
-    intersect_xmin = tf.maximum(x_min1, tf.transpose(x_min2, perm))
+    intersect_ymax = ops.minimum(y_max1, ops.transpose(y_max2, perm))
+    intersect_ymin = ops.maximum(y_min1, ops.transpose(y_min2, perm))
+    intersect_xmax = ops.minimum(x_max1, ops.transpose(x_max2, perm))
+    intersect_xmin = ops.maximum(x_min1, ops.transpose(x_min2, perm))
 
     intersect_height = intersect_ymax - intersect_ymin
     intersect_width = intersect_xmax - intersect_xmin
-    zeros_t = tf.cast(0, intersect_height.dtype)
-    intersect_height = tf.maximum(zeros_t, intersect_height)
-    intersect_width = tf.maximum(zeros_t, intersect_width)
+    zeros_t = ops.cast(0, intersect_height.dtype)
+    intersect_height = ops.maximum(zeros_t, intersect_height)
+    intersect_width = ops.maximum(zeros_t, intersect_width)
 
     return intersect_height * intersect_width
 
@@ -153,10 +147,10 @@ def compute_iou(
     boxes2_area = _compute_area(boxes2)
     boxes2_area_rank = len(boxes2_area.shape)
     boxes2_axis = 1 if (boxes2_area_rank == 2) else 0
-    boxes1_area = tf.expand_dims(boxes1_area, axis=-1)
-    boxes2_area = tf.expand_dims(boxes2_area, axis=boxes2_axis)
+    boxes1_area = ops.expand_dims(boxes1_area, axis=-1)
+    boxes2_area = ops.expand_dims(boxes2_area, axis=boxes2_axis)
     union_area = boxes1_area + boxes2_area - intersect_area
-    res = tf.math.divide_no_nan(intersect_area, union_area)
+    res = ops.divide(intersect_area, union_area + keras.backend.epsilon())
 
     if boxes1_rank == 2:
         perm = [1, 0]
@@ -166,13 +160,13 @@ def compute_iou(
     if not use_masking:
         return res
 
-    mask_val_t = tf.cast(mask_val, res.dtype) * tf.ones_like(res)
-    boxes1_mask = tf.less(tf.reduce_max(boxes1, axis=-1, keepdims=True), 0.0)
-    boxes2_mask = tf.less(tf.reduce_max(boxes2, axis=-1, keepdims=True), 0.0)
-    background_mask = tf.logical_or(
-        boxes1_mask, tf.transpose(boxes2_mask, perm)
+    mask_val_t = ops.cast(mask_val, res.dtype) * ops.ones_like(res)
+    boxes1_mask = ops.less(ops.max(boxes1, axis=-1, keepdims=True), 0.0)
+    boxes2_mask = ops.less(ops.max(boxes2, axis=-1, keepdims=True), 0.0)
+    background_mask = ops.logical_or(
+        boxes1_mask, ops.transpose(boxes2_mask, perm)
     )
-    iou_lookup_table = tf.where(background_mask, mask_val_t, res)
+    iou_lookup_table = ops.where(background_mask, mask_val_t, res)
     return iou_lookup_table
 
 
@@ -188,9 +182,9 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     represent the bounding boxes.
 
     Args:
-        box1 (tf.Tensor): Tensor representing the first bounding box with
+        box1 (tensor): tensor representing the first bounding box with
             shape (..., 4).
-        box2 (tf.Tensor): Tensor representing the second bounding box with
+        box2 (tensor): tensor representing the second bounding box with
             shape (..., 4).
         bounding_box_format: a case-insensitive string (for example, "xyxy").
             Each bounding box is defined by these 4 values. For detailed
@@ -200,7 +194,7 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
             is 1e-7.
 
     Returns:
-        tf.Tensor: The CIoU distance between the two bounding boxes.
+        tensor: The CIoU distance between the two bounding boxes.
     """
     target_format = "xyxy"
     if bounding_box.is_relative(bounding_box_format):
@@ -213,17 +207,15 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     box2 = bounding_box.convert_format(
         box2, source=bounding_box_format, target=target_format
     )
-    b1_x1, b1_y1, b1_x2, b1_y2 = tf.split(box1, 4, axis=-1)
-    b2_x1, b2_y1, b2_x2, b2_y2 = tf.split(box2, 4, axis=-1)
+    b1_x1, b1_y1, b1_x2, b1_y2 = ops.split(box1, 4, axis=-1)
+    b2_x1, b2_y1, b2_x2, b2_y2 = ops.split(box2, 4, axis=-1)
     w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
     w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
 
     # Intersection area
-    inter = tf.math.maximum(
-        tf.math.minimum(b1_x2, b2_x2) - tf.math.maximum(b1_x1, b2_x1), 0
-    ) * tf.math.maximum(
-        tf.math.minimum(b1_y2, b2_y2) - tf.math.maximum(b1_y1, b2_y1), 0
-    )
+    inter = ops.maximum(
+        ops.minimum(b1_x2, b2_x2) - ops.maximum(b1_x1, b2_x1), 0
+    ) * ops.maximum(ops.minimum(b1_y2, b2_y2) - ops.maximum(b1_y1, b2_y1), 0)
 
     # Union Area
     union = w1 * h1 + w2 * h2 - inter + eps
@@ -231,18 +223,18 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     # IoU
     iou = inter / union
 
-    cw = tf.math.maximum(b1_x2, b2_x2) - tf.math.minimum(
+    cw = ops.maximum(b1_x2, b2_x2) - ops.minimum(
         b1_x1, b2_x1
     )  # convex (smallest enclosing box) width
-    ch = tf.math.maximum(b1_y2, b2_y2) - tf.math.minimum(
-        b1_y1, b2_y1
-    )  # convex height
+    ch = ops.maximum(b1_y2, b2_y2) - ops.minimum(b1_y1, b2_y1)  # convex height
     c2 = cw**2 + ch**2 + eps  # convex diagonal squared
     rho2 = (
         (b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2
         + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2
     ) / 4  # center dist ** 2
-    v = tf.pow((4 / math.pi**2) * (tf.atan(w2 / h2) - tf.atan(w1 / h1)), 2)
+    v = ops.power(
+        (4 / math.pi**2) * (ops.arctan(w2 / h2) - ops.arctan(w1 / h1)), 2
+    )
     alpha = v / (v - iou + (1 + eps))
 
     return iou - (rho2 / c2 + v * alpha)

--- a/keras_cv/bounding_box/iou_test.py
+++ b/keras_cv/bounding_box/iou_test.py
@@ -21,8 +21,8 @@ from keras_cv.bounding_box import iou as iou_lib
 
 class IoUTest(tf.test.TestCase):
     def test_compute_single_iou(self):
-        bb1 = tf.constant([[100, 101, 200, 201]], dtype=tf.float32)
-        bb1_off_by_1 = tf.constant([[101, 102, 201, 202]], dtype=tf.float32)
+        bb1 = np.array([[100, 101, 200, 201]])
+        bb1_off_by_1 = np.array([[101, 102, 201, 202]])
         # area of bb1 and bb1_off_by_1 are each 10000.
         # intersection area is 99*99=9801
         # iou=9801/(2*10000 - 9801)=0.96097656633
@@ -44,16 +44,13 @@ class IoUTest(tf.test.TestCase):
             dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
-            [bb1, top_left_bounding_box, far_away_box], dtype=tf.float32
-        )
-        sample_y_pred = tf.constant(
+        sample_y_true = np.array([bb1, top_left_bounding_box, far_away_box])
+        sample_y_pred = np.array(
             [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_batched_compute_iou(self):
         bb1 = [100, 101, 200, 201]
@@ -69,17 +66,15 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [
                 [
                     bb1_off_by_1_pred,
@@ -92,11 +87,10 @@ class IoUTest(tf.test.TestCase):
                     another_far_away_pred,
                 ],
             ],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_batched_boxes1_unbatched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -112,23 +106,20 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_unbatched_boxes1_batched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -144,16 +135,14 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [
                 [
                     bb1_off_by_1_pred,
@@ -166,8 +155,7 @@ class IoUTest(tf.test.TestCase):
                     another_far_away_pred,
                 ],
             ],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tensorflow as tf
 
+from keras_cv import backend
+from keras_cv.backend import ops
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
 
@@ -20,11 +21,10 @@ from keras_cv.bounding_box.validate_format import validate_format
 def mask_invalid_detections(bounding_boxes, output_ragged=False):
     """masks out invalid detections with -1s.
 
-    This utility is mainly used on the output of
-    `tf.image.combined_non_max_suppression` operations. The output of
-    `tf.image.combined_non_max_suppression` contains all the detections, even
-    invalid ones. Users are expected to use `num_detections` to determine how
-    many boxes are in each image.
+    This utility is mainly used on the output of non-max supression operations.
+    The output of non-max-supression contains all the detections, even invalid
+    ones. Users are expected to use `num_detections` to determine how many boxes
+    are in each image.
 
     In contrast, KerasCV expects all bounding boxes to be padded with -1s.
     This function uses the value of `num_detections` to mask out
@@ -38,11 +38,10 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
             boxes.
     Returns:
         bounding boxes with proper masking of the boxes according to
-        `num_detections`. This allows proper interop with
-        `tf.image.combined_non_max_suppression`. Returned boxes match the
-        specification fed to the function, so if the bounding box tensor uses
-        `tf.RaggedTensor` to represent boxes the returned value will also return
-        `tf.RaggedTensor` representations.
+        `num_detections`. This allows proper interop with non-max supression.
+        Returned boxes match the specification fed to the function, so if the
+        bounding box tensor uses `tf.RaggedTensor` to represent boxes the
+        returned value will also return `tf.RaggedTensor` representations.
     """
     # ensure we are complying with KerasCV bounding box format.
     info = validate_format(bounding_boxes)
@@ -65,22 +64,21 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     num_detections = bounding_boxes.get("num_detections")
 
     # Create a mask to select only the first N boxes from each batch
-    mask = tf.repeat(
-        tf.expand_dims(tf.range(tf.shape(boxes)[1]), axis=0),
-        repeats=tf.shape(boxes)[0],
-        axis=0,
+    mask = ops.cast(
+        ops.expand_dims(ops.arange(boxes.shape[1]), axis=0),
+        num_detections.dtype,
     )
     mask = mask < num_detections[:, None]
 
-    classes = tf.where(mask, classes, -tf.ones_like(classes))
+    classes = ops.where(mask, classes, -ops.ones_like(classes))
 
     if confidence is not None:
-        confidence = tf.where(mask, confidence, -tf.ones_like(confidence))
+        confidence = ops.where(mask, confidence, -ops.ones_like(confidence))
 
     # reuse mask for boxes
-    mask = tf.expand_dims(mask, axis=-1)
-    mask = tf.repeat(mask, repeats=boxes.shape[-1], axis=-1)
-    boxes = tf.where(mask, boxes, -tf.ones_like(boxes))
+    mask = ops.expand_dims(mask, axis=-1)
+    mask = ops.repeat(mask, repeats=boxes.shape[-1], axis=-1)
+    boxes = ops.where(mask, boxes, -ops.ones_like(boxes))
 
     result = bounding_boxes.copy()
 
@@ -89,7 +87,7 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     if confidence is not None:
         result["confidence"] = confidence
 
-    if output_ragged:
+    if output_ragged and backend.supports_ragged():
         return to_ragged(result)
 
     return result

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from keras_cv import backend
 from keras_cv import bounding_box
 from keras_cv.backend import ops
 
@@ -44,10 +43,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
             boxes_from_image_3, bounding_boxes["boxes"][2, :4, :]
         )
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_ragged_outputs(self):
         bounding_boxes = {
             "boxes": np.stack(
@@ -69,10 +65,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         self.assertEqual(result["boxes"][0].shape[0], 2)
         self.assertEqual(result["boxes"][1].shape[0], 3)
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_correctly_masks_confidence(self):
         bounding_boxes = {
             "boxes": np.stack(

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -43,7 +43,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
             boxes_from_image_3, bounding_boxes["boxes"][2, :4, :]
         )
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_ragged_outputs(self):
         bounding_boxes = {
             "boxes": np.stack(
@@ -65,7 +65,7 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         self.assertEqual(result["boxes"][0].shape[0], 2)
         self.assertEqual(result["boxes"][1].shape[0], 3)
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_correctly_masks_confidence(self):
         bounding_boxes = {
             "boxes": np.stack(

--- a/keras_cv/bounding_box/to_dense.py
+++ b/keras_cv/bounding_box/to_dense.py
@@ -14,6 +14,7 @@
 import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
+from keras_cv.backend.scope import tf_data
 
 
 def _box_shape(batched, boxes_shape, max_boxes):
@@ -35,6 +36,7 @@ def _classes_shape(batched, classes_shape, max_boxes):
     return [max_boxes] + classes_shape[2:]
 
 
+@tf_data
 def to_dense(bounding_boxes, max_boxes=None, default_value=-1):
     """to_dense converts bounding boxes to Dense tensors
 

--- a/keras_cv/bounding_box/to_dense_test.py
+++ b/keras_cv/bounding_box/to_dense_test.py
@@ -14,15 +14,11 @@
 import pytest
 import tensorflow as tf
 
-from keras_cv import backend
 from keras_cv import bounding_box
 
 
 class ToDenseTest(tf.test.TestCase):
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_converts_to_dense(self):
         bounding_boxes = {
             "boxes": tf.ragged.constant(

--- a/keras_cv/bounding_box/to_dense_test.py
+++ b/keras_cv/bounding_box/to_dense_test.py
@@ -18,7 +18,7 @@ from keras_cv import bounding_box
 
 
 class ToDenseTest(tf.test.TestCase):
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_converts_to_dense(self):
         bounding_boxes = {
             "boxes": tf.ragged.constant(

--- a/keras_cv/bounding_box/to_dense_test.py
+++ b/keras_cv/bounding_box/to_dense_test.py
@@ -11,12 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
 
 
 class ToDenseTest(tf.test.TestCase):
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_converts_to_dense(self):
         bounding_boxes = {
             "boxes": tf.ragged.constant(

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -15,6 +15,7 @@ import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
 from keras_cv import backend
+from keras_cv.backend import keras
 
 
 def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
@@ -53,7 +54,8 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
     if backend.supports_ragged() is False:
         raise NotImplementedError(
             "`bounding_box.to_ragged` was called using a backend which does "
-            "not support ragged tensors."
+            "not support ragged tensors. "
+            f"Current backend: {keras.config.backend()}."
         )
 
     info = validate_format.validate_format(bounding_boxes)

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -55,7 +55,7 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
         raise NotImplementedError(
             "`bounding_box.to_ragged` was called using a backend which does "
             "not support ragged tensors. "
-            f"Current backend: {keras.config.backend()}."
+            f"Current backend: {keras.backend.config.backend()}."
         )
 
     info = validate_format.validate_format(bounding_boxes)

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -55,7 +55,7 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
         raise NotImplementedError(
             "`bounding_box.to_ragged` was called using a backend which does "
             "not support ragged tensors. "
-            f"Current backend: {keras.backend.config.backend()}."
+            f"Current backend: {keras.backend.backend()}."
         )
 
     info = validate_format.validate_format(bounding_boxes)

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -14,6 +14,7 @@
 import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
+from keras_cv import backend
 
 
 def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
@@ -49,6 +50,12 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
         dictionary of `tf.RaggedTensor` or 'tf.Tensor' containing the filtered
         bounding boxes.
     """
+    if backend.supports_ragged() is False:
+        raise NotImplementedError(
+            "`bounding_box.to_ragged` was called using a backend which does "
+            "not support ragged tensors."
+        )
+
     info = validate_format.validate_format(bounding_boxes)
 
     if info["ragged"]:

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -11,19 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
+import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
 
 
 class ToRaggedTest(tf.test.TestCase):
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_converts_to_ragged(self):
         bounding_boxes = {
-            "boxes": tf.constant(
+            "boxes": np.array(
                 [[[0, 0, 0, 0], [0, 0, 0, 0]], [[2, 3, 4, 5], [0, 1, 2, 3]]]
             ),
-            "classes": tf.constant([[-1, -1], [-1, 1]]),
-            "confidence": tf.constant([[0.5, 0.7], [0.23, 0.12]]),
+            "classes": np.array([[-1, -1], [-1, 1]]),
+            "confidence": np.array([[0.5, 0.7], [0.23, 0.12]]),
         }
         bounding_boxes = bounding_box.to_ragged(bounding_boxes)
 
@@ -45,16 +52,20 @@ class ToRaggedTest(tf.test.TestCase):
             ],
         )
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_round_trip(self):
         original = {
-            "boxes": tf.constant(
+            "boxes": np.array(
                 [
                     [[0, 0, 0, 0], [-1, -1, -1, -1]],
                     [[-1, -1, -1, -1], [-1, -1, -1, -1]],
                 ]
             ),
-            "classes": tf.constant([[1, -1], [-1, -1]]),
-            "confidence": tf.constant([[0.5, -1], [-1, -1]]),
+            "classes": np.array([[1, -1], [-1, -1]]),
+            "confidence": np.array([[0.5, -1], [-1, -1]]),
         }
         bounding_boxes = bounding_box.to_ragged(original)
         bounding_boxes = bounding_box.to_dense(bounding_boxes, max_boxes=2)
@@ -70,3 +81,19 @@ class ToRaggedTest(tf.test.TestCase):
         self.assertAllEqual(
             bounding_boxes["confidence"], original["confidence"]
         )
+
+    @pytest.mark.skipif(
+        backend.supports_ragged() is True,
+        reason="Only applies to backends which don't support raggeds",
+    )
+    def test_backend_without_raggeds_throws(self):
+        bounding_boxes = {
+            "boxes": np.array(
+                [[[0, 0, 0, 0], [0, 0, 0, 0]], [[2, 3, 4, 5], [0, 1, 2, 3]]]
+            ),
+            "classes": np.array([[-1, -1], [-1, 1]]),
+            "confidence": np.array([[0.5, 0.7], [0.23, 0.12]]),
+        }
+
+        with self.assertRaisesRegex(NotImplementedError, "support ragged"):
+            bounding_box.to_ragged(bounding_boxes)

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -20,7 +20,7 @@ from keras_cv import bounding_box
 
 
 class ToRaggedTest(tf.test.TestCase):
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_converts_to_ragged(self):
         bounding_boxes = {
             "boxes": np.array(
@@ -49,7 +49,7 @@ class ToRaggedTest(tf.test.TestCase):
             ],
         )
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_round_trip(self):
         original = {
             "boxes": np.array(

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -20,10 +20,7 @@ from keras_cv import bounding_box
 
 
 class ToRaggedTest(tf.test.TestCase):
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_converts_to_ragged(self):
         bounding_boxes = {
             "boxes": np.array(
@@ -52,10 +49,7 @@ class ToRaggedTest(tf.test.TestCase):
             ],
         )
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_round_trip(self):
         original = {
             "boxes": np.array(

--- a/keras_cv/bounding_box/utils_test.py
+++ b/keras_cv/bounding_box/utils_test.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
 import tensorflow as tf
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class BoundingBoxUtilTest(tf.test.TestCase):
@@ -22,12 +24,10 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[200, 200, 400, 400], [100, 100, 300, 300]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([0, 0], dtype=tf.float32),
+            "boxes": np.array([[200, 200, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
@@ -38,17 +38,15 @@ class BoundingBoxUtilTest(tf.test.TestCase):
             y1,
             x2,
             y2,
-        ) = tf.split(boxes, [1, 1, 1, 1], axis=1)
-        self.assertAllLessEqual([x1, x2], width)
-        self.assertAllLessEqual([y1, y2], height)
+        ) = ops.split(boxes, 4, axis=1)
+        self.assertAllLessEqual(ops.concatenate([x1, x2], axis=1), width)
+        self.assertAllLessEqual(ops.concatenate([y1, y2], axis=1), height)
         # Test relative format batched
-        image = tf.ones(shape=(1, height, width, 3))
+        image = ops.ones(shape=(1, height, width, 3))
 
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[[0.2, -1, 1.2, 0.3], [0.4, 1.5, 0.2, 0.3]]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([[0, 0]], dtype=tf.float32),
+            "boxes": np.array([[[0.2, -1, 1.2, 0.3], [0.4, 1.5, 0.2, 0.3]]]),
+            "classes": np.array([[0, 0]]),
         }
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="rel_xyxy", images=image
@@ -60,23 +58,21 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[257, 257, 400, 400], [100, 100, 300, 300]]
-            ),
-            "classes": tf.convert_to_tensor([0, 0]),
+            "boxes": np.array([[257, 257, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
 
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor([[-1, -1, -1, -1], [100, 100, 256, 256]]),
+            np.array([[-1, -1, -1, -1], [100, 100, 256, 256]]),
         ),
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_clip_to_image_filters_fully_out_bounding_boxes_negative_area(self):
@@ -84,18 +80,16 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[110, 120, 100, 100], [100, 100, 300, 300]]
-            ),
-            "classes": [0, 0],
+            "boxes": np.array([[110, 120, 100, 100], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor(
+            np.array(
                 [
                     [
                         -1,
@@ -114,7 +108,7 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         )
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_clip_to_image_filters_nans(self):
@@ -122,18 +116,18 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
+            "boxes": np.array(
                 [[0, float("NaN"), 100, 100], [100, 100, 300, 300]]
             ),
-            "classes": [0, 0],
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor(
+            np.array(
                 [
                     [
                         -1,
@@ -152,7 +146,7 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         )
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_is_relative_util(self):

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -16,7 +16,6 @@ import pytest
 import tensorflow as tf
 from packaging import version
 
-from keras_cv.backend import keras
 from keras_cv.backend.config import multi_backend
 
 

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -66,8 +66,8 @@ def pytest_collection_modifyitems(config, items):
         not run_extra_large_tests, reason="need --run_extra_large option to run"
     )
     skip_tf_only = pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
+        multi_backend(),
+        reason="This test is only supported on tf.keras",
     )
     for item in items:
         if "keras_format" in item.name:

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -44,7 +44,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "tf_only: mark test as a tf only test",
+        "tf_keras_only: mark test as a tf only test",
     )
 
 
@@ -64,7 +64,7 @@ def pytest_collection_modifyitems(config, items):
     skip_extra_large = pytest.mark.skipif(
         not run_extra_large_tests, reason="need --run_extra_large option to run"
     )
-    skip_tf_only = pytest.mark.skipif(
+    skip_tf_keras_only = pytest.mark.skipif(
         multi_backend(),
         reason="This test is only supported on tf.keras",
     )
@@ -77,5 +77,5 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_large)
         if "extra_large" in item.keywords:
             item.add_marker(skip_extra_large)
-        if "tf_only" in item.keywords:
-            item.add_marker(skip_tf_only)
+        if "tf_keras_only" in item.keywords:
+            item.add_marker(skip_tf_keras_only)

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -16,6 +16,9 @@ import pytest
 import tensorflow as tf
 from packaging import version
 
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -40,6 +43,10 @@ def pytest_configure(config):
         "markers",
         "extra_large: mark test as being too large to run continuously",
     )
+    config.addinivalue_line(
+        "markers",
+        "tf_only: mark test as a tf only test",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -58,6 +65,10 @@ def pytest_collection_modifyitems(config, items):
     skip_extra_large = pytest.mark.skipif(
         not run_extra_large_tests, reason="need --run_extra_large option to run"
     )
+    skip_tf_only = pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     for item in items:
         if "keras_format" in item.name:
             item.add_marker(skip_keras_saving_test)
@@ -67,3 +78,5 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_large)
         if "extra_large" in item.keywords:
             item.add_marker(skip_extra_large)
+        if "tf_only" in item.keywords:
+            item.add_marker(skip_tf_only)

--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -22,7 +22,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class AugMix(BaseImageAugmentationLayer):
     """Performs the AugMix data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -37,7 +37,7 @@ USE_TARGETS = "use_targets"
 
 
 base_class = (
-    keras.layers.preprocessing.tf_data_layer.TFDataLayer
+    keras.src.layers.preprocessing.tf_data_layer.TFDataLayer
     if multi_backend()
     else keras.layers.Layer
 )

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
+from keras_cv.backend.config import multi_backend
 from keras_cv.utils import preprocessing
 
 # In order to support both unbatched and batched inputs, the horizontal
@@ -33,8 +36,15 @@ IS_DICT = "is_dict"
 USE_TARGETS = "use_targets"
 
 
+base_class = (
+    keras.layers.preprocessing.tf_data_layer.TFDataLayer
+    if multi_backend()
+    else keras.layers.Layer
+)
+
+
 @keras.utils.register_keras_serializable(package="keras_cv")
-class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
+class BaseImageAugmentationLayer(base_class):
     """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -114,7 +124,12 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
+        self._convert_input_args = False
 
     @property
     def force_output_ragged_images(self):
@@ -391,19 +406,23 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         return None
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3:
-            return self._format_output(self._augment(inputs), metadata)
-        elif images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3:
+                outputs = self._format_output(self._augment(inputs), metadata)
+            elif images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _augment(self, inputs):
         raw_image = inputs.get(IMAGES, None)
@@ -498,7 +517,7 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         if not isinstance(inputs, dict):
             raise ValueError(
                 "Expect the inputs to be image tensor or dict. Got "
-                f"inputs={inputs}"
+                f"inputs={inputs} of type {type(inputs)}"
             )
 
         if BOUNDING_BOXES in inputs:

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -43,7 +43,7 @@ base_class = (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class BaseImageAugmentationLayer(base_class):
     """Abstract base layer for image augmentation.
 

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -126,8 +126,8 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = RandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(8, 8, 3)).astype("float32")
-        filenames = tf.constant("/path/to/first.jpg")
-        inputs = {"images": images, "filenames": filenames}
+        image_timestamp = np.array(123123123)
+        inputs = {"images": images, "image_timestamp": image_timestamp}
         _ = add_layer(inputs)
 
     def test_augment_ragged_images(self):
@@ -203,32 +203,6 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         )
 
         output = add_layer(
-            {
-                "images": images,
-                "bounding_boxes": bounding_boxes,
-                "keypoints": keypoints,
-                "segmentation_masks": segmentation_masks,
-            }
-        )
-
-        bounding_boxes_diff = (
-            output["bounding_boxes"]["boxes"] - bounding_boxes["boxes"]
-        )
-        keypoints_diff = output["keypoints"] - keypoints
-        segmentation_mask_diff = (
-            output["segmentation_masks"] - segmentation_masks
-        )
-        self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
-        self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
-        self.assertNotAllClose(
-            segmentation_mask_diff[0], segmentation_mask_diff[1]
-        )
-
-        @tf.function
-        def in_tf_function(inputs):
-            return add_layer(inputs)
-
-        output = in_tf_function(
             {
                 "images": images,
                 "bounding_boxes": bounding_boxes,

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import fill_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class CutMix(BaseImageAugmentationLayer):
     """CutMix implements the CutMix data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -127,7 +127,12 @@ class CutMix(BaseImageAugmentationLayer):
             tf.gather(images, permutation_order),
         )
 
-        return images, labels, lambda_sample, permutation_order
+        return (
+            images,
+            tf.cast(labels, dtype=self.compute_dtype),
+            lambda_sample,
+            permutation_order,
+        )
 
     def _update_labels(self, images, labels, lambda_sample, permutation_order):
         cutout_labels = tf.gather(labels, permutation_order)

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Equalization(BaseImageAugmentationLayer):
     """Equalization performs histogram equalization on a channel-wise basis.
 

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -17,7 +17,6 @@ import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv.backend import keras
-from keras_cv.backend.config import multi_backend
 from keras_cv.layers.preprocessing.equalization import Equalization
 
 
@@ -30,10 +29,7 @@ class EqualizationTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertAllEqual(xs, 255 * tf.ones((2, 512, 512, 3)))
 
-    @pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
-    )
+    @pytest.mark.tf_only
     def test_return_shapes_inside_model(self):
         layer = Equalization(value_range=(0, 255))
         inp = keras.layers.Input(shape=[512, 512, 5])

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 from keras_cv.layers.preprocessing.equalization import Equalization
 
 
@@ -28,13 +30,17 @@ class EqualizationTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertAllEqual(xs, 255 * tf.ones((2, 512, 512, 3)))
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_return_shapes_inside_model(self):
         layer = Equalization(value_range=(0, 255))
         inp = keras.layers.Input(shape=[512, 512, 5])
         out = layer(inp)
         model = keras.models.Model(inp, out)
 
-        self.assertEqual(model.layers[-1].output_shape, (None, 512, 512, 5))
+        self.assertEqual(model.output_shape, (None, 512, 512, 5))
 
     def test_equalizes_to_all_bins(self):
         xs = tf.random.uniform((2, 512, 512, 3), 0, 255, dtype=tf.float32)

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -29,7 +29,7 @@ class EqualizationTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertAllEqual(xs, 255 * tf.ones((2, 512, 512, 3)))
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_return_shapes_inside_model(self):
         layer = Equalization(value_range=(0, 255))
         inp = keras.layers.Input(shape=[512, 512, 5])

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class FourierMix(BaseImageAugmentationLayer):
     """FourierMix implements the FMix data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Grayscale(VectorizedBaseImageAugmentationLayer):
     """Grayscale is a preprocessing layer that transforms RGB images to
     Grayscale images.

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -33,7 +33,7 @@ def _center_crop(mask, width, height):
     return tf.image.crop_to_bounding_box(mask, h_start, w_start, height, width)
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class GridMask(BaseImageAugmentationLayer):
     """GridMask class for grid-mask augmentation.
 

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -118,7 +117,7 @@ class GridMask(BaseImageAugmentationLayer):
         self.fill_mode = fill_mode
         self.fill_value = fill_value
         self.rotation_factor = rotation_factor
-        self.random_rotate = layers.RandomRotation(
+        self.random_rotate = keras.layers.RandomRotation(
             factor=rotation_factor,
             fill_mode="constant",
             fill_value=0.0,

--- a/keras_cv/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/layers/preprocessing/jittered_resize.py
@@ -29,7 +29,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class JitteredResize(VectorizedBaseImageAugmentationLayer):
     """JitteredResize implements resize with scale distortion.
 

--- a/keras_cv/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/layers/preprocessing/jittered_resize.py
@@ -17,9 +17,9 @@
 # https://github.com/tensorflow/models/blob/master/official/vision/ops/preprocess_ops.py
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -73,7 +73,9 @@ class MixUp(BaseImageAugmentationLayer):
         images, lambda_sample, permutation_order = self._mixup(images)
         if labels is not None:
             labels = self._update_labels(
-                labels, lambda_sample, permutation_order
+                tf.cast(labels, dtype=self.compute_dtype),
+                lambda_sample,
+                permutation_order,
             )
             inputs["labels"] = labels
         if bounding_boxes is not None:

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class MixUp(BaseImageAugmentationLayer):
     """MixUp implements the MixUp data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     BATCHED,
 )

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -34,7 +34,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Mosaic(VectorizedBaseImageAugmentationLayer):
     """Mosaic implements the mosaic data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -96,16 +96,6 @@ class MosaicTest(tf.test.TestCase):
         ):
             _ = layer(inputs)
 
-    def test_int_labels(self):
-        xs = tf.ones((2, 512, 512, 3))
-        ys = tf.one_hot(tf.constant([1, 0]), 2, dtype=tf.int32)
-        inputs = {"images": xs, "labels": ys}
-        layer = Mosaic()
-        with self.assertRaisesRegexp(
-            ValueError, "Mosaic received labels with type"
-        ):
-            _ = layer(inputs)
-
     def test_image_input(self):
         xs = tf.ones((2, 512, 512, 3))
         layer = Mosaic()

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils.preprocessing import transform_value_range
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Posterization(BaseImageAugmentationLayer):
     """Reduces the number of bits for each color channel.
 

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing as cv_preprocessing
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandAugment(RandomAugmentationPipeline):
     """RandAugment performs the Rand Augment operation on input images.
 

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -110,6 +109,7 @@ class RandomApply(BaseImageAugmentationLayer):
         self.auto_vectorize = auto_vectorize
         self.batchwise = batchwise
         self.seed = seed
+        self.built = True
 
     def _should_augment(self):
         return (

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -18,7 +18,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomApply(BaseImageAugmentationLayer):
     """Apply provided layer to random elements in a batch.
 

--- a/keras_cv/layers/preprocessing/random_apply_test.py
+++ b/keras_cv/layers/preprocessing/random_apply_test.py
@@ -14,9 +14,9 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_aspect_ratio.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio.py
@@ -22,7 +22,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomAspectRatio(BaseImageAugmentationLayer):
     """RandomAspectRatio randomly distorts the aspect ratio of the provided
     image.

--- a/keras_cv/layers/preprocessing/random_aspect_ratio.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomAugmentationPipeline(BaseImageAugmentationLayer):
     """RandomAugmentationPipeline constructs a pipeline based on provided
     arguments.

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -55,7 +55,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs, os)
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_calls_layers_augmentations_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomAugmentationPipeline(

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -54,6 +56,10 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs, os)
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_calls_layers_augmentations_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomAugmentationPipeline(

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -18,7 +18,6 @@ from absl.testing import parameterized
 
 from keras_cv import layers
 from keras_cv.backend import keras
-from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -56,10 +55,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs, os)
 
-    @pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
-    )
+    @pytest.mark.tf_only
     def test_calls_layers_augmentations_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomAugmentationPipeline(

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomBrightness(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly adjusts brightness.
 

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomChannelShift(BaseImageAugmentationLayer):
     """Randomly shift values for each channel of the input image(s).
 

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomChoice(BaseImageAugmentationLayer):
     """RandomChoice constructs a pipeline based on provided arguments.
 

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -40,6 +42,10 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_calls_layer_augmentation_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -18,7 +18,6 @@ from absl.testing import parameterized
 
 from keras_cv import layers
 from keras_cv.backend import keras
-from keras_cv.backend.config import multi_backend
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -42,10 +41,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
-    @pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
-    )
+    @pytest.mark.tf_only
     def test_calls_layer_augmentation_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -41,7 +41,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_calls_layer_augmentation_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomColorDegeneration(BaseImageAugmentationLayer):
     """Randomly performs the color degeneration operation on given images.
 

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomColorJitter(VectorizedBaseImageAugmentationLayer):
     """RandomColorJitter class randomly apply brightness, contrast, saturation
     and hue image processing operation sequentially and randomly on the

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomContrast(VectorizedBaseImageAugmentationLayer):
     """RandomContrast randomly adjusts contrast.
 

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -27,7 +27,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCrop(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly crops images.
 

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -14,9 +14,9 @@
 
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -23,7 +23,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCropAndResize(BaseImageAugmentationLayer):
     """Randomly crops a part of an image and resizes it to provided size.
 

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -119,7 +119,9 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
         input_image_shape = (1, self.height, self.width, 3)
         mask_shape = (1, self.height, self.width, 1)
         image = tf.random.uniform(shape=input_image_shape, seed=self.seed)
-        mask = np.random.randint(2, size=mask_shape) * (num_classes - 1)
+        mask = tf.constant(
+            np.random.randint(2, size=mask_shape) * (num_classes - 1)
+        )
 
         inputs = {"images": image, "segmentation_masks": mask}
 

--- a/keras_cv/layers/preprocessing/random_crop_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_test.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.random_crop import RandomCrop
 
 
@@ -144,15 +144,15 @@ class RandomCropTest(tf.test.TestCase, parameterized.TestCase):
             np.float32
         )
         bboxes = {
-            "boxes": tf.convert_to_tensor([[200, 200, 400, 400]]),
-            "classes": tf.convert_to_tensor([1]),
+            "boxes": np.array([[200, 200, 400, 400]]),
+            "classes": np.array([1]),
         }
         input = {"images": input_image, "bounding_boxes": bboxes}
         # for top = 300 and left = 305
         height_offset = 300
         width_offset = 305
-        tops = tf.ones((1, 1)) * (height_offset / (orig_height - height))
-        lefts = tf.ones((1, 1)) * (width_offset / (orig_width - width))
+        tops = np.ones((1, 1)) * (height_offset / (orig_height - height))
+        lefts = np.ones((1, 1)) * (width_offset / (orig_width - width))
         transformations = {"tops": tops, "lefts": lefts}
         layer = RandomCrop(
             height=height, width=width, bounding_box_format="xyxy"
@@ -171,8 +171,8 @@ class RandomCropTest(tf.test.TestCase, parameterized.TestCase):
     def test_augment_bounding_boxes_resize(self):
         input_image = np.random.random((256, 256, 3)).astype(np.float32)
         bboxes = {
-            "boxes": tf.convert_to_tensor([[100, 100, 200, 200]]),
-            "classes": tf.convert_to_tensor([1]),
+            "boxes": np.array([[100, 100, 200, 200]]),
+            "classes": np.array([1]),
         }
         input = {"images": input_image, "bounding_boxes": bboxes}
         layer = RandomCrop(height=512, width=512, bounding_box_format="xyxy")

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -22,7 +22,7 @@ from keras_cv.utils import fill_utils
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCutout(BaseImageAugmentationLayer):
     """Randomly cut out rectangles from images and fill them.
 

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -31,7 +31,7 @@ VERTICAL = "vertical"
 HORIZONTAL_AND_VERTICAL = "horizontal_and_vertical"
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomFlip(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly flips images.
 

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -263,7 +263,7 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose(expected_mask, output["segmentation_masks"])
 
     def test_ragged_bounding_boxes(self):
-        input_image = np.random.random((2, 512, 512, 3)).astype(np.float32)
+        input_image = tf.random.uniform((2, 512, 512, 3))
         bounding_boxes = {
             "boxes": tf.ragged.constant(
                 [

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomGaussianBlur(BaseImageAugmentationLayer):
     """Applies a Gaussian Blur with random strength to an image.
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomHue(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the hue on given images.
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomJpegQuality(BaseImageAugmentationLayer):
     """Applies Random Jpeg compression artifacts to an image.
 

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -28,7 +28,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomRotation(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly rotates images.
 

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -14,9 +14,9 @@
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -231,7 +231,7 @@ class RandomRotation(VectorizedBaseImageAugmentationLayer):
         # mask sparse again using tf.argmax.
         if self.segmentation_classes:
             one_hot_mask = tf.one_hot(
-                tf.squeeze(segmentation_masks, axis=-1),
+                tf.squeeze(tf.cast(segmentation_masks, tf.int32), axis=-1),
                 self.segmentation_classes,
             )
             rotated_one_hot_mask = self._rotate_images(

--- a/keras_cv/layers/preprocessing/random_rotation_test.py
+++ b/keras_cv/layers/preprocessing/random_rotation_test.py
@@ -61,10 +61,8 @@ class RandomRotationTest(tf.test.TestCase):
     def test_augment_bounding_boxes(self):
         input_image = np.random.random((512, 512, 3)).astype(np.float32)
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[200, 200, 400, 400], [100, 100, 300, 300]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([1, 2], dtype=tf.float32),
+            "boxes": np.array([[200, 200, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([1, 2]),
         }
         input = {"images": input_image, "bounding_boxes": bounding_boxes}
         # 180 rotation.
@@ -74,11 +72,10 @@ class RandomRotationTest(tf.test.TestCase):
             output["bounding_boxes"]
         )
         expected_bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
+            "boxes": np.array(
                 [[112.0, 112.0, 312.0, 312.0], [212.0, 212.0, 412.0, 412.0]],
-                dtype=tf.float32,
             ),
-            "classes": tf.convert_to_tensor([1, 2], dtype=tf.float32),
+            "classes": np.array([1, 2]),
         }
         self.assertAllClose(expected_bounding_boxes, output["bounding_boxes"])
 
@@ -90,7 +87,7 @@ class RandomRotationTest(tf.test.TestCase):
         self.assertAllEqual(layer(inputs).dtype, "uint8")
 
     def test_ragged_bounding_boxes(self):
-        input_image = np.random.random((2, 512, 512, 3)).astype(np.float32)
+        input_image = tf.random.uniform((2, 512, 512, 3))
         bounding_boxes = {
             "boxes": tf.ragged.constant(
                 [
@@ -182,8 +179,10 @@ class RandomRotationTest(tf.test.TestCase):
         num_classes = 8
 
         input_images = np.random.random((2, 20, 20, 3)).astype(np.float32)
-        masks = tf.one_hot(
-            np.random.randint(num_classes, size=(2, 20, 20)), num_classes
+        masks = np.array(
+            tf.one_hot(
+                np.random.randint(num_classes, size=(2, 20, 20)), num_classes
+            )
         )
         inputs = {"images": input_images, "segmentation_masks": masks}
 

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomSaturation(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the saturation on given images.
 

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomSharpness(VectorizedBaseImageAugmentationLayer):
     """Randomly performs the sharpness operation on given images.
 

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -15,10 +15,10 @@
 import warnings
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -25,7 +25,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomShear(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly shears images.
 

--- a/keras_cv/layers/preprocessing/random_translation.py
+++ b/keras_cv/layers/preprocessing/random_translation.py
@@ -25,7 +25,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomTranslation(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly translates images.
 

--- a/keras_cv/layers/preprocessing/random_translation.py
+++ b/keras_cv/layers/preprocessing/random_translation.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -15,8 +15,8 @@
 
 import tensorflow as tf
 from keras import backend
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -28,7 +28,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomZoom(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly zooms images.
 

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -20,7 +20,7 @@ from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RepeatedAugmentation(BaseImageAugmentationLayer):
     """RepeatedAugmentation augments each image in a batch multiple times.
 

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/rescaling.py
+++ b/keras_cv/layers/preprocessing/rescaling.py
@@ -25,7 +25,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Rescaling(BaseImageAugmentationLayer):
     """A preprocessing layer which rescales input values to a new range.
 

--- a/keras_cv/layers/preprocessing/rescaling.py
+++ b/keras_cv/layers/preprocessing/rescaling.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv.utils
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -309,7 +309,7 @@ class Resizing(BaseImageAugmentationLayer):
         def resize_with_crop_to_aspect(x, interpolation_method):
             if isinstance(x, tf.RaggedTensor):
                 x = x.to_tensor()
-            return keras.preprocessing.image.smart_resize(
+            return ops.smart_resize(
                 x,
                 size=size,
                 interpolation=interpolation_method,

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -150,7 +150,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("crop_to_aspect_ratio_false", False),
         ("crop_to_aspect_ratio_true", True),
     )
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_ragged_image(self, crop_to_aspect_ratio):
         inputs = tf.ragged.constant(
             [
@@ -228,7 +228,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -267,7 +267,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
-    @pytest.mark.tf_only
+    @pytest.mark.tf_keras_only
     def test_pad_to_size_with_bounding_boxes_ragged_images_upsample(self):
         images = tf.ragged.constant(
             [

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -16,10 +16,7 @@ import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
-from keras_cv import backend
 from keras_cv import layers as cv_layers
-from keras_cv.backend import keras
-from keras_cv.backend.config import multi_backend
 
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
@@ -153,10 +150,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("crop_to_aspect_ratio_false", False),
         ("crop_to_aspect_ratio_true", True),
     )
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_ragged_image(self, crop_to_aspect_ratio):
         inputs = tf.ragged.constant(
             [
@@ -199,10 +193,6 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("batch_pad_to_aspect_ratio", False, True, True),
         ("single_sample_pad_to_aspect_ratio", False, True, False),
     )
-    @pytest.mark.skipif(
-        multi_backend() and keras.backend.config.backend() != "tensorflow",
-        reason="Only TF supports in-graph preprocessing layers",
-    )
     def test_static_shape_inference(
         self, crop_to_aspect_ratio, pad_to_aspect_ratio, batch
     ):
@@ -238,10 +228,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -280,10 +267,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
-    @pytest.mark.skipif(
-        backend.supports_ragged() is False,
-        reason="Only TensorFlow supports raggeds",
-    )
+    @pytest.mark.tf_only
     def test_pad_to_size_with_bounding_boxes_ragged_images_upsample(self):
         images = tf.ragged.constant(
             [

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv import backend
 from keras_cv import layers as cv_layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 
 class ResizingTest(tf.test.TestCase, parameterized.TestCase):
@@ -149,6 +153,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("crop_to_aspect_ratio_false", False),
         ("crop_to_aspect_ratio_true", True),
     )
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_image(self, crop_to_aspect_ratio):
         inputs = tf.ragged.constant(
             [
@@ -191,6 +199,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("batch_pad_to_aspect_ratio", False, True, True),
         ("single_sample_pad_to_aspect_ratio", False, True, False),
     )
+    @pytest.mark.skipif(
+        multi_backend() and keras.backend.config.backend() != "tensorflow",
+        reason="Only TF supports in-graph preprocessing layers",
+    )
     def test_static_shape_inference(
         self, crop_to_aspect_ratio, pad_to_aspect_ratio, batch
     ):
@@ -226,6 +238,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -264,6 +280,10 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_pad_to_size_with_bounding_boxes_ragged_images_upsample(self):
         images = tf.ragged.constant(
             [

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -21,7 +21,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Solarization(VectorizedBaseImageAugmentationLayer):
     """Applies (max_value - pixel + min_value) for each pixel in the image.
 

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -37,7 +37,7 @@ USE_TARGETS = "use_targets"
 
 
 base_class = (
-    keras.layers.preprocessing.tf_data_layer.TFDataLayer
+    keras.src.layers.preprocessing.tf_data_layer.TFDataLayer
     if multi_backend()
     else keras.layers.Layer
 )

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -43,7 +43,7 @@ base_class = (
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class VectorizedBaseImageAugmentationLayer(base_class):
     """Abstract base layer for vectorized image augmentation.
 

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
+from keras_cv.backend.config import multi_backend
 from keras_cv.utils import preprocessing
 
 H_AXIS = -3
@@ -33,10 +36,15 @@ BATCHED = "batched"
 USE_TARGETS = "use_targets"
 
 
+base_class = (
+    keras.layers.preprocessing.tf_data_layer.TFDataLayer
+    if multi_backend()
+    else keras.layers.Layer
+)
+
+
 @keras.utils.register_keras_serializable(package="keras_cv")
-class VectorizedBaseImageAugmentationLayer(
-    keras.__internal__.layers.BaseRandomLayer
-):
+class VectorizedBaseImageAugmentationLayer(base_class):
     """Abstract base layer for vectorized image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -95,7 +103,12 @@ class VectorizedBaseImageAugmentationLayer(
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
+        self._convert_input_args = False
 
     @property
     def force_output_dense_images(self):
@@ -402,17 +415,21 @@ class VectorizedBaseImageAugmentationLayer(
         return result
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3 or images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3 or images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _format_inputs(self, inputs):
         metadata = {IS_DICT: True, USE_TARGETS: False}
@@ -484,6 +501,21 @@ class VectorizedBaseImageAugmentationLayer(
             inputs[IMAGES],
             self.compute_dtype,
         )
+        if LABELS in inputs:
+            inputs[LABELS] = preprocessing.ensure_tensor(
+                inputs[LABELS],
+                self.compute_dtype,
+            )
+        if KEYPOINTS in inputs:
+            inputs[KEYPOINTS] = preprocessing.ensure_tensor(
+                inputs[KEYPOINTS],
+                self.compute_dtype,
+            )
+        if SEGMENTATION_MASKS in inputs:
+            inputs[SEGMENTATION_MASKS] = preprocessing.ensure_tensor(
+                inputs[SEGMENTATION_MASKS],
+                self.compute_dtype,
+            )
         if BOUNDING_BOXES in inputs:
             inputs[BOUNDING_BOXES]["boxes"] = preprocessing.ensure_tensor(
                 inputs[BOUNDING_BOXES]["boxes"],

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -255,10 +255,10 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = VectorizedRandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(8, 8, 3)).astype("float32")
-        filenames = tf.constant("/path/to/first.jpg")
-        inputs = {"images": images, "filenames": filenames}
+        timestamps = np.array(123123123)
+        inputs = {"images": images, "timestamps": timestamps}
         output = add_layer(inputs)
-        self.assertAllEqual(output["filenames"], filenames)
+        self.assertAllEqual(output["timestamps"], timestamps)
 
     def test_augment_ragged_images(self):
         images = tf.ragged.stack(
@@ -435,31 +435,26 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
             "segmentation_masks": segmentation_masks,
         }
 
-        output = add_layer(input, training=True)
-        expected_output = {
-            "images": images + 2.0,
-            "bounding_boxes": bounding_box.to_dense(
-                {
-                    "boxes": bounding_boxes["boxes"] + 2.0,
-                    "classes": bounding_boxes["classes"] + 2.0,
-                }
-            ),
-            "keypoints": keypoints + 2.0,
-            "segmentation_masks": segmentation_masks + 2.0,
-        }
+        print(input)
+        print(input["bounding_boxes"]["boxes"].shape)
 
-        self.assertAllClose(output["images"], expected_output["images"])
-        self.assertAllClose(output["keypoints"], expected_output["keypoints"])
+        output = add_layer(input, training=True)
+
+        print(output)
+        print(input["bounding_boxes"]["boxes"].shape)
+
+        self.assertAllClose(output["images"], images + 2.0)
+        self.assertAllClose(output["keypoints"], keypoints + 2.0)
         self.assertAllClose(
             output["bounding_boxes"]["boxes"],
-            expected_output["bounding_boxes"]["boxes"],
+            tf.squeeze(bounding_boxes["boxes"]) + 2.0,
         )
         self.assertAllClose(
             output["bounding_boxes"]["classes"],
-            expected_output["bounding_boxes"]["classes"],
+            tf.squeeze(bounding_boxes["classes"]) + 2.0,
         )
         self.assertAllClose(
-            output["segmentation_masks"], expected_output["segmentation_masks"]
+            output["segmentation_masks"], segmentation_masks + 2.0
         )
 
     def test_augment_all_data_for_assertion(self):
@@ -490,21 +485,30 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_all_data_with_ragged_images_for_assertion(self):
         images = tf.ragged.stack(
             [
-                np.random.random(size=(8, 8, 3)).astype("float32"),
-                np.random.random(size=(16, 8, 3)).astype("float32"),
+                tf.random.uniform(shape=(8, 8, 3)),
+                tf.random.uniform(shape=(16, 8, 3)),
             ]
         )
-        labels = np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
-        bounding_boxes = {
-            "boxes": np.random.random(size=(2, 3, 4)).astype("float32"),
-            "classes": np.random.random(size=(2, 3)).astype("float32"),
-        }
-        keypoints = np.random.random(size=(2, 5, 2)).astype("float32")
-        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype(
-            "float32"
+        labels = tf.constant(
+            np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
         )
+        bounding_boxes = {
+            "boxes": tf.random.uniform(shape=(2, 3, 4)),
+            "classes": tf.random.uniform(shape=(2, 3)),
+        }
+        keypoints = tf.random.uniform(shape=(2, 5, 2))
+        segmentation_masks = tf.random.uniform(shape=(2, 8, 8, 1))
         assertion_layer = VectorizedAssertionLayer()
 
+        print(
+            {
+                "images": type(images),
+                "labels": type(labels),
+                "bounding_boxes": type(bounding_boxes),
+                "keypoints": type(keypoints),
+                "segmentation_masks": type(segmentation_masks),
+            }
+        )
         _ = assertion_layer(
             {
                 "images": images,

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -435,13 +435,7 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
             "segmentation_masks": segmentation_masks,
         }
 
-        print(input)
-        print(input["bounding_boxes"]["boxes"].shape)
-
         output = add_layer(input, training=True)
-
-        print(output)
-        print(input["bounding_boxes"]["boxes"].shape)
 
         self.assertAllClose(output["images"], images + 2.0)
         self.assertAllClose(output["keypoints"], keypoints + 2.0)

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -156,7 +156,7 @@ class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
                     "`tf.image.adjust_hue`. Skipping."
                 )
 
-        keras.mixed_precision.set_dtype_policy("mixed_float16")
+        keras.mixed_precision.set_global_policy("mixed_float16")
 
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=255, dtype=tf.float32
@@ -170,7 +170,7 @@ class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         # Do not affect other tests
-        keras.mixed_precision.set_dtype_policy("float32")
+        keras.mixed_precision.set_global_policy("float32")
 
 
 if __name__ == "__main__":

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
 
 TEST_CONFIGURATIONS = [
     ("AutoContrast", layers.AutoContrast, {"value_range": (0, 255)}),
@@ -145,6 +147,10 @@ NO_CPU_FP16_KERNEL_LAYERS = [
 ]
 
 
+@pytest.mark.skipif(
+    multi_backend(),
+    reason="Multi-backend Keras doesn't yet support mixed precision",
+)
 class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     @parameterized.named_parameters(*TEST_CONFIGURATIONS)
     def test_can_run_in_mixed_precision(self, layer_cls, init_args):

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -132,6 +132,4 @@ class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
         # This currently asserts that all layers are no-ops.
         # When preprocessing layers are updated to mutate segmentation masks,
         # this condition should only be asserted for no-op layers.
-        self.assertAllClose(
-            inputs["segmentation_masks"], outputs["segmentation_masks"]
-        )
+        self.assertAllClose(segmentation_mask, outputs["segmentation_masks"])

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -17,6 +17,7 @@ from tensorflow import keras
 from tensorflow.keras import backend
 
 from keras_cv import core
+from keras_cv.backend import ops
 
 _TF_INTERPOLATION_METHODS = {
     "bilinear": tf.image.ResizeMethod.BILINEAR,
@@ -376,10 +377,10 @@ def transform(
 
 def ensure_tensor(inputs, dtype=None):
     """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
-    if not isinstance(inputs, (tf.Tensor, tf.RaggedTensor, tf.SparseTensor)):
-        inputs = tf.convert_to_tensor(inputs, dtype)
+    if not ops.is_tensor(inputs):
+        inputs = ops.convert_to_tensor(inputs, dtype)
     if dtype is not None and inputs.dtype != dtype:
-        inputs = tf.cast(inputs, dtype)
+        inputs = ops.cast(inputs, dtype)
     return inputs
 
 

--- a/keras_cv/utils/target_gather.py
+++ b/keras_cv/utils/target_gather.py
@@ -80,11 +80,6 @@ def _target_gather(
             return _assign_when_rows_not_empty()
         else:
             return _assign_when_rows_empty()
-        # return ops.cond(
-        #     ops.greater(num_gt_boxes, 0),
-        #     _assign_when_rows_not_empty,
-        #     _assign_when_rows_empty,
-        # )
 
     def _gather_batched(labels, match_indices, mask, mask_val):
         """Gather based on batched labels."""

--- a/keras_cv/utils/target_gather_test.py
+++ b/keras_cv/utils/target_gather_test.py
@@ -12,106 +12,109 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
+from keras_cv.backend import ops
 from keras_cv.utils.target_gather import _target_gather
 
 
 class TargetGatherTest(tf.test.TestCase):
     def test_target_gather_boxes_batched(self):
-        target_boxes = tf.constant(
+        target_boxes = np.array(
             [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
         )
-        target_boxes = target_boxes[tf.newaxis, ...]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
-        expected_boxes = expected_boxes[tf.newaxis, ...]
+        target_boxes = ops.expand_dims(target_boxes, axis=0)
+        indices = np.array([[0, 2]], dtype="int32")
+        expected_boxes = np.array([[0, 0, 5, 5], [5, 0, 10, 5]])
+        expected_boxes = ops.expand_dims(expected_boxes, axis=0)
         res = _target_gather(target_boxes, indices)
         self.assertAllClose(expected_boxes, res)
 
     def test_target_gather_boxes_unbatched(self):
-        target_boxes = tf.constant(
-            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
+        target_boxes = np.array(
+            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]],
+            "int32",
         )
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
+        indices = np.array([0, 2], dtype="int32")
+        expected_boxes = np.array([[0, 0, 5, 5], [5, 0, 10, 5]])
         res = _target_gather(target_boxes, indices)
         self.assertAllClose(expected_boxes, res)
 
     def test_target_gather_classes_batched(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        expected_classes = tf.constant([[1, 3]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        expected_classes = np.array([[1, 3]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_unbatched(self):
-        target_classes = tf.constant([1, 2, 3, 4])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        expected_classes = tf.constant([1, 3])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([1, 2, 3, 4])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
+        expected_classes = np.array([1, 3])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_batched_with_mask(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        masks = tf.constant(([[False, True]]))
-        masks = masks[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        masks = np.array(([[False, True]]))
+        masks = ops.expand_dims(masks, axis=-1)
         # the second element is masked
-        expected_classes = tf.constant([[1, 0]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([[1, 0]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_batched_with_mask_val(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        masks = tf.constant(([[False, True]]))
-        masks = masks[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        masks = np.array(([[False, True]]))
+        masks = ops.expand_dims(masks, axis=-1)
         # the second element is masked
-        expected_classes = tf.constant([[1, -1]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([[1, -1]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks, -1)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_unbatched_with_mask(self):
-        target_classes = tf.constant([1, 2, 3, 4])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        masks = tf.constant([False, True])
-        masks = masks[..., tf.newaxis]
-        expected_classes = tf.constant([1, 0])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([1, 2, 3, 4])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
+        masks = np.array([False, True])
+        masks = ops.expand_dims(masks, axis=-1)
+        expected_classes = np.array([1, 0])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_with_empty_targets(self):
-        target_classes = tf.constant([])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
+        target_classes = np.array([])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
         # return all 0s since input is empty
-        expected_classes = tf.constant([0, 0])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([0, 0])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_multi_batch(self):
-        target_classes = tf.constant([[1, 2, 3, 4], [5, 6, 7, 8]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2], [1, 3]], dtype=tf.int32)
-        expected_classes = tf.constant([[1, 3], [6, 8]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2], [1, 3]], dtype="int32")
+        expected_classes = np.array([[1, 3], [6, 8]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_invalid_rank(self):
-        targets = tf.random.normal([32, 2, 2, 2])
-        indices = tf.constant([0, 1], dtype=tf.int32)
+        targets = np.random.normal(size=[32, 2, 2, 2])
+        indices = np.array([0, 1], dtype="int32")
         with self.assertRaisesRegex(ValueError, "larger than 3"):
             _ = _target_gather(targets, indices)

--- a/keras_cv/utils/train.py
+++ b/keras_cv/utils/train.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+
+from keras_cv.backend import keras
 
 
 def scale_loss_for_distribution(loss_value):


### PR DESCRIPTION
🚧 This is an experimental feature branch, more details soon. 🚧

This is a retry of #1901

If the diff is too overwhelming, I can remove the changes to the preprocessing layers and put them in a separate PR.

The big points for review here are:

- Backend import infrastructure
- The TFDataScope and tf_data decorator
- CI setup

I expect that getting /gcbrun working is going to take some doing, but I've sent this for review now to get the conversation started. I think we can sort that out later since we're working on this `core` branch and just leave it be for now. I have been testing large tests with all backends on my working branch.