### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -33,4 +33,4 @@ from keras_cv.core import FactorSampler
 from keras_cv.core import NormalFactorSampler
 from keras_cv.core import UniformFactorSampler
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
We are currently broken against Keras 2.13, so we need to cut a quick release to fix (the fixes are already in `master`, just not on PyPi)