### PR TITLE
Add support for PyTorch and Jax to KerasCV

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -100,6 +100,7 @@ jobs:
         JAX_ENABLE_X64: true
       run: |
         pytest --run_large keras_cv/bounding_box \
+               keras_cv/losses \
                keras_cv/layers/preprocessing \
                keras_cv/models/backbones \
                --durations 0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         pytest --run_large keras_cv/bounding_box \
                keras_cv/layers/preprocessing \
+               keras_cv/models/backbones \
                --durations 0
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,14 +7,14 @@ on:
     types: [created]
 jobs:
   test:
-    name: Test the code
+    name: Test the code with tf.keras
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -27,29 +27,90 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Setup SSH Keys and known_hosts
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
     - name: Install dependencies
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
-        pip install tensorflow-cpu==2.11.0
+        pip install tensorflow==2.12.0
+        pip install torch>=2.0.1+cpu
+        pip install "jax[cpu]"
         pip install -e ".[tests]" --progress-bar off --upgrade
-    - name: Build custom ops for tests
-      run: |
-        python build_deps/configure.py
-        bazel build keras_cv/custom_ops:all
-        cp bazel-bin/keras_cv/custom_ops/*.so keras_cv/custom_ops/
+        git clone git@github.com:keras-team/keras-core.git
+        pip install -r keras-core/requirements.txt
+        python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
-        TEST_CUSTOM_OPS: true
+        TEST_CUSTOM_OPS: false
       run: |
         pytest keras_cv/ --ignore keras_cv/models/legacy/ --durations 0
+  multibackend:
+    name: Test the code with Keras Core
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [tensorflow, jax, torch]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -m pip install --upgrade pip setuptools
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Setup SSH Keys and known_hosts
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
+    - name: Install dependencies
+      env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+        pip install tensorflow==2.12.0
+        pip install "jax[cpu]"
+        pip install torch>=2.0.1+cpu
+        pip install torchvision>=0.15.1
+        git clone git@github.com:keras-team/keras-core.git
+        pip install -r keras-core/requirements.txt
+        python keras-core/pip_build.py --install
+        pip install -e ".[tests]" --progress-bar off --upgrade
+    - name: Test with pytest
+      env:
+        TEST_CUSTOM_OPS: false # TODO(ianstenbit): test custom ops, or figure out what our story is here
+        KERAS_CV_MULTI_BACKEND: true
+        KERAS_BACKEND: ${{ matrix.backend }}
+        JAX_ENABLE_X64: true
+      run: |
+        pytest --run_large keras_cv/bounding_box \
+               keras_cv/layers/preprocessing \
+               --durations 0
   format:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -75,4 +136,3 @@ jobs:
         extensions: 'h,c,cpp,hpp,cc'
         clangFormatVersion: 14
         style: google
-  

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         pytest --run_large keras_cv/bounding_box \
                keras_cv/losses \
+               keras_cv/layers/object_detection \
                keras_cv/layers/preprocessing \
                keras_cv/models/backbones \
                keras_cv/models/classification \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.12.0
+        pip install tensorflow==2.13.0
         pip install torch>=2.0.1+cpu
         pip install "jax[cpu]"
         pip install keras-core
@@ -66,7 +66,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.12.0
+        pip install tensorflow==2.13.0
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -87,6 +87,7 @@ jobs:
                keras_cv/models/backbones \
                keras_cv/models/classification \
                keras_cv/models/object_detection/retinanet \
+               keras_cv/models/object_detection/yolo_v8 \
                --durations 0
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -103,6 +103,7 @@ jobs:
                keras_cv/losses \
                keras_cv/layers/preprocessing \
                keras_cv/models/backbones \
+               keras_cv/models/classification \
                --durations 0
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -105,6 +105,7 @@ jobs:
                keras_cv/layers/preprocessing \
                keras_cv/models/backbones \
                keras_cv/models/classification \
+               keras_cv/models/object_detection/retinanet \
                --durations 0
   format:
     name: Check the code format

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,23 +27,13 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Setup SSH Keys and known_hosts
-      env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      run: |
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
     - name: Install dependencies
-      env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
         pip install torch>=2.0.1+cpu
         pip install "jax[cpu]"
+        pip install keras-core
         pip install -e ".[tests]" --progress-bar off --upgrade
-        git clone git@github.com:keras-team/keras-core.git
-        pip install -r keras-core/requirements.txt
-        python keras-core/pip_build.py --install
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false
@@ -74,23 +64,13 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Setup SSH Keys and known_hosts
-      env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      run: |
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.KERAS_CORE }}"
     - name: Install dependencies
-      env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         pip install tensorflow==2.12.0
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
-        git clone git@github.com:keras-team/keras-core.git
-        pip install -r keras-core/requirements.txt
-        python keras-core/pip_build.py --install
+        pip install keras-core
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -100,6 +100,7 @@ jobs:
         JAX_ENABLE_X64: true
       run: |
         pytest --run_large keras_cv/bounding_box \
+               keras_cv/callbacks \
                keras_cv/losses \
                keras_cv/layers/object_detection \
                keras_cv/layers/preprocessing \

--- a/cloudbuild/README.md
+++ b/cloudbuild/README.md
@@ -29,7 +29,7 @@ To add a dependency for GPU tests:
 - Have a Keras team member update the Docker image for GPU tests by running the remaining steps
 - Create a `Dockerfile` with the following contents:
 ```
-FROM tensorflow/tensorflow:2.11.0-gpu
+FROM tensorflow/tensorflow:2.13.0-gpu
 RUN \
     apt-get -y update && \
     apt-get -y install openjdk-8-jdk && \

--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -42,4 +42,4 @@ from keras_cv.core import FactorSampler
 from keras_cv.core import NormalFactorSampler
 from keras_cv.core import UniformFactorSampler
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/keras_cv/__init__.py
+++ b/keras_cv/__init__.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    # When using torch and tensorflow, torch needs to be imported first,
+    # otherwise it will segfault upon import.
+    import torch
+
+    del torch
+except ImportError:
+    pass
+
 # isort:off
 from keras_cv import version_check
 

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -22,6 +22,8 @@ as add shims to support older version of `tf.keras`.
 - `ops`: `keras_core.ops`, always tf-backed if using `tf.keras`.
 """
 
+import types
+
 from keras_cv.backend.config import multi_backend
 
 # Keys are of the form: "module.where.attr.exists->module.where.to.alias"
@@ -42,6 +44,9 @@ if multi_backend():
     import keras_core as keras
 else:
     from tensorflow import keras
+
+    if not hasattr(keras, "saving"):
+        keras.saving = types.SimpleNamespace()
 
     # add aliases
     for key, value in _KERAS_CORE_ALIASES.items():

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -1,0 +1,78 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Keras backend module.
+
+This module adds a temporarily Keras API surface that is fully under KerasCV
+control. This allows us to switch between `keras_core` and `tf.keras`, as well
+as add shims to support older version of `tf.keras`.
+- `config`: check which backend is being run.
+- `keras`: The full `keras` API (via `keras_core` or `tf.keras`).
+- `ops`: `keras_core.ops`, always tf-backed if using `tf.keras`.
+"""
+
+from keras_cv.backend.config import multi_backend
+
+# Keys are of the form: "module.where.attr.exists->module.where.to.alias"
+# Value are of the form: ["attr1", "attr2", ...] or
+#                        [("attr1_original_name", "attr1_alias_name")]
+_KERAS_CORE_ALIASES = {
+    "utils->saving": [
+        "register_keras_serializable",
+        "deserialize_keras_object",
+        "serialize_keras_object",
+        "get_registered_object",
+    ],
+    "models->saving": ["load_model"],
+}
+
+
+if multi_backend():
+    import keras_core as keras
+else:
+    from tensorflow import keras
+
+    # add aliases
+    for key, value in _KERAS_CORE_ALIASES.items():
+        src, _, dst = key.partition("->")
+        src = src.split(".")
+        dst = dst.split(".")
+
+        src_mod, dst_mod = keras, keras
+
+        # navigate to where we want to alias the attributes
+        for mod in src:
+            src_mod = getattr(src_mod, mod)
+        for mod in dst:
+            dst_mod = getattr(dst_mod, mod)
+
+        # add an alias for each attribute
+        for attr in value:
+            if isinstance(attr, tuple):
+                src_attr, dst_attr = attr
+            else:
+                src_attr, dst_attr = attr, attr
+            attr_val = getattr(src_mod, src_attr)
+            setattr(dst_mod, dst_attr, attr_val)
+
+    # TF Keras doesn't have this rename.
+    keras.activations.silu = keras.activations.swish
+
+from keras_cv.backend import config  # noqa: E402
+from keras_cv.backend import ops  # noqa: E402
+from keras_cv.backend import tf_ops  # noqa: E402
+
+
+def supports_ragged():
+    return not multi_backend()

--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -74,5 +74,13 @@ from keras_cv.backend import ops  # noqa: E402
 from keras_cv.backend import tf_ops  # noqa: E402
 
 
+def assert_tf_keras(src):
+    if multi_backend():
+        raise NotImplementedError(
+            f"KerasCV component {src} does not yet support Keras Core, and can "
+            "only be used in `tf.keras`."
+        )
+
+
 def supports_ragged():
     return not multi_backend()

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -1,0 +1,69 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+
+_MULTI_BACKEND = False
+
+# Set Keras base dir path given KERAS_HOME env variable, if applicable.
+# Otherwise either ~/.keras or /tmp.
+if "KERAS_HOME" in os.environ:
+    _keras_dir = os.environ.get("KERAS_HOME")
+else:
+    _keras_base_dir = os.path.expanduser("~")
+    if not os.access(_keras_base_dir, os.W_OK):
+        _keras_base_dir = "/tmp"
+    _keras_dir = os.path.join(_keras_base_dir, ".keras")
+
+# Attempt to read KerasCV config file.
+_config_path = os.path.expanduser(os.path.join(_keras_dir, "keras-cv.json"))
+if os.path.exists(_config_path):
+    try:
+        with open(_config_path) as f:
+            _config = json.load(f)
+    except ValueError:
+        _config = {}
+    _MULTI_BACKEND = _config.get("multi_backend", _MULTI_BACKEND)
+
+# Save config file, if possible.
+if not os.path.exists(_keras_dir):
+    try:
+        os.makedirs(_keras_dir)
+    except OSError:
+        # Except permission denied and potential race conditions
+        # in multi-threaded environments.
+        pass
+
+if not os.path.exists(_config_path):
+    _config = {
+        "multi_backend": _MULTI_BACKEND,
+    }
+    try:
+        with open(_config_path, "w") as f:
+            f.write(json.dumps(_config, indent=4))
+    except IOError:
+        # Except permission denied.
+        pass
+
+# Set Keras backend based on KERAS_CV_MULTI_BACKEND flag, if applicable.
+if "KERAS_CV_MULTI_BACKEND" in os.environ:
+    if os.environ["KERAS_CV_MULTI_BACKEND"]:
+        _MULTI_BACKEND = True
+
+if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
+    _MULTI_BACKEND = True
+
+
+def multi_backend():
+    return _MULTI_BACKEND

--- a/keras_cv/backend/ops.py
+++ b/keras_cv/backend/ops.py
@@ -1,0 +1,23 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_cv.backend.config import multi_backend
+
+if multi_backend():
+    from keras_core.src.backend import vectorized_map  # noqa: F403, F401
+    from keras_core.src.ops import *  # noqa: F403, F401
+    from keras_core.src.utils.image_utils import (  # noqa: F403, F401
+        smart_resize,
+    )
+else:
+    from keras_cv.backend.tf_ops import *  # noqa: F403, F401

--- a/keras_cv/backend/scope.py
+++ b/keras_cv/backend/scope.py
@@ -1,0 +1,59 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import functools
+
+from keras_cv import backend
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend import tf_ops
+from keras_cv.backend.config import multi_backend
+
+_ORIGINAL_OPS = copy.copy(backend.ops.__dict__)
+_ORIGINAL_SUPPORTS_RAGGED = backend.supports_ragged
+
+# A counter for potentially nested TF data scopes
+_IN_TF_DATA_SCOPE = 0
+
+
+def tf_data(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        if multi_backend() and keras.src.utils.backend_utils.in_tf_graph():
+            with TFDataScope():
+                return function(*args, **kwargs)
+        else:
+            return function(*args, **kwargs)
+
+    return wrapper
+
+
+class TFDataScope:
+    def __enter__(self):
+        global _IN_TF_DATA_SCOPE
+        if _IN_TF_DATA_SCOPE == 0:
+            for k, v in ops.__dict__.items():
+                if k in tf_ops.__dict__:
+                    setattr(ops, k, getattr(tf_ops, k))
+            backend.supports_ragged = lambda: True
+        _IN_TF_DATA_SCOPE += 1
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        global _IN_TF_DATA_SCOPE
+        _IN_TF_DATA_SCOPE -= 1
+        if _IN_TF_DATA_SCOPE == 0:
+            for k, v in ops.__dict__.items():
+                setattr(ops, k, _ORIGINAL_OPS[k])
+            backend.supports_ragged = _ORIGINAL_SUPPORTS_RAGGED
+            _IN_TF_DATA_SCOPE = False

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -1,0 +1,31 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from keras_core.src.backend.tensorflow import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow import (  # noqa: F403, F401
+    convert_to_numpy,
+)
+from keras_core.src.backend.tensorflow.core import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.math import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.nn import *  # noqa: F403, F401
+from keras_core.src.backend.tensorflow.numpy import *  # noqa: F403, F401
+
+# Some TF APIs where the numpy API doesn't support raggeds that we need
+from tensorflow import concat as concatenate  # noqa: F403, F401
+from tensorflow import range as arange  # noqa: F403, F401
+from tensorflow import reduce_max as max  # noqa: F403, F401
+from tensorflow import reshape  # noqa: F403, F401
+from tensorflow import split  # noqa: F403, F401
+from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401
+    smart_resize,
+)

--- a/keras_cv/backend/tf_ops.py
+++ b/keras_cv/backend/tf_ops.py
@@ -23,7 +23,9 @@ from keras_core.src.backend.tensorflow.numpy import *  # noqa: F403, F401
 # Some TF APIs where the numpy API doesn't support raggeds that we need
 from tensorflow import concat as concatenate  # noqa: F403, F401
 from tensorflow import range as arange  # noqa: F403, F401
+from tensorflow import reduce_all as all  # noqa: F403, F401
 from tensorflow import reduce_max as max  # noqa: F403, F401
+from tensorflow import repeat  # noqa: F403, F401
 from tensorflow import reshape  # noqa: F403, F401
 from tensorflow import split  # noqa: F403, F401
 from tensorflow.keras.preprocessing.image import (  # noqa: F403, F401

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Converter functions for working with bounding box formats."""
 
-from typing import List
-from typing import Optional
-from typing import Union
 
 import tensorflow as tf
-from tensorflow import keras
+
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend.scope import tf_data
 
 
 # Internal exception to propagate the fact images was not passed to a converter
@@ -27,23 +27,22 @@ class RequiresImagesException(Exception):
     pass
 
 
-ALL_AXES = [1, 1, 1, 1]
+ALL_AXES = 4
 
 
 def _encode_box_to_deltas(
-    anchors: tf.Tensor,
-    boxes: tf.Tensor,
+    anchors,
+    boxes,
     anchor_format: str,
     box_format: str,
-    variance: Optional[Union[List[float], tf.Tensor]] = None,
+    variance=None,
     image_shape=None,
 ):
     """Converts bounding_boxes from `center_yxhw` to delta format."""
     if variance is not None:
-        if tf.is_tensor(variance):
-            var_len = variance.get_shape().as_list()[-1]
-        else:
-            var_len = len(variance)
+        variance = ops.convert_to_tensor(variance, "float32")
+        var_len = variance.shape[-1]
+
         if var_len != 4:
             raise ValueError(f"`variance` must be length 4, got {variance}")
     encoded_anchors = convert_format(
@@ -55,15 +54,15 @@ def _encode_box_to_deltas(
     boxes = convert_format(
         boxes, source=box_format, target="center_yxhw", image_shape=image_shape
     )
-    anchor_dimensions = tf.maximum(
+    anchor_dimensions = ops.maximum(
         encoded_anchors[..., 2:], keras.backend.epsilon()
     )
-    box_dimensions = tf.maximum(boxes[..., 2:], keras.backend.epsilon())
+    box_dimensions = ops.maximum(boxes[..., 2:], keras.backend.epsilon())
     # anchors be unbatched, boxes can either be batched or unbatched.
-    boxes_delta = tf.concat(
+    boxes_delta = ops.concatenate(
         [
             (boxes[..., :2] - encoded_anchors[..., :2]) / anchor_dimensions,
-            tf.math.log(box_dimensions / anchor_dimensions),
+            ops.log(box_dimensions / anchor_dimensions),
         ],
         axis=-1,
     )
@@ -73,22 +72,20 @@ def _encode_box_to_deltas(
 
 
 def _decode_deltas_to_boxes(
-    anchors: tf.Tensor,
-    boxes_delta: tf.Tensor,
+    anchors,
+    boxes_delta,
     anchor_format: str,
     box_format: str,
-    variance: Optional[Union[List[float], tf.Tensor]] = None,
+    variance=None,
     image_shape=None,
 ):
     """Converts bounding_boxes from delta format to `center_yxhw`."""
     if variance is not None:
-        if tf.is_tensor(variance):
-            var_len = variance.get_shape().as_list()[-1]
-        else:
-            var_len = len(variance)
+        variance = ops.convert_to_tensor(variance, "float32")
+        var_len = variance.shape[-1]
+
         if var_len != 4:
             raise ValueError(f"`variance` must be length 4, got {variance}")
-    tf.nest.assert_same_structure(anchors, boxes_delta)
 
     def decode_single_level(anchor, box_delta):
         encoded_anchor = convert_format(
@@ -100,11 +97,11 @@ def _decode_deltas_to_boxes(
         if variance is not None:
             box_delta = box_delta * variance
         # anchors be unbatched, boxes can either be batched or unbatched.
-        box = tf.concat(
+        box = ops.concatenate(
             [
                 box_delta[..., :2] * encoded_anchor[..., 2:]
                 + encoded_anchor[..., :2],
-                tf.math.exp(box_delta[..., 2:]) * encoded_anchor[..., 2:],
+                ops.exp(box_delta[..., 2:]) * encoded_anchor[..., 2:],
             ],
             axis=-1,
         )
@@ -126,29 +123,29 @@ def _decode_deltas_to_boxes(
 
 
 def _center_yxhw_to_xyxy(boxes, images=None, image_shape=None):
-    y, x, height, width = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    y, x, height, width = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [x - width / 2.0, y - height / 2.0, x + width / 2.0, y + height / 2.0],
         axis=-1,
     )
 
 
 def _center_xywh_to_xyxy(boxes, images=None, image_shape=None):
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [x - width / 2.0, y - height / 2.0, x + width / 2.0, y + height / 2.0],
         axis=-1,
     )
 
 
 def _xywh_to_xyxy(boxes, images=None, image_shape=None):
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([x, y, x + width, y + height], axis=-1)
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([x, y, x + width, y + height], axis=-1)
 
 
 def _xyxy_to_center_yxhw(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             (top + bottom) / 2.0,
             (left + right) / 2.0,
@@ -161,8 +158,8 @@ def _xyxy_to_center_yxhw(boxes, images=None, image_shape=None):
 
 def _rel_xywh_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    x, y, width, height = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    x, y, width, height = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             image_width * x,
             image_height * y,
@@ -178,8 +175,8 @@ def _xyxy_no_op(boxes, images=None, image_shape=None):
 
 
 def _xyxy_to_xywh(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [left, top, right - left, bottom - top],
         axis=-1,
     )
@@ -187,21 +184,21 @@ def _xyxy_to_xywh(boxes, images=None, image_shape=None):
 
 def _xyxy_to_rel_xywh(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
     left, right = (
         left / image_width,
         right / image_width,
     )
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right - left, bottom - top],
         axis=-1,
     )
 
 
 def _xyxy_to_center_xywh(boxes, images=None, image_shape=None):
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat(
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate(
         [
             (left + right) / 2.0,
             (top + bottom) / 2.0,
@@ -214,14 +211,14 @@ def _xyxy_to_center_xywh(boxes, images=None, image_shape=None):
 
 def _rel_xyxy_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(
+    left, top, right, bottom = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left * image_width, right * image_width
     top, bottom = top * image_height, bottom * image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
@@ -229,50 +226,50 @@ def _rel_xyxy_to_xyxy(boxes, images=None, image_shape=None):
 
 def _xyxy_to_rel_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(
+    left, top, right, bottom = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left / image_width, right / image_width
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
 
 
 def _yxyx_to_xyxy(boxes, images=None, image_shape=None):
-    y1, x1, y2, x2 = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([x1, y1, x2, y2], axis=-1)
+    y1, x1, y2, x2 = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([x1, y1, x2, y2], axis=-1)
 
 
 def _rel_yxyx_to_xyxy(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    top, left, bottom, right = tf.split(
+    top, left, bottom, right = ops.split(
         boxes,
         ALL_AXES,
         axis=-1,
     )
     left, right = left * image_width, right * image_width
     top, bottom = top * image_height, bottom * image_height
-    return tf.concat(
+    return ops.concatenate(
         [left, top, right, bottom],
         axis=-1,
     )
 
 
 def _xyxy_to_yxyx(boxes, images=None, image_shape=None):
-    x1, y1, x2, y2 = tf.split(boxes, ALL_AXES, axis=-1)
-    return tf.concat([y1, x1, y2, x2], axis=-1)
+    x1, y1, x2, y2 = ops.split(boxes, ALL_AXES, axis=-1)
+    return ops.concatenate([y1, x1, y2, x2], axis=-1)
 
 
 def _xyxy_to_rel_yxyx(boxes, images=None, image_shape=None):
     image_height, image_width = _image_shape(images, image_shape, boxes)
-    left, top, right, bottom = tf.split(boxes, ALL_AXES, axis=-1)
+    left, top, right, bottom = ops.split(boxes, ALL_AXES, axis=-1)
     left, right = left / image_width, right / image_width
     top, bottom = top / image_height, bottom / image_height
-    return tf.concat(
+    return ops.concatenate(
         [top, left, bottom, right],
         axis=-1,
     )
@@ -301,6 +298,7 @@ FROM_XYXY_CONVERTERS = {
 }
 
 
+@tf_data
 def convert_format(
     boxes, source, target, images=None, image_shape=None, dtype="float32"
 ):
@@ -350,12 +348,12 @@ def convert_format(
     ```
 
     Args:
-        boxes: tf.Tensor representing bounding boxes in the format specified in
+        boxes: tensor representing bounding boxes in the format specified in
             the `source` parameter. `boxes` can optionally have extra
             dimensions stacked on the final axis to store metadata. boxes
-            should be a 3D Tensor, with the shape `[batch_size, num_boxes, 4]`.
+            should be a 3D tensor, with the shape `[batch_size, num_boxes, 4]`.
             Alternatively, boxes can be a dictionary with key 'boxes' containing
-            a Tensor matching the aforementioned spec.
+            a tensor matching the aforementioned spec.
         source:One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.
             Used to specify the original format of the `boxes` parameter.
         target:One of {" ".join([f'"{f}"' for f in TO_XYXY_CONVERTERS.keys()])}.
@@ -367,7 +365,7 @@ def convert_format(
             dimensions. Required when transforming from a rel format to a
             non-rel format.
         dtype: the data type to use when transforming the boxes, defaults to
-            `tf.float32`.
+            `"float32"`.
     """
     if isinstance(boxes, dict):
         boxes["boxes"] = convert_format(
@@ -380,7 +378,7 @@ def convert_format(
         )
         return boxes
 
-    if boxes.shape[-1] != 4:
+    if boxes.shape[-1] is not None and boxes.shape[-1] != 4:
         raise ValueError(
             "Expected `boxes` to be a Tensor with a final dimension of "
             f"`4`. Instead, got `boxes.shape={boxes.shape}`."
@@ -408,7 +406,7 @@ def convert_format(
             f"{FROM_XYXY_CONVERTERS.keys()}. Got target={target}"
         )
 
-    boxes = tf.cast(boxes, dtype)
+    boxes = ops.cast(boxes, dtype)
     if source == target:
         return boxes
 
@@ -462,10 +460,10 @@ def _format_inputs(boxes, images):
                 "len(boxes.shape)=3 AND len(images.shape)=4."
             )
         if not images_include_batch:
-            images = tf.expand_dims(images, axis=0)
+            images = ops.expand_dims(images, axis=0)
 
     if not boxes_includes_batch:
-        return tf.expand_dims(boxes, axis=0), images, True
+        return ops.expand_dims(boxes, axis=0), images, True
     return boxes, images, False
 
 
@@ -483,7 +481,7 @@ def _validate_image_shape(image_shape):
         return
 
     # tensor
-    if isinstance(image_shape, tf.Tensor):
+    if ops.is_tensor(image_shape):
         if len(image_shape.shape) > 1:
             raise ValueError(
                 "image_shape.shape should be (3), but got "
@@ -505,7 +503,7 @@ def _validate_image_shape(image_shape):
 
 def _format_outputs(boxes, squeeze):
     if squeeze:
-        return tf.squeeze(boxes, axis=0)
+        return ops.squeeze(boxes, axis=0)
     return boxes
 
 
@@ -515,15 +513,13 @@ def _image_shape(images, image_shape, boxes):
 
     if image_shape is None:
         if not isinstance(images, tf.RaggedTensor):
-            image_shape = tf.shape(images)
+            image_shape = ops.shape(images)
             height, width = image_shape[1], image_shape[2]
         else:
-            height = tf.reshape(images.row_lengths(), (-1, 1))
-            width = tf.reshape(
-                tf.reduce_max(images.row_lengths(axis=2), 1), (-1, 1)
-            )
-            height = tf.expand_dims(height, axis=-1)
-            width = tf.expand_dims(width, axis=-1)
+            height = ops.reshape(images.row_lengths(), (-1, 1))
+            width = ops.reshape(ops.max(images.row_lengths(axis=2), 1), (-1, 1))
+            height = ops.expand_dims(height, axis=-1)
+            width = ops.expand_dims(width, axis=-1)
     else:
         height, width = image_shape[0], image_shape[1]
-    return tf.cast(height, boxes.dtype), tf.cast(width, boxes.dtype)
+    return ops.cast(height, boxes.dtype), ops.cast(width, boxes.dtype)

--- a/keras_cv/bounding_box/converters_test.py
+++ b/keras_cv/bounding_box/converters_test.py
@@ -15,40 +15,35 @@
 import itertools
 
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
 from keras_cv import bounding_box
 
-xyxy_box = tf.constant(
-    [[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype=tf.float32
+xyxy_box = np.array([[[10, 20, 110, 120], [20, 30, 120, 130]]], dtype="float32")
+yxyx_box = np.array([[[20, 10, 120, 110], [30, 20, 130, 120]]], dtype="float32")
+rel_xyxy_box = np.array(
+    [[[0.01, 0.02, 0.11, 0.12], [0.02, 0.03, 0.12, 0.13]]], dtype="float32"
 )
-yxyx_box = tf.constant(
-    [[[20, 10, 120, 110], [30, 20, 130, 120]]], dtype=tf.float32
+rel_xyxy_box_ragged_images = np.array(
+    [[[0.10, 0.20, 1.1, 1.20], [0.40, 0.6, 2.40, 2.6]]], dtype="float32"
 )
-rel_xyxy_box = tf.constant(
-    [[[0.01, 0.02, 0.11, 0.12], [0.02, 0.03, 0.12, 0.13]]], dtype=tf.float32
+rel_yxyx_box = np.array(
+    [[[0.02, 0.01, 0.12, 0.11], [0.03, 0.02, 0.13, 0.12]]], dtype="float32"
 )
-rel_xyxy_box_ragged_images = tf.constant(
-    [[[0.10, 0.20, 1.1, 1.20], [0.40, 0.6, 2.40, 2.6]]], dtype=tf.float32
+rel_yxyx_box_ragged_images = np.array(
+    [[[0.2, 0.1, 1.2, 1.1], [0.6, 0.4, 2.6, 2.4]]], dtype="float32"
 )
-rel_yxyx_box = tf.constant(
-    [[[0.02, 0.01, 0.12, 0.11], [0.03, 0.02, 0.13, 0.12]]], dtype=tf.float32
+center_xywh_box = np.array(
+    [[[60, 70, 100, 100], [70, 80, 100, 100]]], dtype="float32"
 )
-rel_yxyx_box_ragged_images = tf.constant(
-    [[[0.2, 0.1, 1.2, 1.1], [0.6, 0.4, 2.6, 2.4]]], dtype=tf.float32
+xywh_box = np.array([[[10, 20, 100, 100], [20, 30, 100, 100]]], dtype="float32")
+rel_xywh_box = np.array(
+    [[[0.01, 0.02, 0.1, 0.1], [0.02, 0.03, 0.1, 0.1]]], dtype="float32"
 )
-center_xywh_box = tf.constant(
-    [[[60, 70, 100, 100], [70, 80, 100, 100]]], dtype=tf.float32
-)
-xywh_box = tf.constant(
-    [[[10, 20, 100, 100], [20, 30, 100, 100]]], dtype=tf.float32
-)
-rel_xywh_box = tf.constant(
-    [[[0.01, 0.02, 0.1, 0.1], [0.02, 0.03, 0.1, 0.1]]], dtype=tf.float32
-)
-rel_xywh_box_ragged_images = tf.constant(
-    [[[0.1, 0.2, 1, 1], [0.4, 0.6, 2, 2]]], dtype=tf.float32
+rel_xywh_box_ragged_images = np.array(
+    [[[0.1, 0.2, 1, 1], [0.4, 0.6, 2, 2]]], dtype="float32"
 )
 
 ragged_images = tf.ragged.constant(
@@ -56,9 +51,9 @@ ragged_images = tf.ragged.constant(
     ragged_rank=2,
 )
 
-images = tf.ones([2, 1000, 1000, 3])
+images = np.ones([2, 1000, 1000, 3])
 
-ragged_classes = tf.ragged.constant([[0], [0]], dtype=tf.float32)
+ragged_classes = tf.ragged.constant([[0], [0]], dtype="float32")
 
 boxes = {
     "xyxy": xyxy_box,
@@ -107,6 +102,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.tf_keras_only
     def test_converters_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -157,6 +153,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -168,6 +165,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])
@@ -179,6 +177,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_cases)
+    @pytest.mark.tf_keras_only
     def test_ragged_bounding_box_with_image_shape(self, source, target):
         source_box = _raggify(boxes[source])
         target_box = _raggify(boxes[target])
@@ -193,6 +192,7 @@ class ConvertersTestCase(tf.test.TestCase, parameterized.TestCase):
         )
 
     @parameterized.named_parameters(*test_image_ragged)
+    @pytest.mark.tf_keras_only
     def test_dense_bounding_box_with_ragged_images(self, source, target):
         source_box = _raggify(boxes_ragged_images[source])
         target_box = _raggify(boxes_ragged_images[target])

--- a/keras_cv/bounding_box/ensure_tensor_test.py
+++ b/keras_cv/bounding_box/ensure_tensor_test.py
@@ -15,25 +15,18 @@
 import tensorflow as tf
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class BoundingBoxEnsureTensorTest(tf.test.TestCase):
     def test_convert_list(self):
         boxes = {"boxes": [[0, 1, 2, 3]], "classes": [0]}
         output = bounding_box.ensure_tensor(boxes)
-        self.assertFalse(
-            any([isinstance(boxes[k], tf.Tensor) for k in boxes.keys()])
-        )
-        self.assertTrue(
-            all([isinstance(output[k], tf.Tensor) for k in output.keys()])
-        )
+        self.assertFalse(any([ops.is_tensor(boxes[k]) for k in boxes.keys()]))
+        self.assertTrue(all([ops.is_tensor(output[k]) for k in output.keys()]))
 
     def test_confidence(self):
         boxes = {"boxes": [[0, 1, 2, 3]], "classes": [0], "confidence": [0.245]}
         output = bounding_box.ensure_tensor(boxes)
-        self.assertFalse(
-            any([isinstance(boxes[k], tf.Tensor) for k in boxes.keys()])
-        )
-        self.assertTrue(
-            all([isinstance(output[k], tf.Tensor) for k in output.keys()])
-        )
+        self.assertFalse(any([ops.is_tensor(boxes[k]) for k in boxes.keys()]))
+        self.assertTrue(all([ops.is_tensor(output[k]) for k in output.keys()]))

--- a/keras_cv/bounding_box/iou.py
+++ b/keras_cv/bounding_box/iou.py
@@ -14,9 +14,9 @@
 """Contains functions to compute ious of bounding boxes."""
 import math
 
-import tensorflow as tf
-
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
 def _compute_area(box):
@@ -28,10 +28,8 @@ def _compute_area(box):
     Returns:
       a float Tensor of [N] or [batch_size, N]
     """
-    y_min, x_min, y_max, x_max = tf.split(
-        box[..., :4], num_or_size_splits=4, axis=-1
-    )
-    return tf.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
+    y_min, x_min, y_max, x_max = ops.split(box[..., :4], 4, axis=-1)
+    return ops.squeeze((y_max - y_min) * (x_max - x_min), axis=-1)
 
 
 def _compute_intersection(boxes1, boxes2):
@@ -43,25 +41,21 @@ def _compute_intersection(boxes1, boxes2):
     Returns:
       a [N, M] or [batch_size, N, M] float Tensor.
     """
-    y_min1, x_min1, y_max1, x_max1 = tf.split(
-        boxes1[..., :4], num_or_size_splits=4, axis=-1
-    )
-    y_min2, x_min2, y_max2, x_max2 = tf.split(
-        boxes2[..., :4], num_or_size_splits=4, axis=-1
-    )
+    y_min1, x_min1, y_max1, x_max1 = ops.split(boxes1[..., :4], 4, axis=-1)
+    y_min2, x_min2, y_max2, x_max2 = ops.split(boxes2[..., :4], 4, axis=-1)
     boxes2_rank = len(boxes2.shape)
     perm = [1, 0] if boxes2_rank == 2 else [0, 2, 1]
     # [N, M] or [batch_size, N, M]
-    intersect_ymax = tf.minimum(y_max1, tf.transpose(y_max2, perm))
-    intersect_ymin = tf.maximum(y_min1, tf.transpose(y_min2, perm))
-    intersect_xmax = tf.minimum(x_max1, tf.transpose(x_max2, perm))
-    intersect_xmin = tf.maximum(x_min1, tf.transpose(x_min2, perm))
+    intersect_ymax = ops.minimum(y_max1, ops.transpose(y_max2, perm))
+    intersect_ymin = ops.maximum(y_min1, ops.transpose(y_min2, perm))
+    intersect_xmax = ops.minimum(x_max1, ops.transpose(x_max2, perm))
+    intersect_xmin = ops.maximum(x_min1, ops.transpose(x_min2, perm))
 
     intersect_height = intersect_ymax - intersect_ymin
     intersect_width = intersect_xmax - intersect_xmin
-    zeros_t = tf.cast(0, intersect_height.dtype)
-    intersect_height = tf.maximum(zeros_t, intersect_height)
-    intersect_width = tf.maximum(zeros_t, intersect_width)
+    zeros_t = ops.cast(0, intersect_height.dtype)
+    intersect_height = ops.maximum(zeros_t, intersect_height)
+    intersect_width = ops.maximum(zeros_t, intersect_width)
 
     return intersect_height * intersect_width
 
@@ -153,10 +147,10 @@ def compute_iou(
     boxes2_area = _compute_area(boxes2)
     boxes2_area_rank = len(boxes2_area.shape)
     boxes2_axis = 1 if (boxes2_area_rank == 2) else 0
-    boxes1_area = tf.expand_dims(boxes1_area, axis=-1)
-    boxes2_area = tf.expand_dims(boxes2_area, axis=boxes2_axis)
+    boxes1_area = ops.expand_dims(boxes1_area, axis=-1)
+    boxes2_area = ops.expand_dims(boxes2_area, axis=boxes2_axis)
     union_area = boxes1_area + boxes2_area - intersect_area
-    res = tf.math.divide_no_nan(intersect_area, union_area)
+    res = ops.divide(intersect_area, union_area + keras.backend.epsilon())
 
     if boxes1_rank == 2:
         perm = [1, 0]
@@ -166,13 +160,13 @@ def compute_iou(
     if not use_masking:
         return res
 
-    mask_val_t = tf.cast(mask_val, res.dtype) * tf.ones_like(res)
-    boxes1_mask = tf.less(tf.reduce_max(boxes1, axis=-1, keepdims=True), 0.0)
-    boxes2_mask = tf.less(tf.reduce_max(boxes2, axis=-1, keepdims=True), 0.0)
-    background_mask = tf.logical_or(
-        boxes1_mask, tf.transpose(boxes2_mask, perm)
+    mask_val_t = ops.cast(mask_val, res.dtype) * ops.ones_like(res)
+    boxes1_mask = ops.less(ops.max(boxes1, axis=-1, keepdims=True), 0.0)
+    boxes2_mask = ops.less(ops.max(boxes2, axis=-1, keepdims=True), 0.0)
+    background_mask = ops.logical_or(
+        boxes1_mask, ops.transpose(boxes2_mask, perm)
     )
-    iou_lookup_table = tf.where(background_mask, mask_val_t, res)
+    iou_lookup_table = ops.where(background_mask, mask_val_t, res)
     return iou_lookup_table
 
 
@@ -188,9 +182,9 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     represent the bounding boxes.
 
     Args:
-        box1 (tf.Tensor): Tensor representing the first bounding box with
+        box1 (tensor): tensor representing the first bounding box with
             shape (..., 4).
-        box2 (tf.Tensor): Tensor representing the second bounding box with
+        box2 (tensor): tensor representing the second bounding box with
             shape (..., 4).
         bounding_box_format: a case-insensitive string (for example, "xyxy").
             Each bounding box is defined by these 4 values. For detailed
@@ -200,7 +194,7 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
             is 1e-7.
 
     Returns:
-        tf.Tensor: The CIoU distance between the two bounding boxes.
+        tensor: The CIoU distance between the two bounding boxes.
     """
     target_format = "xyxy"
     if bounding_box.is_relative(bounding_box_format):
@@ -213,17 +207,15 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     box2 = bounding_box.convert_format(
         box2, source=bounding_box_format, target=target_format
     )
-    b1_x1, b1_y1, b1_x2, b1_y2 = tf.split(box1, 4, axis=-1)
-    b2_x1, b2_y1, b2_x2, b2_y2 = tf.split(box2, 4, axis=-1)
+    b1_x1, b1_y1, b1_x2, b1_y2 = ops.split(box1, 4, axis=-1)
+    b2_x1, b2_y1, b2_x2, b2_y2 = ops.split(box2, 4, axis=-1)
     w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
     w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
 
     # Intersection area
-    inter = tf.math.maximum(
-        tf.math.minimum(b1_x2, b2_x2) - tf.math.maximum(b1_x1, b2_x1), 0
-    ) * tf.math.maximum(
-        tf.math.minimum(b1_y2, b2_y2) - tf.math.maximum(b1_y1, b2_y1), 0
-    )
+    inter = ops.maximum(
+        ops.minimum(b1_x2, b2_x2) - ops.maximum(b1_x1, b2_x1), 0
+    ) * ops.maximum(ops.minimum(b1_y2, b2_y2) - ops.maximum(b1_y1, b2_y1), 0)
 
     # Union Area
     union = w1 * h1 + w2 * h2 - inter + eps
@@ -231,18 +223,18 @@ def compute_ciou(box1, box2, bounding_box_format, eps=1e-7):
     # IoU
     iou = inter / union
 
-    cw = tf.math.maximum(b1_x2, b2_x2) - tf.math.minimum(
+    cw = ops.maximum(b1_x2, b2_x2) - ops.minimum(
         b1_x1, b2_x1
     )  # convex (smallest enclosing box) width
-    ch = tf.math.maximum(b1_y2, b2_y2) - tf.math.minimum(
-        b1_y1, b2_y1
-    )  # convex height
+    ch = ops.maximum(b1_y2, b2_y2) - ops.minimum(b1_y1, b2_y1)  # convex height
     c2 = cw**2 + ch**2 + eps  # convex diagonal squared
     rho2 = (
         (b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2
         + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2
     ) / 4  # center dist ** 2
-    v = tf.pow((4 / math.pi**2) * (tf.atan(w2 / h2) - tf.atan(w1 / h1)), 2)
+    v = ops.power(
+        (4 / math.pi**2) * (ops.arctan(w2 / h2) - ops.arctan(w1 / h1)), 2
+    )
     alpha = v / (v - iou + (1 + eps))
 
     return iou - (rho2 / c2 + v * alpha)

--- a/keras_cv/bounding_box/iou_test.py
+++ b/keras_cv/bounding_box/iou_test.py
@@ -21,8 +21,8 @@ from keras_cv.bounding_box import iou as iou_lib
 
 class IoUTest(tf.test.TestCase):
     def test_compute_single_iou(self):
-        bb1 = tf.constant([[100, 101, 200, 201]], dtype=tf.float32)
-        bb1_off_by_1 = tf.constant([[101, 102, 201, 202]], dtype=tf.float32)
+        bb1 = np.array([[100, 101, 200, 201]])
+        bb1_off_by_1 = np.array([[101, 102, 201, 202]])
         # area of bb1 and bb1_off_by_1 are each 10000.
         # intersection area is 99*99=9801
         # iou=9801/(2*10000 - 9801)=0.96097656633
@@ -44,16 +44,13 @@ class IoUTest(tf.test.TestCase):
             dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
-            [bb1, top_left_bounding_box, far_away_box], dtype=tf.float32
-        )
-        sample_y_pred = tf.constant(
+        sample_y_true = np.array([bb1, top_left_bounding_box, far_away_box])
+        sample_y_pred = np.array(
             [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_batched_compute_iou(self):
         bb1 = [100, 101, 200, 201]
@@ -69,17 +66,15 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [
                 [
                     bb1_off_by_1_pred,
@@ -92,11 +87,10 @@ class IoUTest(tf.test.TestCase):
                     another_far_away_pred,
                 ],
             ],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_batched_boxes1_unbatched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -112,23 +106,20 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [bb1_off_by_1_pred, top_left_bounding_box, another_far_away_pred],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)
 
     def test_unbatched_boxes1_batched_boxes2(self):
         bb1 = [100, 101, 200, 201]
@@ -144,16 +135,14 @@ class IoUTest(tf.test.TestCase):
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
                 [[iou_bb1_bb1_off, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
             ],
-            dtype=np.float32,
         )
 
-        sample_y_true = tf.constant(
+        sample_y_true = np.array(
             [
                 [bb1, top_left_bounding_box, far_away_box],
             ],
-            dtype=tf.float32,
         )
-        sample_y_pred = tf.constant(
+        sample_y_pred = np.array(
             [
                 [
                     bb1_off_by_1_pred,
@@ -166,8 +155,7 @@ class IoUTest(tf.test.TestCase):
                     another_far_away_pred,
                 ],
             ],
-            dtype=tf.float32,
         )
 
         result = iou_lib.compute_iou(sample_y_true, sample_y_pred, "yxyx")
-        self.assertAllClose(expected_result, result.numpy())
+        self.assertAllClose(expected_result, result)

--- a/keras_cv/bounding_box/mask_invalid_detections.py
+++ b/keras_cv/bounding_box/mask_invalid_detections.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tensorflow as tf
 
+from keras_cv import backend
+from keras_cv.backend import ops
 from keras_cv.bounding_box.to_ragged import to_ragged
 from keras_cv.bounding_box.validate_format import validate_format
 
@@ -20,11 +21,10 @@ from keras_cv.bounding_box.validate_format import validate_format
 def mask_invalid_detections(bounding_boxes, output_ragged=False):
     """masks out invalid detections with -1s.
 
-    This utility is mainly used on the output of
-    `tf.image.combined_non_max_suppression` operations. The output of
-    `tf.image.combined_non_max_suppression` contains all the detections, even
-    invalid ones. Users are expected to use `num_detections` to determine how
-    many boxes are in each image.
+    This utility is mainly used on the output of non-max supression operations.
+    The output of non-max-supression contains all the detections, even invalid
+    ones. Users are expected to use `num_detections` to determine how many boxes
+    are in each image.
 
     In contrast, KerasCV expects all bounding boxes to be padded with -1s.
     This function uses the value of `num_detections` to mask out
@@ -38,11 +38,10 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
             boxes.
     Returns:
         bounding boxes with proper masking of the boxes according to
-        `num_detections`. This allows proper interop with
-        `tf.image.combined_non_max_suppression`. Returned boxes match the
-        specification fed to the function, so if the bounding box tensor uses
-        `tf.RaggedTensor` to represent boxes the returned value will also return
-        `tf.RaggedTensor` representations.
+        `num_detections`. This allows proper interop with non-max supression.
+        Returned boxes match the specification fed to the function, so if the
+        bounding box tensor uses `tf.RaggedTensor` to represent boxes the
+        returned value will also return `tf.RaggedTensor` representations.
     """
     # ensure we are complying with KerasCV bounding box format.
     info = validate_format(bounding_boxes)
@@ -65,22 +64,21 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     num_detections = bounding_boxes.get("num_detections")
 
     # Create a mask to select only the first N boxes from each batch
-    mask = tf.repeat(
-        tf.expand_dims(tf.range(tf.shape(boxes)[1]), axis=0),
-        repeats=tf.shape(boxes)[0],
-        axis=0,
+    mask = ops.cast(
+        ops.expand_dims(ops.arange(boxes.shape[1]), axis=0),
+        num_detections.dtype,
     )
     mask = mask < num_detections[:, None]
 
-    classes = tf.where(mask, classes, -tf.ones_like(classes))
+    classes = ops.where(mask, classes, -ops.ones_like(classes))
 
     if confidence is not None:
-        confidence = tf.where(mask, confidence, -tf.ones_like(confidence))
+        confidence = ops.where(mask, confidence, -ops.ones_like(confidence))
 
     # reuse mask for boxes
-    mask = tf.expand_dims(mask, axis=-1)
-    mask = tf.repeat(mask, repeats=boxes.shape[-1], axis=-1)
-    boxes = tf.where(mask, boxes, -tf.ones_like(boxes))
+    mask = ops.expand_dims(mask, axis=-1)
+    mask = ops.repeat(mask, repeats=boxes.shape[-1], axis=-1)
+    boxes = ops.where(mask, boxes, -ops.ones_like(boxes))
 
     result = bounding_boxes.copy()
 
@@ -89,7 +87,7 @@ def mask_invalid_detections(bounding_boxes, output_ragged=False):
     if confidence is not None:
         result["confidence"] = confidence
 
-    if output_ragged:
+    if output_ragged and backend.supports_ragged():
         return to_ragged(result)
 
     return result

--- a/keras_cv/bounding_box/mask_invalid_detections_test.py
+++ b/keras_cv/bounding_box/mask_invalid_detections_test.py
@@ -12,24 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pytest
 import tensorflow as tf
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class MaskInvalidDetectionsTest(tf.test.TestCase):
     def test_correctly_masks_based_on_max_dets(self):
         bounding_boxes = {
-            "boxes": tf.random.uniform((4, 100, 4)),
-            "num_detections": tf.constant([2, 3, 4, 2]),
-            "classes": tf.random.uniform((4, 100)),
+            "boxes": ops.random.uniform((4, 100, 4)),
+            "num_detections": ops.array([2, 3, 4, 2]),
+            "classes": ops.random.uniform((4, 100)),
         }
 
         result = bounding_box.mask_invalid_detections(bounding_boxes)
 
         negative_one_boxes = result["boxes"][:, 5:, :]
         self.assertAllClose(
-            negative_one_boxes, -tf.ones_like(negative_one_boxes)
+            negative_one_boxes, -np.ones_like(negative_one_boxes)
         )
 
         preserved_boxes = result["boxes"][:, :2, :]
@@ -40,40 +43,18 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
             boxes_from_image_3, bounding_boxes["boxes"][2, :4, :]
         )
 
-    def test_correctly_masks_based_on_max_dets_in_graph(self):
-        bounding_boxes = {
-            "boxes": tf.random.uniform((4, 100, 4)),
-            "num_detections": tf.constant([2, 3, 4, 2]),
-            "classes": tf.random.uniform((4, 100)),
-        }
-
-        @tf.function()
-        def apply_mask_detections(bounding_boxes):
-            return bounding_box.mask_invalid_detections(bounding_boxes)
-
-        result = apply_mask_detections(bounding_boxes)
-
-        negative_one_boxes = result["boxes"][:, 5:, :]
-        self.assertAllClose(
-            negative_one_boxes, -tf.ones_like(negative_one_boxes)
-        )
-
-        preserved_boxes = result["boxes"][:, :2, :]
-        self.assertAllClose(preserved_boxes, bounding_boxes["boxes"][:, :2, :])
-
-        boxes_from_image_3 = result["boxes"][2, :4, :]
-        self.assertAllClose(
-            boxes_from_image_3, bounding_boxes["boxes"][2, :4, :]
-        )
-
+    @pytest.mark.tf_keras_only
     def test_ragged_outputs(self):
         bounding_boxes = {
-            "boxes": tf.stack(
-                [tf.random.uniform((10, 4)), tf.random.uniform((10, 4))]
+            "boxes": np.stack(
+                [
+                    np.random.uniform(size=(10, 4)),
+                    np.random.uniform(size=(10, 4)),
+                ]
             ),
-            "num_detections": tf.constant([2, 3]),
-            "classes": tf.stack(
-                [tf.random.uniform((10,)), tf.random.uniform((10,))]
+            "num_detections": np.array([2, 3]),
+            "classes": np.stack(
+                [np.random.uniform(size=(10,)), np.random.uniform(size=(10,))]
             ),
         }
 
@@ -84,15 +65,19 @@ class MaskInvalidDetectionsTest(tf.test.TestCase):
         self.assertEqual(result["boxes"][0].shape[0], 2)
         self.assertEqual(result["boxes"][1].shape[0], 3)
 
+    @pytest.mark.tf_keras_only
     def test_correctly_masks_confidence(self):
         bounding_boxes = {
-            "boxes": tf.stack(
-                [tf.random.uniform((10, 4)), tf.random.uniform((10, 4))]
+            "boxes": np.stack(
+                [
+                    np.random.uniform(size=(10, 4)),
+                    np.random.uniform(size=(10, 4)),
+                ]
             ),
-            "confidence": tf.random.uniform((2, 10)),
-            "num_detections": tf.constant([2, 3]),
-            "classes": tf.stack(
-                [tf.random.uniform((10,)), tf.random.uniform((10,))]
+            "confidence": np.random.uniform(size=(2, 10)),
+            "num_detections": np.array([2, 3]),
+            "classes": np.stack(
+                [np.random.uniform(size=(10,)), np.random.uniform(size=(10,))]
             ),
         }
 

--- a/keras_cv/bounding_box/to_dense.py
+++ b/keras_cv/bounding_box/to_dense.py
@@ -14,6 +14,7 @@
 import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
+from keras_cv.backend.scope import tf_data
 
 
 def _box_shape(batched, boxes_shape, max_boxes):
@@ -35,6 +36,7 @@ def _classes_shape(batched, classes_shape, max_boxes):
     return [max_boxes] + classes_shape[2:]
 
 
+@tf_data
 def to_dense(bounding_boxes, max_boxes=None, default_value=-1):
     """to_dense converts bounding boxes to Dense tensors
 

--- a/keras_cv/bounding_box/to_dense_test.py
+++ b/keras_cv/bounding_box/to_dense_test.py
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 import tensorflow as tf
 
 from keras_cv import bounding_box
 
 
 class ToDenseTest(tf.test.TestCase):
+    @pytest.mark.tf_keras_only
     def test_converts_to_dense(self):
         bounding_boxes = {
             "boxes": tf.ragged.constant(

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -14,6 +14,8 @@
 import tensorflow as tf
 
 import keras_cv.bounding_box.validate_format as validate_format
+from keras_cv import backend
+from keras_cv.backend import keras
 
 
 def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
@@ -49,6 +51,13 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
         dictionary of `tf.RaggedTensor` or 'tf.Tensor' containing the filtered
         bounding boxes.
     """
+    if backend.supports_ragged() is False:
+        raise NotImplementedError(
+            "`bounding_box.to_ragged` was called using a backend which does "
+            "not support ragged tensors. "
+            f"Current backend: {keras.backend.backend()}."
+        )
+
     info = validate_format.validate_format(bounding_boxes)
 
     if info["ragged"]:

--- a/keras_cv/bounding_box/to_ragged_test.py
+++ b/keras_cv/bounding_box/to_ragged_test.py
@@ -11,19 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
+import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import bounding_box
 
 
 class ToRaggedTest(tf.test.TestCase):
+    @pytest.mark.tf_keras_only
     def test_converts_to_ragged(self):
         bounding_boxes = {
-            "boxes": tf.constant(
+            "boxes": np.array(
                 [[[0, 0, 0, 0], [0, 0, 0, 0]], [[2, 3, 4, 5], [0, 1, 2, 3]]]
             ),
-            "classes": tf.constant([[-1, -1], [-1, 1]]),
-            "confidence": tf.constant([[0.5, 0.7], [0.23, 0.12]]),
+            "classes": np.array([[-1, -1], [-1, 1]]),
+            "confidence": np.array([[0.5, 0.7], [0.23, 0.12]]),
         }
         bounding_boxes = bounding_box.to_ragged(bounding_boxes)
 
@@ -45,16 +49,17 @@ class ToRaggedTest(tf.test.TestCase):
             ],
         )
 
+    @pytest.mark.tf_keras_only
     def test_round_trip(self):
         original = {
-            "boxes": tf.constant(
+            "boxes": np.array(
                 [
                     [[0, 0, 0, 0], [-1, -1, -1, -1]],
                     [[-1, -1, -1, -1], [-1, -1, -1, -1]],
                 ]
             ),
-            "classes": tf.constant([[1, -1], [-1, -1]]),
-            "confidence": tf.constant([[0.5, -1], [-1, -1]]),
+            "classes": np.array([[1, -1], [-1, -1]]),
+            "confidence": np.array([[0.5, -1], [-1, -1]]),
         }
         bounding_boxes = bounding_box.to_ragged(original)
         bounding_boxes = bounding_box.to_dense(bounding_boxes, max_boxes=2)
@@ -70,3 +75,19 @@ class ToRaggedTest(tf.test.TestCase):
         self.assertAllEqual(
             bounding_boxes["confidence"], original["confidence"]
         )
+
+    @pytest.mark.skipif(
+        backend.supports_ragged() is True,
+        reason="Only applies to backends which don't support raggeds",
+    )
+    def test_backend_without_raggeds_throws(self):
+        bounding_boxes = {
+            "boxes": np.array(
+                [[[0, 0, 0, 0], [0, 0, 0, 0]], [[2, 3, 4, 5], [0, 1, 2, 3]]]
+            ),
+            "classes": np.array([[-1, -1], [-1, 1]]),
+            "confidence": np.array([[0.5, 0.7], [0.23, 0.12]]),
+        }
+
+        with self.assertRaisesRegex(NotImplementedError, "support ragged"):
+            bounding_box.to_ragged(bounding_boxes)

--- a/keras_cv/bounding_box/utils.py
+++ b/keras_cv/bounding_box/utils.py
@@ -142,7 +142,8 @@ def _clip_boxes(boxes, box_format, image_shape):
         max_length = [height, width, height, width]
     else:
         image_shape = ops.cast(image_shape, dtype=boxes.dtype)
-        height, width, _ = ops.unstack(image_shape, axis=-1)
+        height = image_shape[0]
+        width = image_shape[1]
         max_length = ops.stack([height, width, height, width], axis=-1)
 
     clipped_boxes = ops.maximum(ops.minimum(boxes, max_length), 0.0)

--- a/keras_cv/bounding_box/utils_test.py
+++ b/keras_cv/bounding_box/utils_test.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
 import tensorflow as tf
 
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class BoundingBoxUtilTest(tf.test.TestCase):
@@ -22,12 +24,10 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[200, 200, 400, 400], [100, 100, 300, 300]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([0, 0], dtype=tf.float32),
+            "boxes": np.array([[200, 200, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
@@ -38,17 +38,15 @@ class BoundingBoxUtilTest(tf.test.TestCase):
             y1,
             x2,
             y2,
-        ) = tf.split(boxes, [1, 1, 1, 1], axis=1)
-        self.assertAllLessEqual([x1, x2], width)
-        self.assertAllLessEqual([y1, y2], height)
+        ) = ops.split(boxes, 4, axis=1)
+        self.assertAllLessEqual(ops.concatenate([x1, x2], axis=1), width)
+        self.assertAllLessEqual(ops.concatenate([y1, y2], axis=1), height)
         # Test relative format batched
-        image = tf.ones(shape=(1, height, width, 3))
+        image = ops.ones(shape=(1, height, width, 3))
 
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[[0.2, -1, 1.2, 0.3], [0.4, 1.5, 0.2, 0.3]]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([[0, 0]], dtype=tf.float32),
+            "boxes": np.array([[[0.2, -1, 1.2, 0.3], [0.4, 1.5, 0.2, 0.3]]]),
+            "classes": np.array([[0, 0]]),
         }
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="rel_xyxy", images=image
@@ -60,23 +58,21 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[257, 257, 400, 400], [100, 100, 300, 300]]
-            ),
-            "classes": tf.convert_to_tensor([0, 0]),
+            "boxes": np.array([[257, 257, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
 
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor([[-1, -1, -1, -1], [100, 100, 256, 256]]),
+            np.array([[-1, -1, -1, -1], [100, 100, 256, 256]]),
         ),
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_clip_to_image_filters_fully_out_bounding_boxes_negative_area(self):
@@ -84,18 +80,16 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[110, 120, 100, 100], [100, 100, 300, 300]]
-            ),
-            "classes": [0, 0],
+            "boxes": np.array([[110, 120, 100, 100], [100, 100, 300, 300]]),
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor(
+            np.array(
                 [
                     [
                         -1,
@@ -114,7 +108,7 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         )
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_clip_to_image_filters_nans(self):
@@ -122,18 +116,18 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         height = 256
         width = 256
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
+            "boxes": np.array(
                 [[0, float("NaN"), 100, 100], [100, 100, 300, 300]]
             ),
-            "classes": [0, 0],
+            "classes": np.array([0, 0]),
         }
-        image = tf.ones(shape=(height, width, 3))
+        image = ops.ones(shape=(height, width, 3))
         bounding_boxes = bounding_box.clip_to_image(
             bounding_boxes, bounding_box_format="xyxy", images=image
         )
         self.assertAllEqual(
             bounding_boxes["boxes"],
-            tf.convert_to_tensor(
+            np.array(
                 [
                     [
                         -1,
@@ -152,7 +146,7 @@ class BoundingBoxUtilTest(tf.test.TestCase):
         )
         self.assertAllEqual(
             bounding_boxes["classes"],
-            tf.convert_to_tensor([-1, 0]),
+            np.array([-1, 0]),
         )
 
     def test_is_relative_util(self):

--- a/keras_cv/callbacks/pycoco_callback_test.py
+++ b/keras_cv/callbacks/pycoco_callback_test.py
@@ -14,7 +14,6 @@
 
 import pytest
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv.callbacks import PyCOCOCallback
@@ -25,18 +24,12 @@ from keras_cv.models.object_detection.__test_utils__ import (
 
 
 class PyCOCOCallbackTest(tf.test.TestCase):
-    @pytest.fixture(autouse=True)
-    def cleanup_global_session(self):
-        # Code before yield runs before the test
-        yield
-        keras.backend.clear_session()
-
     @pytest.mark.large  # Fit is slow, so mark these large.
     def test_model_fit_retinanet(self):
         model = keras_cv.models.RetinaNet(
             num_classes=10,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet50V2Backbone(),
+            backbone=keras_cv.models.CSPDarkNetTinyBackbone(),
         )
         # all metric formats must match
         model.compile(
@@ -52,8 +45,15 @@ class PyCOCOCallbackTest(tf.test.TestCase):
             bounding_box_format="xyxy", use_dictionary_box_format=True
         )
 
+        def dict_to_tuple(inputs):
+            return inputs["images"], inputs["bounding_boxes"]
+
+        train_ds = train_ds.map(dict_to_tuple)
+        val_ds = val_ds.map(dict_to_tuple)
+
         callback = PyCOCOCallback(
-            validation_data=val_ds, bounding_box_format="xyxy"
+            validation_data=val_ds,
+            bounding_box_format="xyxy",
         )
         history = model.fit(train_ds, callbacks=[callback])
 

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -16,6 +16,8 @@ import pytest
 import tensorflow as tf
 from packaging import version
 
+from keras_cv.backend.config import multi_backend
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -40,6 +42,10 @@ def pytest_configure(config):
         "markers",
         "extra_large: mark test as being too large to run continuously",
     )
+    config.addinivalue_line(
+        "markers",
+        "tf_keras_only: mark test as a tf only test",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -58,6 +64,10 @@ def pytest_collection_modifyitems(config, items):
     skip_extra_large = pytest.mark.skipif(
         not run_extra_large_tests, reason="need --run_extra_large option to run"
     )
+    skip_tf_keras_only = pytest.mark.skipif(
+        multi_backend(),
+        reason="This test is only supported on tf.keras",
+    )
     for item in items:
         if "keras_format" in item.name:
             item.add_marker(skip_keras_saving_test)
@@ -67,3 +77,5 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_large)
         if "extra_large" in item.keywords:
             item.add_marker(skip_extra_large)
+        if "tf_keras_only" in item.keywords:
+            item.add_marker(skip_tf_keras_only)

--- a/keras_cv/layers/__init__.py
+++ b/keras_cv/layers/__init__.py
@@ -24,6 +24,9 @@ from keras_cv.layers.object_detection.box_matcher import BoxMatcher
 from keras_cv.layers.object_detection.multi_class_non_max_suppression import (
     MultiClassNonMaxSuppression,
 )
+from keras_cv.layers.object_detection.non_max_suppression import (
+    NonMaxSuppression,
+)
 from keras_cv.layers.object_detection_3d.centernet_label_encoder import (
     CenterNetLabelEncoder,
 )

--- a/keras_cv/layers/fusedmbconv.py
+++ b/keras_cv/layers/fusedmbconv.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 
-from keras import backend
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras_cv.backend import keras
 
 BN_AXIS = 3
 
@@ -29,8 +27,8 @@ CONV_KERNEL_INITIALIZER = {
 }
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class FusedMBConvBlock(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class FusedMBConvBlock(keras.layers.Layer):
     """
     Implementation of the FusedMBConv block (Fused Mobile Inverted Residual
     Bottleneck) from:
@@ -112,7 +110,7 @@ class FusedMBConvBlock(layers.Layer):
         self.filters = self.input_filters * self.expand_ratio
         self.filters_se = max(1, int(input_filters * se_ratio))
 
-        self.conv1 = layers.Conv2D(
+        self.conv1 = keras.layers.Conv2D(
             filters=self.filters,
             kernel_size=kernel_size,
             strides=strides,
@@ -122,20 +120,20 @@ class FusedMBConvBlock(layers.Layer):
             use_bias=False,
             name=self.name + "expand_conv",
         )
-        self.bn1 = layers.BatchNormalization(
+        self.bn1 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "expand_bn",
         )
-        self.act = layers.Activation(
+        self.act = keras.layers.Activation(
             self.activation, name=self.name + "expand_activation"
         )
 
-        self.bn2 = layers.BatchNormalization(
+        self.bn2 = keras.layers.BatchNormalization(
             axis=BN_AXIS, momentum=self.bn_momentum, name=self.name + "bn"
         )
 
-        self.se_conv1 = layers.Conv2D(
+        self.se_conv1 = keras.layers.Conv2D(
             self.filters_se,
             1,
             padding="same",
@@ -144,7 +142,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "se_reduce",
         )
 
-        self.se_conv2 = layers.Conv2D(
+        self.se_conv2 = keras.layers.Conv2D(
             self.filters,
             1,
             padding="same",
@@ -153,7 +151,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "se_expand",
         )
 
-        self.output_conv = layers.Conv2D(
+        self.output_conv = keras.layers.Conv2D(
             filters=self.output_filters,
             kernel_size=1 if expand_ratio != 1 else kernel_size,
             strides=1,
@@ -164,7 +162,7 @@ class FusedMBConvBlock(layers.Layer):
             name=self.name + "project_conv",
         )
 
-        self.bn3 = layers.BatchNormalization(
+        self.bn3 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "project_bn",
@@ -172,7 +170,7 @@ class FusedMBConvBlock(layers.Layer):
 
     def build(self, input_shape):
         if self.name is None:
-            self.name = backend.get_uid("block0")
+            self.name = keras.backend.get_uid("block0")
 
     def call(self, inputs):
         # Expansion phase
@@ -185,18 +183,22 @@ class FusedMBConvBlock(layers.Layer):
 
         # Squeeze and excite
         if 0 < self.se_ratio <= 1:
-            se = layers.GlobalAveragePooling2D(name=self.name + "se_squeeze")(x)
+            se = keras.layers.GlobalAveragePooling2D(
+                name=self.name + "se_squeeze"
+            )(x)
             if BN_AXIS == 1:
                 se_shape = (self.filters, 1, 1)
             else:
                 se_shape = (1, 1, self.filters)
 
-            se = layers.Reshape(se_shape, name=self.name + "se_reshape")(se)
+            se = keras.layers.Reshape(se_shape, name=self.name + "se_reshape")(
+                se
+            )
 
             se = self.se_conv1(se)
             se = self.se_conv2(se)
 
-            x = layers.multiply([x, se], name=self.name + "se_excite")
+            x = keras.layers.multiply([x, se], name=self.name + "se_excite")
 
         # Output phase:
         x = self.output_conv(x)
@@ -207,12 +209,12 @@ class FusedMBConvBlock(layers.Layer):
         # Residual:
         if self.strides == 1 and self.input_filters == self.output_filters:
             if self.survival_probability:
-                x = layers.Dropout(
+                x = keras.layers.Dropout(
                     self.survival_probability,
                     noise_shape=(None, 1, 1, 1),
                     name=self.name + "drop",
                 )(x)
-            x = layers.add([x, inputs], name=self.name + "add")
+            x = keras.layers.add([x, inputs], name=self.name + "add")
         return x
 
     def get_config(self):

--- a/keras_cv/layers/mbconv.py
+++ b/keras_cv/layers/mbconv.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 
-from keras import backend
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras_cv.backend import keras
 
 BN_AXIS = 3
 
@@ -29,8 +27,8 @@ CONV_KERNEL_INITIALIZER = {
 }
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class MBConvBlock(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class MBConvBlock(keras.layers.Layer):
     def __init__(
         self,
         input_filters: int,
@@ -110,7 +108,7 @@ class MBConvBlock(layers.Layer):
         self.filters = self.input_filters * self.expand_ratio
         self.filters_se = max(1, int(input_filters * se_ratio))
 
-        self.conv1 = layers.Conv2D(
+        self.conv1 = keras.layers.Conv2D(
             filters=self.filters,
             kernel_size=1,
             strides=1,
@@ -120,15 +118,15 @@ class MBConvBlock(layers.Layer):
             use_bias=False,
             name=self.name + "expand_conv",
         )
-        self.bn1 = layers.BatchNormalization(
+        self.bn1 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "expand_bn",
         )
-        self.act = layers.Activation(
+        self.act = keras.layers.Activation(
             self.activation, name=self.name + "activation"
         )
-        self.depthwise = layers.DepthwiseConv2D(
+        self.depthwise = keras.layers.DepthwiseConv2D(
             kernel_size=self.kernel_size,
             strides=self.strides,
             depthwise_initializer=CONV_KERNEL_INITIALIZER,
@@ -138,11 +136,11 @@ class MBConvBlock(layers.Layer):
             name=self.name + "dwconv2",
         )
 
-        self.bn2 = layers.BatchNormalization(
+        self.bn2 = keras.layers.BatchNormalization(
             axis=BN_AXIS, momentum=self.bn_momentum, name=self.name + "bn"
         )
 
-        self.se_conv1 = layers.Conv2D(
+        self.se_conv1 = keras.layers.Conv2D(
             self.filters_se,
             1,
             padding="same",
@@ -151,7 +149,7 @@ class MBConvBlock(layers.Layer):
             name=self.name + "se_reduce",
         )
 
-        self.se_conv2 = layers.Conv2D(
+        self.se_conv2 = keras.layers.Conv2D(
             self.filters,
             1,
             padding="same",
@@ -160,7 +158,7 @@ class MBConvBlock(layers.Layer):
             name=self.name + "se_expand",
         )
 
-        self.output_conv = layers.Conv2D(
+        self.output_conv = keras.layers.Conv2D(
             filters=self.output_filters,
             kernel_size=1 if expand_ratio != 1 else kernel_size,
             strides=1,
@@ -171,7 +169,7 @@ class MBConvBlock(layers.Layer):
             name=self.name + "project_conv",
         )
 
-        self.bn3 = layers.BatchNormalization(
+        self.bn3 = keras.layers.BatchNormalization(
             axis=BN_AXIS,
             momentum=self.bn_momentum,
             name=self.name + "project_bn",
@@ -179,7 +177,7 @@ class MBConvBlock(layers.Layer):
 
     def build(self, input_shape):
         if self.name is None:
-            self.name = backend.get_uid("block0")
+            self.name = keras.backend.get_uid("block0")
 
     def call(self, inputs):
         # Expansion phase
@@ -197,17 +195,21 @@ class MBConvBlock(layers.Layer):
 
         # Squeeze and excite
         if 0 < self.se_ratio <= 1:
-            se = layers.GlobalAveragePooling2D(name=self.name + "se_squeeze")(x)
+            se = keras.layers.GlobalAveragePooling2D(
+                name=self.name + "se_squeeze"
+            )(x)
             if BN_AXIS == 1:
                 se_shape = (self.filters, 1, 1)
             else:
                 se_shape = (1, 1, self.filters)
-            se = layers.Reshape(se_shape, name=self.name + "se_reshape")(se)
+            se = keras.layers.Reshape(se_shape, name=self.name + "se_reshape")(
+                se
+            )
 
             se = self.se_conv1(se)
             se = self.se_conv2(se)
 
-            x = layers.multiply([x, se], name=self.name + "se_excite")
+            x = keras.layers.multiply([x, se], name=self.name + "se_excite")
 
         # Output phase
         x = self.output_conv(x)
@@ -215,12 +217,12 @@ class MBConvBlock(layers.Layer):
 
         if self.strides == 1 and self.input_filters == self.output_filters:
             if self.survival_probability:
-                x = layers.Dropout(
+                x = keras.layers.Dropout(
                     self.survival_probability,
                     noise_shape=(None, 1, 1, 1),
                     name=self.name + "drop",
                 )(x)
-            x = layers.add([x, inputs], name=self.name + "add")
+            x = keras.layers.add([x, inputs], name=self.name + "add")
         return x
 
     def get_config(self):

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-from tensorflow import keras
+import math
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class AnchorGenerator(keras.layers.Layer):
     """AnchorGenerator generates anchors for multiple feature maps.
 
@@ -56,7 +57,7 @@ class AnchorGenerator(keras.layers.Layer):
     sizes = [32.0, 64.0, 128.0]
     aspect_ratios = [0.5, 1.0, 2.0]
 
-    image = tf.random.uniform((512, 512, 3))
+    image = np.random.uniform(size=(512, 512, 3))
     anchor_generator = cv_layers.AnchorGenerator(
         bounding_box_format="rel_yxyx",
         sizes=sizes,
@@ -150,15 +151,13 @@ class AnchorGenerator(keras.layers.Layer):
     @staticmethod
     def _match_param_structure_to_sizes(params, sizes):
         """broadcast the params to match sizes."""
-        # if isinstance(sizes, (tuple, list)):
-        #     return [params] * len(sizes)
         if not isinstance(sizes, dict):
             raise ValueError(
                 "the structure of `sizes` must be a dict, "
                 f"received sizes={sizes}"
             )
 
-        return tf.nest.map_structure(lambda _: params, sizes)
+        return {key: params for key in sizes.keys()}
 
     def __call__(self, image=None, image_shape=None):
         if image is None and image_shape is None:
@@ -167,19 +166,17 @@ class AnchorGenerator(keras.layers.Layer):
             )
 
         if image is not None:
-            if image.shape.rank != 3:
+            if len(image.shape) != 3:
                 raise ValueError(
                     "Expected `image` to be a Tensor of rank 3. Got "
-                    f"image.shape.rank={image.shape.rank}"
+                    f"image.shape.rank={len(image.shape)}"
                 )
-            image_shape = tf.shape(image)
+            image_shape = image.shape
 
-        anchor_generators = tf.nest.flatten(self.anchor_generators)
-        results = [anchor_gen(image_shape) for anchor_gen in anchor_generators]
-        results = tf.nest.pack_sequence_as(self.anchor_generators, results)
-        for key in results:
+        results = {}
+        for key, generator in self.anchor_generators.items():
             results[key] = bounding_box.convert_format(
-                results[key],
+                generator(image_shape),
                 source="yxyx",
                 target=self.bounding_box_format,
                 image_shape=image_shape,
@@ -237,12 +234,12 @@ class _SingleAnchorGenerator:
         self.dtype = dtype
 
     def __call__(self, image_size):
-        image_height = tf.cast(image_size[0], tf.float32)
-        image_width = tf.cast(image_size[1], tf.float32)
+        image_height = image_size[0]
+        image_width = image_size[1]
 
-        aspect_ratios = tf.cast(self.aspect_ratios, tf.float32)
-        aspect_ratios_sqrt = tf.cast(tf.sqrt(aspect_ratios), dtype=tf.float32)
-        anchor_size = tf.cast(self.sizes, tf.float32)
+        aspect_ratios = ops.cast(self.aspect_ratios, "float32")
+        aspect_ratios_sqrt = ops.cast(ops.sqrt(aspect_ratios), dtype="float32")
+        anchor_size = ops.cast(self.sizes, "float32")
 
         # [K]
         anchor_heights = []
@@ -253,48 +250,54 @@ class _SingleAnchorGenerator:
             anchor_width = anchor_size_t * aspect_ratios_sqrt
             anchor_heights.append(anchor_height)
             anchor_widths.append(anchor_width)
-        anchor_heights = tf.concat(anchor_heights, axis=0)
-        anchor_widths = tf.concat(anchor_widths, axis=0)
-        half_anchor_heights = tf.reshape(0.5 * anchor_heights, [1, 1, -1])
-        half_anchor_widths = tf.reshape(0.5 * anchor_widths, [1, 1, -1])
+        anchor_heights = ops.concatenate(anchor_heights, axis=0)
+        anchor_widths = ops.concatenate(anchor_widths, axis=0)
+        half_anchor_heights = ops.reshape(0.5 * anchor_heights, [1, 1, -1])
+        half_anchor_widths = ops.reshape(0.5 * anchor_widths, [1, 1, -1])
 
-        stride = tf.cast(self.stride, tf.float32)
+        stride = self.stride
         # make sure range of `cx` is within limit of `image_width` with
         # `stride`, also for sizes where `image_width % stride != 0`.
         # [W]
-        cx = tf.range(
-            0.5 * stride, tf.math.ceil(image_width / stride) * stride, stride
+        cx = ops.cast(
+            ops.arange(
+                0.5 * stride, math.ceil(image_width / stride) * stride, stride
+            ),
+            "float32",
         )
         # make sure range of `cy` is within limit of `image_height` with
         # `stride`, also for sizes where `image_height % stride != 0`.
         # [H]
-        cy = tf.range(
-            0.5 * stride, tf.math.ceil(image_height / stride) * stride, stride
+        cy = ops.cast(
+            ops.arange(
+                0.5 * stride, math.ceil(image_height / stride) * stride, stride
+            ),
+            "float32",
         )
         # [H, W]
-        cx_grid, cy_grid = tf.meshgrid(cx, cy)
+        cx_grid, cy_grid = ops.meshgrid(cx, cy)
         # [H, W, 1]
-        cx_grid = tf.expand_dims(cx_grid, axis=-1)
-        cy_grid = tf.expand_dims(cy_grid, axis=-1)
+        cx_grid = ops.expand_dims(cx_grid, axis=-1)
+        cy_grid = ops.expand_dims(cy_grid, axis=-1)
 
-        y_min = tf.reshape(cy_grid - half_anchor_heights, (-1,))
-        y_max = tf.reshape(cy_grid + half_anchor_heights, (-1,))
-        x_min = tf.reshape(cx_grid - half_anchor_widths, (-1,))
-        x_max = tf.reshape(cx_grid + half_anchor_widths, (-1,))
+        y_min = ops.reshape(cy_grid - half_anchor_heights, (-1,))
+        y_max = ops.reshape(cy_grid + half_anchor_heights, (-1,))
+        x_min = ops.reshape(cx_grid - half_anchor_widths, (-1,))
+        x_max = ops.reshape(cx_grid + half_anchor_widths, (-1,))
 
         # [H * W * K, 1]
-        y_min = tf.expand_dims(y_min, axis=-1)
-        y_max = tf.expand_dims(y_max, axis=-1)
-        x_min = tf.expand_dims(x_min, axis=-1)
-        x_max = tf.expand_dims(x_max, axis=-1)
+        y_min = ops.expand_dims(y_min, axis=-1)
+        y_max = ops.expand_dims(y_max, axis=-1)
+        x_min = ops.expand_dims(x_min, axis=-1)
+        x_max = ops.expand_dims(x_max, axis=-1)
 
         if self.clip_boxes:
-            y_min = tf.maximum(tf.minimum(y_min, image_height), 0.0)
-            y_max = tf.maximum(tf.minimum(y_max, image_height), 0.0)
-            x_min = tf.maximum(tf.minimum(x_min, image_width), 0.0)
-            x_max = tf.maximum(tf.minimum(x_max, image_width), 0.0)
+            y_min = ops.maximum(ops.minimum(y_min, image_height), 0.0)
+            y_max = ops.maximum(ops.minimum(y_max, image_height), 0.0)
+            x_min = ops.maximum(ops.minimum(x_min, image_width), 0.0)
+            x_max = ops.maximum(ops.minimum(x_max, image_width), 0.0)
 
         # [H * W * K, 4]
-        return tf.cast(
-            tf.concat([y_min, x_min, y_max, x_max], axis=-1), self.dtype
+        return ops.cast(
+            ops.concatenate([y_min, x_min, y_max, x_max], axis=-1), self.dtype
         )

--- a/keras_cv/layers/object_detection/box_matcher_test.py
+++ b/keras_cv/layers/object_detection/box_matcher_test.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
+from keras_cv.backend import ops
 from keras_cv.layers.object_detection.box_matcher import BoxMatcher
 
 
@@ -41,9 +43,7 @@ class BoxMatcherTest(tf.test.TestCase):
             )
 
     def test_box_matcher_unbatched(self):
-        sim_matrix = tf.constant(
-            [[0.04, 0, 0, 0], [0, 0, 1.0, 0]], dtype=tf.float32
-        )
+        sim_matrix = np.array([[0.04, 0, 0, 0], [0, 0, 1.0, 0]])
 
         fg_threshold = 0.5
         bg_thresh_hi = 0.2
@@ -54,18 +54,16 @@ class BoxMatcherTest(tf.test.TestCase):
             match_values=[-3, -2, -1, 1],
         )
         match_indices, matched_values = matcher(sim_matrix)
-        positive_matches = tf.greater_equal(matched_values, 0)
-        negative_matches = tf.equal(matched_values, -2)
+        positive_matches = ops.greater_equal(matched_values, 0)
+        negative_matches = ops.equal(matched_values, -2)
 
-        self.assertAllEqual(positive_matches.numpy(), [False, True])
-        self.assertAllEqual(negative_matches.numpy(), [True, False])
-        self.assertAllEqual(match_indices.numpy(), [0, 2])
-        self.assertAllEqual(matched_values.numpy(), [-2, 1])
+        self.assertAllEqual(positive_matches, [False, True])
+        self.assertAllEqual(negative_matches, [True, False])
+        self.assertAllEqual(match_indices, [0, 2])
+        self.assertAllEqual(matched_values, [-2, 1])
 
     def test_box_matcher_batched(self):
-        sim_matrix = tf.constant(
-            [[[0.04, 0, 0, 0], [0, 0, 1.0, 0]]], dtype=tf.float32
-        )
+        sim_matrix = np.array([[[0.04, 0, 0, 0], [0, 0, 1.0, 0]]])
 
         fg_threshold = 0.5
         bg_thresh_hi = 0.2
@@ -76,18 +74,17 @@ class BoxMatcherTest(tf.test.TestCase):
             match_values=[-3, -2, -1, 1],
         )
         match_indices, matched_values = matcher(sim_matrix)
-        positive_matches = tf.greater_equal(matched_values, 0)
-        negative_matches = tf.equal(matched_values, -2)
+        positive_matches = ops.greater_equal(matched_values, 0)
+        negative_matches = ops.equal(matched_values, -2)
 
-        self.assertAllEqual(positive_matches.numpy(), [[False, True]])
-        self.assertAllEqual(negative_matches.numpy(), [[True, False]])
-        self.assertAllEqual(match_indices.numpy(), [[0, 2]])
-        self.assertAllEqual(matched_values.numpy(), [[-2, 1]])
+        self.assertAllEqual(positive_matches, [[False, True]])
+        self.assertAllEqual(negative_matches, [[True, False]])
+        self.assertAllEqual(match_indices, [[0, 2]])
+        self.assertAllEqual(matched_values, [[-2, 1]])
 
     def test_box_matcher_force_match(self):
-        sim_matrix = tf.constant(
+        sim_matrix = np.array(
             [[0, 0.04, 0, 0.1], [0, 0, 1.0, 0], [0.1, 0, 0, 0], [0, 0, 0, 0.6]],
-            dtype=tf.float32,
         )
 
         fg_threshold = 0.5
@@ -100,20 +97,18 @@ class BoxMatcherTest(tf.test.TestCase):
             force_match_for_each_col=True,
         )
         match_indices, matched_values = matcher(sim_matrix)
-        positive_matches = tf.greater_equal(matched_values, 0)
-        negative_matches = tf.equal(matched_values, -2)
+        positive_matches = ops.greater_equal(matched_values, 0)
+        negative_matches = ops.equal(matched_values, -2)
 
-        self.assertAllEqual(positive_matches.numpy(), [True, True, True, True])
-        self.assertAllEqual(
-            negative_matches.numpy(), [False, False, False, False]
-        )
+        self.assertAllEqual(positive_matches, [True, True, True, True])
+        self.assertAllEqual(negative_matches, [False, False, False, False])
         # the first anchor cannot be matched to 4th gt box given that is matched
         # to the last anchor.
-        self.assertAllEqual(match_indices.numpy(), [1, 2, 0, 3])
-        self.assertAllEqual(matched_values.numpy(), [1, 1, 1, 1])
+        self.assertAllEqual(match_indices, [1, 2, 0, 3])
+        self.assertAllEqual(matched_values, [1, 1, 1, 1])
 
     def test_box_matcher_empty_gt_boxes(self):
-        sim_matrix = tf.constant([[], []], dtype=tf.float32)
+        sim_matrix = np.array([[], []])
 
         fg_threshold = 0.5
         bg_thresh_hi = 0.2
@@ -124,10 +119,10 @@ class BoxMatcherTest(tf.test.TestCase):
             match_values=[-3, -2, -1, 1],
         )
         match_indices, matched_values = matcher(sim_matrix)
-        positive_matches = tf.greater_equal(matched_values, 0)
-        ignore_matches = tf.equal(matched_values, -1)
+        positive_matches = ops.greater_equal(matched_values, 0)
+        ignore_matches = ops.equal(matched_values, -1)
 
-        self.assertAllEqual(positive_matches.numpy(), [False, False])
-        self.assertAllEqual(ignore_matches.numpy(), [True, True])
-        self.assertAllEqual(match_indices.numpy(), [0, 0])
-        self.assertAllEqual(matched_values.numpy(), [-1, -1])
+        self.assertAllEqual(positive_matches, [False, False])
+        self.assertAllEqual(ignore_matches, [True, True])
+        self.assertAllEqual(match_indices, [0, 0])
+        self.assertAllEqual(matched_values, [-1, -1])

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv import layers as cv_layers
@@ -41,6 +42,7 @@ def decode_predictions_output_shapes():
     return result
 
 
+@pytest.mark.tf_keras_only
 class NmsPredictionDecoderTest(tf.test.TestCase):
     def test_decode_predictions_output_shapes(self):
         result = decode_predictions_output_shapes()

--- a/keras_cv/layers/object_detection/non_max_suppression.py
+++ b/keras_cv/layers/object_detection/non_max_suppression.py
@@ -1,0 +1,525 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import tensorflow as tf
+
+from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend.config import multi_backend
+
+EPSILON = 1e-8
+
+
+@keras.saving.register_keras_serializable(package="keras_cv")
+class NonMaxSuppression(keras.layers.Layer):
+    """A Keras layer that decodes predictions of an object detection model.
+
+    Args:
+      bounding_box_format: The format of bounding boxes of input dataset. Refer
+        [to the keras.io docs](https://keras.io/api/keras_cv/bounding_box/formats/)
+        for more details on supported bounding box
+        formats.
+      from_logits: boolean, True means input score is logits, False means
+        confidence.
+      iou_threshold: a float value in the range [0, 1] representing the minimum
+        IoU threshold for two boxes to be considered same for suppression.
+        Defaults to 0.5.
+      confidence_threshold: a float value in the range [0, 1]. All boxes with
+        confidence below this value will be discarded, defaults to 0.5.
+      max_detections: the maximum detections to consider after nms is applied. A
+        large number may trigger significant memory overhead, defaults to 100.
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        bounding_box_format,
+        from_logits,
+        iou_threshold=0.5,
+        confidence_threshold=0.5,
+        max_detections=100,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.bounding_box_format = bounding_box_format
+        self.from_logits = from_logits
+        self.iou_threshold = iou_threshold
+        self.confidence_threshold = confidence_threshold
+        self.max_detections = max_detections
+        self.built = True
+
+    def call(
+        self, box_prediction, class_prediction, images=None, image_shape=None
+    ):
+        """Accepts images and raw predictions, and returns bounding box
+        predictions.
+
+        Args:
+            box_prediction: Dense Tensor of shape [batch, boxes, 4] in the
+                `bounding_box_format` specified in the constructor.
+            class_prediction: Dense Tensor of shape [batch, boxes, num_classes].
+        """
+        target_format = "yxyx"
+        if bounding_box.is_relative(self.bounding_box_format):
+            target_format = bounding_box.as_relative(target_format)
+
+        box_prediction = bounding_box.convert_format(
+            box_prediction,
+            source=self.bounding_box_format,
+            target=target_format,
+            images=images,
+            image_shape=image_shape,
+        )
+        if self.from_logits:
+            class_prediction = ops.sigmoid(class_prediction)
+
+        confidence_prediction = ops.max(class_prediction, axis=-1)
+
+        # TODO(tirthasheshpatel): Use backend-specific op where available
+        if multi_backend():
+            idx, valid_det = non_max_suppression(
+                box_prediction,
+                confidence_prediction,
+                max_output_size=self.max_detections,
+                iou_threshold=self.iou_threshold,
+                score_threshold=self.confidence_threshold,
+            )
+        else:
+            # For non-multibackend, our NMS fails during graph tracing due to
+            # the lack of a defined batch size, so we just fall back to the
+            # original implementation that this is ported from.
+            idx, valid_det = tf.image.non_max_suppression_padded(
+                box_prediction,
+                confidence_prediction,
+                max_output_size=self.max_detections,
+                iou_threshold=self.iou_threshold,
+                score_threshold=self.confidence_threshold,
+                pad_to_max_output_size=True,
+                sorted_input=False,
+            )
+
+        box_prediction = ops.take_along_axis(
+            box_prediction, ops.expand_dims(idx, axis=-1), axis=1
+        )
+        box_prediction = ops.reshape(
+            box_prediction, (-1, self.max_detections, 4)
+        )
+        confidence_prediction = ops.take_along_axis(
+            confidence_prediction, idx, axis=1
+        )
+        class_prediction = ops.take_along_axis(
+            class_prediction, ops.expand_dims(idx, axis=-1), axis=1
+        )
+
+        box_prediction = bounding_box.convert_format(
+            box_prediction,
+            source=target_format,
+            target=self.bounding_box_format,
+            images=images,
+            image_shape=image_shape,
+        )
+        bounding_boxes = {
+            "boxes": box_prediction,
+            "confidence": confidence_prediction,
+            "classes": ops.argmax(class_prediction, axis=-1),
+            "num_detections": valid_det,
+        }
+
+        # this is required to comply with KerasCV bounding box format.
+        return bounding_box.mask_invalid_detections(
+            bounding_boxes, output_ragged=False
+        )
+
+    def get_config(self):
+        config = {
+            "bounding_box_format": self.bounding_box_format,
+            "from_logits": self.from_logits,
+            "iou_threshold": self.iou_threshold,
+            "confidence_threshold": self.confidence_threshold,
+            "max_detections": self.max_detections,
+        }
+        base_config = super().get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+def non_max_suppression(
+    boxes,
+    scores,
+    max_output_size,
+    iou_threshold=0.5,
+    score_threshold=0.0,
+    tile_size=512,
+):
+    # Box format must be yxyx
+    """Non-maximum suppression.
+    Ported from https://github.com/tensorflow/tensorflow/blob/v2.12.0/tensorflow/python/ops/image_ops_impl.py#L5368-L5458
+
+    Args:
+      boxes: a tensor of rank 2 or higher with a shape of [..., num_boxes, 4].
+        Dimensions except the last two are batch dimensions. The last dimension
+        represents box coordinates in yxyx format.
+      scores: a tensor of rank 1 or higher with a shape of [..., num_boxes].
+      max_output_size: a scalar integer tensor representing the maximum number
+        of boxes to be selected by non max suppression.
+      iou_threshold: a float representing the threshold for deciding whether boxes
+        overlap too much with respect to IoU (intersection over union).
+      score_threshold: a float representing the threshold for box scores. Boxes
+        with a score that is not larger than this threshold will be suppressed.
+      tile_size: an integer representing the number of boxes in a tile, i.e.,
+        the maximum number of boxes per image that can be used to suppress other
+        boxes in parallel; larger tile_size means larger parallelism and
+        potentially more redundant work.
+
+    Returns:
+      idx: a tensor with a shape of [..., num_boxes] representing the
+        indices selected by non-max suppression. The leading dimensions
+        are the batch dimensions of the input boxes. All numbers are within
+        [0, num_boxes). For each image (i.e., idx[i]), only the first num_valid[i]
+        indices (i.e., idx[i][:num_valid[i]]) are valid.
+      num_valid: a tensor of rank 0 or higher with a shape of [...]
+        representing the number of valid indices in idx. Its dimensions are the
+        batch dimensions of the input boxes.
+    """  # noqa: E501
+
+    def _sort_scores_and_boxes(scores, boxes):
+        """Sort boxes based their score from highest to lowest.
+
+        Args:
+          scores: a tensor with a shape of [batch_size, num_boxes] representing
+            the scores of boxes.
+          boxes: a tensor with a shape of [batch_size, num_boxes, 4] representing
+            the boxes.
+
+        Returns:
+          sorted_scores: a tensor with a shape of [batch_size, num_boxes]
+            representing the sorted scores.
+          sorted_boxes: a tensor representing the sorted boxes.
+          sorted_scores_indices: a tensor with a shape of [batch_size, num_boxes]
+            representing the index of the scores in a sorted descending order.
+        """  # noqa: E501
+        with ops.name_scope("sort_scores_and_boxes"):
+            sorted_scores_indices = ops.flip(
+                ops.cast(ops.argsort(scores, axis=1), "int32"), axis=1
+            )
+            sorted_scores = ops.take_along_axis(
+                scores,
+                sorted_scores_indices,
+                axis=1,
+            )
+            sorted_boxes = ops.take_along_axis(
+                boxes,
+                ops.expand_dims(sorted_scores_indices, axis=-1),
+                axis=1,
+            )
+        return sorted_scores, sorted_boxes, sorted_scores_indices
+
+    batch_dims = ops.shape(boxes)[:-2]
+    num_boxes = boxes.shape[-2]
+    boxes = ops.reshape(boxes, [-1, num_boxes, 4])
+    scores = ops.reshape(scores, [-1, num_boxes])
+    batch_size = boxes.shape[0]
+    if score_threshold != float("-inf"):
+        with ops.name_scope("filter_by_score"):
+            score_mask = ops.cast(scores > score_threshold, scores.dtype)
+            scores *= score_mask
+            box_mask = ops.expand_dims(ops.cast(score_mask, boxes.dtype), 2)
+            boxes *= box_mask
+
+    scores, boxes, sorted_indices = _sort_scores_and_boxes(scores, boxes)
+
+    pad = (
+        math.ceil(max(num_boxes, max_output_size) / tile_size) * tile_size
+        - num_boxes
+    )
+    boxes = ops.pad(ops.cast(boxes, "float32"), [[0, 0], [0, pad], [0, 0]])
+    scores = ops.pad(ops.cast(scores, "float32"), [[0, 0], [0, pad]])
+    num_boxes_after_padding = num_boxes + pad
+    num_iterations = num_boxes_after_padding // tile_size
+
+    def _loop_cond(unused_boxes, unused_threshold, output_size, idx):
+        return ops.logical_and(
+            ops.min(output_size) < ops.cast(max_output_size, "int32"),
+            ops.cast(idx, "int32") < num_iterations,
+        )
+
+    def suppression_loop_body(boxes, iou_threshold, output_size, idx):
+        return _suppression_loop_body(
+            boxes, iou_threshold, output_size, idx, tile_size
+        )
+
+    selected_boxes, _, output_size, _ = ops.while_loop(
+        _loop_cond,
+        suppression_loop_body,
+        [
+            boxes,
+            iou_threshold,
+            ops.zeros([batch_size], "int32"),
+            ops.array(0),
+        ],
+    )
+    num_valid = ops.minimum(output_size, max_output_size)
+    idx = num_boxes_after_padding - ops.cast(
+        ops.top_k(
+            ops.cast(ops.any(selected_boxes > 0, [2]), "int32")
+            * ops.cast(
+                ops.expand_dims(ops.arange(num_boxes_after_padding, 0, -1), 0),
+                "int32",
+            ),
+            max_output_size,
+        )[0],
+        "int32",
+    )
+    idx = ops.minimum(idx, num_boxes - 1)
+
+    index_offsets = ops.cast(ops.arange(batch_size) * num_boxes, "int32")
+    take_along_axis_idx = ops.reshape(
+        idx + ops.expand_dims(index_offsets, 1), [-1]
+    )
+
+    # TODO(ianstenbit): Fix bug in tfnp.take_along_axis that causes this hack.
+    # (This will be removed anyway when we use built-in NMS for TF.)
+    if multi_backend() and keras.backend.backend() != "tensorflow":
+        idx = ops.take_along_axis(
+            ops.reshape(sorted_indices, [-1]), take_along_axis_idx
+        )
+    else:
+        import tensorflow as tf
+
+        idx = tf.gather(ops.reshape(sorted_indices, [-1]), take_along_axis_idx)
+    idx = ops.reshape(idx, [batch_size, -1])
+
+    invalid_index = ops.zeros([batch_size, max_output_size], dtype="int32")
+    idx_index = ops.cast(
+        ops.expand_dims(ops.arange(max_output_size), 0), "int32"
+    )
+    num_valid_expanded = ops.expand_dims(num_valid, 1)
+    idx = ops.where(idx_index < num_valid_expanded, idx, invalid_index)
+
+    num_valid = ops.reshape(num_valid, batch_dims)
+    return idx, num_valid
+
+
+def _bbox_overlap(boxes_a, boxes_b):
+    """Calculates the overlap (iou - intersection over union) between boxes_a and boxes_b.
+
+    Args:
+      boxes_a: a tensor with a shape of [batch_size, N, 4]. N is the number of
+        boxes per image. The last dimension is the pixel coordinates in
+        [ymin, xmin, ymax, xmax] form.
+      boxes_b: a tensor with a shape of [batch_size, M, 4]. M is the number of
+        boxes. The last dimension is the pixel coordinates in
+        [ymin, xmin, ymax, xmax] form.
+
+    Returns:
+      intersection_over_union: a tensor with as a shape of [batch_size, N, M],
+      representing the ratio of intersection area over union area (IoU) between
+      two boxes
+    """  # noqa: E501
+    with ops.name_scope("bbox_overlap"):
+        if len(boxes_a.shape) == 4:
+            boxes_a = ops.squeeze(boxes_a, axis=0)
+        a_y_min, a_x_min, a_y_max, a_x_max = ops.split(boxes_a, 4, axis=2)
+        b_y_min, b_x_min, b_y_max, b_x_max = ops.split(boxes_b, 4, axis=2)
+
+        # Calculates the intersection area.
+        i_xmin = ops.maximum(a_x_min, ops.transpose(b_x_min, [0, 2, 1]))
+        i_xmax = ops.minimum(a_x_max, ops.transpose(b_x_max, [0, 2, 1]))
+        i_ymin = ops.maximum(a_y_min, ops.transpose(b_y_min, [0, 2, 1]))
+        i_ymax = ops.minimum(a_y_max, ops.transpose(b_y_max, [0, 2, 1]))
+        i_area = ops.maximum((i_xmax - i_xmin), 0) * ops.maximum(
+            (i_ymax - i_ymin), 0
+        )
+
+        # Calculates the union area.
+        a_area = (a_y_max - a_y_min) * (a_x_max - a_x_min)
+        b_area = (b_y_max - b_y_min) * (b_x_max - b_x_min)
+
+        # Adds a small epsilon to avoid divide-by-zero.
+        u_area = a_area + ops.transpose(b_area, [0, 2, 1]) - i_area + EPSILON
+
+        intersection_over_union = i_area / u_area
+
+        return intersection_over_union
+
+
+def _self_suppression(iou, _, iou_sum, iou_threshold):
+    """Suppress boxes in the same tile.
+
+    Compute boxes that cannot be suppressed by others (i.e.,
+    can_suppress_others), and then use them to suppress boxes in the same tile.
+
+    Args:
+      iou: a tensor of shape [batch_size, num_boxes_with_padding] representing
+      intersection over union.
+      iou_sum: a scalar tensor.
+      iou_threshold: a scalar tensor.
+
+    Returns:
+      iou_suppressed: a tensor of shape [batch_size, num_boxes_with_padding].
+      iou_diff: a scalar tensor representing whether any box is supressed in
+        this step.
+      iou_sum_new: a scalar tensor of shape [batch_size] that represents
+        the iou sum after suppression.
+      iou_threshold: a scalar tensor.
+    """  # noqa: E501
+    batch_size = ops.shape(iou)[0]
+    can_suppress_others = ops.cast(
+        ops.reshape(ops.max(iou, 1) < iou_threshold, [batch_size, -1, 1]),
+        iou.dtype,
+    )
+    iou_after_suppression = (
+        ops.reshape(
+            ops.cast(
+                ops.max(can_suppress_others * iou, 1) < iou_threshold, iou.dtype
+            ),
+            [batch_size, -1, 1],
+        )
+        * iou
+    )
+    iou_sum_new = ops.sum(iou_after_suppression, [1, 2])
+    return [
+        iou_after_suppression,
+        ops.any(iou_sum - iou_sum_new > iou_threshold),
+        iou_sum_new,
+        iou_threshold,
+    ]
+
+
+def _cross_suppression(boxes, box_slice, iou_threshold, inner_idx, tile_size):
+    """Suppress boxes between different tiles.
+
+    Args:
+      boxes: a tensor of shape [batch_size, num_boxes_with_padding, 4]
+      box_slice: a tensor of shape [batch_size, tile_size, 4]
+      iou_threshold: a scalar tensor
+      inner_idx: a scalar tensor representing the tile index of the tile
+        that is used to supress box_slice
+      tile_size: an integer representing the number of boxes in a tile
+
+    Returns:
+      boxes: unchanged boxes as input
+      box_slice_after_suppression: box_slice after suppression
+      iou_threshold: unchanged
+    """
+    slice_index = ops.expand_dims(
+        ops.expand_dims(
+            ops.cast(
+                ops.linspace(
+                    inner_idx * tile_size,
+                    (inner_idx + 1) * tile_size - 1,
+                    tile_size,
+                ),
+                "int32",
+            ),
+            axis=0,
+        ),
+        axis=-1,
+    )
+    new_slice = ops.expand_dims(
+        ops.take_along_axis(boxes, slice_index, axis=1), 0
+    )
+    iou = _bbox_overlap(new_slice, box_slice)
+    box_slice_after_suppression = (
+        ops.expand_dims(
+            ops.cast(ops.all(iou < iou_threshold, [1]), box_slice.dtype), 2
+        )
+        * box_slice
+    )
+    return boxes, box_slice_after_suppression, iou_threshold, inner_idx + 1
+
+
+def _suppression_loop_body(boxes, iou_threshold, output_size, idx, tile_size):
+    """Process boxes in the range [idx*tile_size, (idx+1)*tile_size).
+
+    Args:
+      boxes: a tensor with a shape of [batch_size, anchors, 4].
+      iou_threshold: a float representing the threshold for deciding whether boxes
+        overlap too much with respect to IOU.
+      output_size: an int32 tensor of size [batch_size]. Representing the number
+        of selected boxes for each batch.
+      idx: an integer scalar representing induction variable.
+      tile_size: an integer representing the number of boxes in a tile
+
+    Returns:
+      boxes: updated boxes.
+      iou_threshold: pass down iou_threshold to the next iteration.
+      output_size: the updated output_size.
+      idx: the updated induction variable.
+    """  # noqa: E501
+    with ops.name_scope("suppression_loop_body"):
+        num_tiles = boxes.shape[1] // tile_size
+        batch_size = boxes.shape[0]
+
+        def cross_suppression_func(boxes, box_slice, iou_threshold, inner_idx):
+            return _cross_suppression(
+                boxes, box_slice, iou_threshold, inner_idx, tile_size
+            )
+
+        # Iterates over tiles that can possibly suppress the current tile.
+        slice_index = ops.expand_dims(
+            ops.expand_dims(
+                ops.cast(
+                    ops.linspace(
+                        idx * tile_size, (idx + 1) * tile_size - 1, tile_size
+                    ),
+                    "int32",
+                ),
+                axis=0,
+            ),
+            axis=-1,
+        )
+        box_slice = ops.take_along_axis(boxes, slice_index, axis=1)
+        _, box_slice, _, _ = ops.while_loop(
+            lambda _boxes, _box_slice, _threshold, inner_idx: inner_idx < idx,
+            cross_suppression_func,
+            [boxes, box_slice, iou_threshold, ops.array(0)],
+        )
+
+        # Iterates over the current tile to compute self-suppression.
+        iou = _bbox_overlap(box_slice, box_slice)
+        mask = ops.expand_dims(
+            ops.reshape(ops.arange(tile_size), [1, -1])
+            > ops.reshape(ops.arange(tile_size), [-1, 1]),
+            0,
+        )
+        iou *= ops.cast(ops.logical_and(mask, iou >= iou_threshold), iou.dtype)
+        suppressed_iou, _, _, _ = ops.while_loop(
+            lambda _iou, loop_condition, _iou_sum, _: loop_condition,
+            _self_suppression,
+            [iou, ops.array(True), ops.sum(iou, [1, 2]), iou_threshold],
+        )
+        suppressed_box = ops.sum(suppressed_iou, 1) > 0
+        box_slice *= ops.expand_dims(
+            1.0 - ops.cast(suppressed_box, box_slice.dtype), 2
+        )
+
+        # Uses box_slice to update the input boxes.
+        mask = ops.reshape(
+            ops.cast(ops.equal(ops.arange(num_tiles), idx), boxes.dtype),
+            [1, -1, 1, 1],
+        )
+        boxes = ops.tile(
+            ops.expand_dims(box_slice, 1), [1, num_tiles, 1, 1]
+        ) * mask + ops.reshape(boxes, [batch_size, num_tiles, tile_size, 4]) * (
+            1 - mask
+        )
+        boxes = ops.reshape(boxes, [batch_size, -1, 4])
+
+        # Updates output_size.
+        output_size += ops.cast(
+            ops.sum(ops.any(box_slice > 0, [2]), [1]), "int32"
+        )
+    return boxes, iou_threshold, output_size, idx + 1

--- a/keras_cv/layers/object_detection/non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/non_max_suppression_test.py
@@ -1,0 +1,72 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import tensorflow as tf
+
+from keras_cv import layers
+from keras_cv.backend import ops
+
+
+class NonMaxSupressionTest(tf.test.TestCase):
+    def test_confidence_threshold(self):
+        boxes = np.random.uniform(low=0, high=1, size=(2, 5, 4))
+        classes = ops.expand_dims(
+            np.array(
+                [[0.1, 0.1, 0.4, 0.9, 0.5], [0.7, 0.5, 0.3, 0.0, 0.0]],
+                "float32",
+            ),
+            axis=-1,
+        )
+
+        nms = layers.NonMaxSuppression(
+            bounding_box_format="yxyx",
+            from_logits=False,
+            iou_threshold=1.0,
+            confidence_threshold=0.45,
+            max_detections=2,
+        )
+
+        outputs = nms(boxes, classes)
+
+        self.assertAllClose(
+            outputs["boxes"], [boxes[0][-2:, ...], boxes[1][:2, ...]]
+        )
+        self.assertAllClose(outputs["classes"], [[0.0, 0.0], [0.0, 0.0]])
+        self.assertAllClose(outputs["confidence"], [[0.9, 0.5], [0.7, 0.5]])
+
+    def test_max_detections(self):
+        boxes = np.random.uniform(low=0, high=1, size=(2, 5, 4))
+        classes = ops.expand_dims(
+            np.array(
+                [[0.1, 0.1, 0.4, 0.5, 0.9], [0.7, 0.5, 0.3, 0.0, 0.0]],
+                "float32",
+            ),
+            axis=-1,
+        )
+
+        nms = layers.NonMaxSuppression(
+            bounding_box_format="yxyx",
+            from_logits=False,
+            iou_threshold=1.0,
+            confidence_threshold=0.1,
+            max_detections=1,
+        )
+
+        outputs = nms(boxes, classes)
+
+        self.assertAllClose(
+            outputs["boxes"], [boxes[0][-1:, ...], boxes[1][:1, ...]]
+        )
+        self.assertAllClose(outputs["classes"], [[0.0], [0.0]])
+        self.assertAllClose(outputs["confidence"], [[0.9], [0.7]])

--- a/keras_cv/layers/object_detection/roi_align.py
+++ b/keras_cv/layers/object_detection/roi_align.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import assert_tf_keras
 
 
 def _feature_bilinear_interpolation(
@@ -394,6 +395,7 @@ class _ROIAligner(keras.layers.Layer):
           sample_offset: A `float` in [0, 1] of the subpixel sample offset.
           **kwargs: Additional keyword arguments passed to Layer.
         """
+        assert_tf_keras("keras_cv.layers._ROIAligner")
         self._config_dict = {
             "bounding_box_format": bounding_box_format,
             "crop_size": target_size,

--- a/keras_cv/layers/object_detection/roi_generator.py
+++ b/keras_cv/layers/object_detection/roi_generator.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import assert_tf_keras
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
@@ -95,6 +96,7 @@ class ROIGenerator(keras.layers.Layer):
         post_nms_topk_test: int = 1000,
         **kwargs,
     ):
+        assert_tf_keras("keras_cv.layers.ROIGenerator")
         super().__init__(**kwargs)
         self.bounding_box_format = bounding_box_format
         self.pre_nms_topk_train = pre_nms_topk_train

--- a/keras_cv/layers/object_detection/roi_generator_test.py
+++ b/keras_cv/layers/object_detection/roi_generator_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv.layers.object_detection.roi_generator import ROIGenerator
 
 
+@pytest.mark.tf_keras_only
 class ROIGeneratorTest(tf.test.TestCase):
     def test_single_tensor(self):
         roi_generator = ROIGenerator("xyxy", nms_iou_threshold_train=0.96)

--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import assert_tf_keras
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
@@ -57,6 +58,7 @@ class ROIPooler(keras.layers.Layer):
         image_shape,
         **kwargs,
     ):
+        assert_tf_keras("keras_cv.layers.ROIPooler")
         if not isinstance(target_size, (tuple, list)):
             raise ValueError(
                 "Expected `target_size` to be tuple or list, got "

--- a/keras_cv/layers/object_detection/roi_pool_test.py
+++ b/keras_cv/layers/object_detection/roi_pool_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv.layers.object_detection.roi_pool import ROIPooler
 
 
+@pytest.mark.tf_keras_only
 class ROIPoolTest(tf.test.TestCase):
     def test_no_quantize(self):
         roi_pooler = ROIPooler(

--- a/keras_cv/layers/object_detection/roi_sampler.py
+++ b/keras_cv/layers/object_detection/roi_sampler.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import assert_tf_keras
 from keras_cv.bounding_box import iou
 from keras_cv.layers.object_detection import box_matcher
 from keras_cv.layers.object_detection import sampling
@@ -68,6 +69,7 @@ class _ROISampler(keras.layers.Layer):
         append_gt_boxes: bool = True,
         **kwargs,
     ):
+        assert_tf_keras("keras_cv.layers._ROISampler")
         super().__init__(**kwargs)
         self.bounding_box_format = bounding_box_format
         self.roi_matcher = roi_matcher

--- a/keras_cv/layers/object_detection/roi_sampler_test.py
+++ b/keras_cv/layers/object_detection/roi_sampler_test.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv.layers.object_detection.box_matcher import BoxMatcher
 from keras_cv.layers.object_detection.roi_sampler import _ROISampler
 
 
+@pytest.mark.tf_keras_only
 class ROISamplerTest(tf.test.TestCase):
     def test_roi_sampler(self):
         box_matcher = BoxMatcher(thresholds=[0.3], match_values=[-1, 1])

--- a/keras_cv/layers/object_detection/rpn_label_encoder.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import assert_tf_keras
 from keras_cv.bounding_box import iou
 from keras_cv.layers.object_detection import box_matcher
 from keras_cv.layers.object_detection import sampling
@@ -72,6 +73,7 @@ class _RpnLabelEncoder(keras.layers.Layer):
         box_variance=[0.1, 0.1, 0.2, 0.2],
         **kwargs,
     ):
+        assert_tf_keras("keras_cv.layers._RpnLabelEncoder")
         super().__init__(**kwargs)
         self.anchor_format = anchor_format
         self.ground_truth_box_format = ground_truth_box_format

--- a/keras_cv/layers/object_detection/rpn_label_encoder_test.py
+++ b/keras_cv/layers/object_detection/rpn_label_encoder_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv.layers.object_detection.rpn_label_encoder import _RpnLabelEncoder
 
 
+@pytest.mark.tf_keras_only
 class RpnLabelEncoderTest(tf.test.TestCase):
     def test_rpn_label_encoder(self):
         rpn_encoder = _RpnLabelEncoder(

--- a/keras_cv/layers/object_detection/sampling_test.py
+++ b/keras_cv/layers/object_detection/sampling_test.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 
 from keras_cv.layers.object_detection.sampling import balanced_sample
 
 
+@pytest.mark.tf_keras_only
 class BalancedSamplingTest(tf.test.TestCase):
     def test_balanced_sampling(self):
         positive_matches = tf.constant(

--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class AugMix(BaseImageAugmentationLayer):
     """Performs the AugMix data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from keras import backend as keras_backend
+from keras.src import backend as keras_backend
 
 from keras_cv import bounding_box
 from keras_cv.backend import keras

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
+from keras_cv.backend.config import multi_backend
 from keras_cv.utils import preprocessing
 
 # In order to support both unbatched and batched inputs, the horizontal
@@ -33,8 +36,15 @@ IS_DICT = "is_dict"
 USE_TARGETS = "use_targets"
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
+base_class = (
+    keras.src.layers.preprocessing.tf_data_layer.TFDataLayer
+    if multi_backend()
+    else keras.layers.Layer
+)
+
+
+@keras.saving.register_keras_serializable(package="keras_cv")
+class BaseImageAugmentationLayer(base_class):
     """Abstract base layer for image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -114,7 +124,12 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
+        self._convert_input_args = False
 
     @property
     def force_output_ragged_images(self):
@@ -391,19 +406,23 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         return None
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3:
-            return self._format_output(self._augment(inputs), metadata)
-        elif images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3:
+                outputs = self._format_output(self._augment(inputs), metadata)
+            elif images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _augment(self, inputs):
         raw_image = inputs.get(IMAGES, None)
@@ -498,7 +517,7 @@ class BaseImageAugmentationLayer(keras.__internal__.layers.BaseRandomLayer):
         if not isinstance(inputs, dict):
             raise ValueError(
                 "Expect the inputs to be image tensor or dict. Got "
-                f"inputs={inputs}"
+                f"inputs={inputs} of type {type(inputs)}"
             )
 
         if BOUNDING_BOXES in inputs:

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -126,8 +126,8 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = RandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(8, 8, 3)).astype("float32")
-        filenames = tf.constant("/path/to/first.jpg")
-        inputs = {"images": images, "filenames": filenames}
+        image_timestamp = np.array(123123123)
+        inputs = {"images": images, "image_timestamp": image_timestamp}
         _ = add_layer(inputs)
 
     def test_augment_ragged_images(self):
@@ -203,32 +203,6 @@ class BaseImageAugmentationLayerTest(tf.test.TestCase):
         )
 
         output = add_layer(
-            {
-                "images": images,
-                "bounding_boxes": bounding_boxes,
-                "keypoints": keypoints,
-                "segmentation_masks": segmentation_masks,
-            }
-        )
-
-        bounding_boxes_diff = (
-            output["bounding_boxes"]["boxes"] - bounding_boxes["boxes"]
-        )
-        keypoints_diff = output["keypoints"] - keypoints
-        segmentation_mask_diff = (
-            output["segmentation_masks"] - segmentation_masks
-        )
-        self.assertNotAllClose(bounding_boxes_diff[0], bounding_boxes_diff[1])
-        self.assertNotAllClose(keypoints_diff[0], keypoints_diff[1])
-        self.assertNotAllClose(
-            segmentation_mask_diff[0], segmentation_mask_diff[1]
-        )
-
-        @tf.function
-        def in_tf_function(inputs):
-            return add_layer(inputs)
-
-        output = in_tf_function(
             {
                 "images": images,
                 "bounding_boxes": bounding_boxes,

--- a/keras_cv/layers/preprocessing/cut_mix.py
+++ b/keras_cv/layers/preprocessing/cut_mix.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import fill_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class CutMix(BaseImageAugmentationLayer):
     """CutMix implements the CutMix data augmentation technique.
 
@@ -127,7 +127,12 @@ class CutMix(BaseImageAugmentationLayer):
             tf.gather(images, permutation_order),
         )
 
-        return images, labels, lambda_sample, permutation_order
+        return (
+            images,
+            tf.cast(labels, dtype=self.compute_dtype),
+            lambda_sample,
+            permutation_order,
+        )
 
     def _update_labels(self, images, labels, lambda_sample, permutation_order):
         cutout_labels = tf.gather(labels, permutation_order)

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Equalization(BaseImageAugmentationLayer):
     """Equalization performs histogram equalization on a channel-wise basis.
 

--- a/keras_cv/layers/preprocessing/equalization_test.py
+++ b/keras_cv/layers/preprocessing/equalization_test.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.equalization import Equalization
 
 
@@ -28,13 +29,14 @@ class EqualizationTest(tf.test.TestCase, parameterized.TestCase):
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertAllEqual(xs, 255 * tf.ones((2, 512, 512, 3)))
 
+    @pytest.mark.tf_keras_only
     def test_return_shapes_inside_model(self):
         layer = Equalization(value_range=(0, 255))
         inp = keras.layers.Input(shape=[512, 512, 5])
         out = layer(inp)
         model = keras.models.Model(inp, out)
 
-        self.assertEqual(model.layers[-1].output_shape, (None, 512, 512, 5))
+        self.assertEqual(model.output_shape, (None, 512, 512, 5))
 
     def test_equalizes_to_all_bins(self):
         xs = tf.random.uniform((2, 512, 512, 3), 0, 255, dtype=tf.float32)

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class FourierMix(BaseImageAugmentationLayer):
     """FourierMix implements the FMix data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Grayscale(VectorizedBaseImageAugmentationLayer):
     """Grayscale is a preprocessing layer that transforms RGB images to
     Grayscale images.

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -34,7 +33,7 @@ def _center_crop(mask, width, height):
     return tf.image.crop_to_bounding_box(mask, h_start, w_start, height, width)
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class GridMask(BaseImageAugmentationLayer):
     """GridMask class for grid-mask augmentation.
 
@@ -118,7 +117,7 @@ class GridMask(BaseImageAugmentationLayer):
         self.fill_mode = fill_mode
         self.fill_value = fill_value
         self.rotation_factor = rotation_factor
-        self.random_rotate = layers.RandomRotation(
+        self.random_rotate = keras.layers.RandomRotation(
             factor=rotation_factor,
             fill_mode="constant",
             fill_value=0.0,

--- a/keras_cv/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/layers/preprocessing/jittered_resize.py
@@ -17,9 +17,9 @@
 # https://github.com/tensorflow/models/blob/master/official/vision/ops/preprocess_ops.py
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -29,7 +29,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class JitteredResize(VectorizedBaseImageAugmentationLayer):
     """JitteredResize implements resize with scale distortion.
 

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class MixUp(BaseImageAugmentationLayer):
     """MixUp implements the MixUp data augmentation technique.
 
@@ -73,7 +73,9 @@ class MixUp(BaseImageAugmentationLayer):
         images, lambda_sample, permutation_order = self._mixup(images)
         if labels is not None:
             labels = self._update_labels(
-                labels, lambda_sample, permutation_order
+                tf.cast(labels, dtype=self.compute_dtype),
+                lambda_sample,
+                permutation_order,
             )
             inputs["labels"] = labels
         if bounding_boxes is not None:

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     BATCHED,
 )
@@ -34,7 +34,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Mosaic(VectorizedBaseImageAugmentationLayer):
     """Mosaic implements the mosaic data augmentation technique.
 

--- a/keras_cv/layers/preprocessing/mosaic_test.py
+++ b/keras_cv/layers/preprocessing/mosaic_test.py
@@ -96,16 +96,6 @@ class MosaicTest(tf.test.TestCase):
         ):
             _ = layer(inputs)
 
-    def test_int_labels(self):
-        xs = tf.ones((2, 512, 512, 3))
-        ys = tf.one_hot(tf.constant([1, 0]), 2, dtype=tf.int32)
-        inputs = {"images": xs, "labels": ys}
-        layer = Mosaic()
-        with self.assertRaisesRegexp(
-            ValueError, "Mosaic received labels with type"
-        ):
-            _ = layer(inputs)
-
     def test_image_input(self):
         xs = tf.ones((2, 512, 512, 3))
         layer = Mosaic()

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils.preprocessing import transform_value_range
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Posterization(BaseImageAugmentationLayer):
     """Reduces the number of bits for each color channel.
 

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing as cv_preprocessing
 from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
     RandomAugmentationPipeline,
@@ -22,7 +21,7 @@ from keras_cv.layers.preprocessing.random_augmentation_pipeline import (
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandAugment(RandomAugmentationPipeline):
     """RandAugment performs the Rand Augment operation on input images.
 

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomApply(BaseImageAugmentationLayer):
     """Apply provided layer to random elements in a batch.
 
@@ -110,6 +109,7 @@ class RandomApply(BaseImageAugmentationLayer):
         self.auto_vectorize = auto_vectorize
         self.batchwise = batchwise
         self.seed = seed
+        self.built = True
 
     def _should_augment(self):
         return (

--- a/keras_cv/layers/preprocessing/random_apply_test.py
+++ b/keras_cv/layers/preprocessing/random_apply_test.py
@@ -14,9 +14,9 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )

--- a/keras_cv/layers/preprocessing/random_aspect_ratio.py
+++ b/keras_cv/layers/preprocessing/random_aspect_ratio.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomAspectRatio(BaseImageAugmentationLayer):
     """RandomAspectRatio randomly distorts the aspect ratio of the provided
     image.

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomAugmentationPipeline(BaseImageAugmentationLayer):
     """RandomAugmentationPipeline constructs a pipeline based on provided
     arguments.

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline_test.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -54,6 +55,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs, os)
 
+    @pytest.mark.tf_keras_only
     def test_calls_layers_augmentations_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomAugmentationPipeline(

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomBrightness(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly adjusts brightness.
 

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomChannelShift(BaseImageAugmentationLayer):
     """Randomly shift values for each channel of the input image(s).
 

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomChoice(BaseImageAugmentationLayer):
     """RandomChoice constructs a pipeline based on provided arguments.
 

--- a/keras_cv/layers/preprocessing/random_choice_test.py
+++ b/keras_cv/layers/preprocessing/random_choice_test.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 
 
 class AddOneToInputs(keras.layers.Layer):
@@ -40,6 +41,7 @@ class RandomAugmentationPipelineTest(tf.test.TestCase, parameterized.TestCase):
 
         self.assertAllClose(xs + 1, os)
 
+    @pytest.mark.tf_keras_only
     def test_calls_layer_augmentation_in_graph(self):
         layer = AddOneToInputs()
         pipeline = layers.RandomChoice(layers=[layer])

--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomColorDegeneration(BaseImageAugmentationLayer):
     """Randomly performs the color degeneration operation on given images.
 

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
@@ -21,7 +20,7 @@ from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer impo
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomColorJitter(VectorizedBaseImageAugmentationLayer):
     """RandomColorJitter class randomly apply brightness, contrast, saturation
     and hue image processing operation sequentially and randomly on the

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomContrast(VectorizedBaseImageAugmentationLayer):
     """RandomContrast randomly adjusts contrast.
 

--- a/keras_cv/layers/preprocessing/random_crop.py
+++ b/keras_cv/layers/preprocessing/random_crop.py
@@ -14,9 +14,9 @@
 
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -27,7 +27,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCrop(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly crops images.
 

--- a/keras_cv/layers/preprocessing/random_crop_and_resize.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCropAndResize(BaseImageAugmentationLayer):
     """Randomly crops a part of an image and resizes it to provided size.
 

--- a/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_and_resize_test.py
@@ -119,7 +119,9 @@ class RandomCropAndResizeTest(tf.test.TestCase, parameterized.TestCase):
         input_image_shape = (1, self.height, self.width, 3)
         mask_shape = (1, self.height, self.width, 1)
         image = tf.random.uniform(shape=input_image_shape, seed=self.seed)
-        mask = np.random.randint(2, size=mask_shape) * (num_classes - 1)
+        mask = tf.constant(
+            np.random.randint(2, size=mask_shape) * (num_classes - 1)
+        )
 
         inputs = {"images": image, "segmentation_masks": mask}
 

--- a/keras_cv/layers/preprocessing/random_crop_test.py
+++ b/keras_cv/layers/preprocessing/random_crop_test.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.random_crop import RandomCrop
 
 
@@ -144,15 +144,15 @@ class RandomCropTest(tf.test.TestCase, parameterized.TestCase):
             np.float32
         )
         bboxes = {
-            "boxes": tf.convert_to_tensor([[200, 200, 400, 400]]),
-            "classes": tf.convert_to_tensor([1]),
+            "boxes": np.array([[200, 200, 400, 400]]),
+            "classes": np.array([1]),
         }
         input = {"images": input_image, "bounding_boxes": bboxes}
         # for top = 300 and left = 305
         height_offset = 300
         width_offset = 305
-        tops = tf.ones((1, 1)) * (height_offset / (orig_height - height))
-        lefts = tf.ones((1, 1)) * (width_offset / (orig_width - width))
+        tops = np.ones((1, 1)) * (height_offset / (orig_height - height))
+        lefts = np.ones((1, 1)) * (width_offset / (orig_width - width))
         transformations = {"tops": tops, "lefts": lefts}
         layer = RandomCrop(
             height=height, width=width, bounding_box_format="xyxy"
@@ -171,8 +171,8 @@ class RandomCropTest(tf.test.TestCase, parameterized.TestCase):
     def test_augment_bounding_boxes_resize(self):
         input_image = np.random.random((256, 256, 3)).astype(np.float32)
         bboxes = {
-            "boxes": tf.convert_to_tensor([[100, 100, 200, 200]]),
-            "classes": tf.convert_to_tensor([1]),
+            "boxes": np.array([[100, 100, 200, 200]]),
+            "classes": np.array([1]),
         }
         input = {"images": input_image, "bounding_boxes": bboxes}
         layer = RandomCrop(height=512, width=512, bounding_box_format="xyxy")

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -22,7 +22,7 @@ from keras_cv.utils import fill_utils
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomCutout(BaseImageAugmentationLayer):
     """Randomly cut out rectangles from images and fill them.
 

--- a/keras_cv/layers/preprocessing/random_flip.py
+++ b/keras_cv/layers/preprocessing/random_flip.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -31,7 +31,7 @@ VERTICAL = "vertical"
 HORIZONTAL_AND_VERTICAL = "horizontal_and_vertical"
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomFlip(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly flips images.
 

--- a/keras_cv/layers/preprocessing/random_flip_test.py
+++ b/keras_cv/layers/preprocessing/random_flip_test.py
@@ -263,7 +263,7 @@ class RandomFlipTest(tf.test.TestCase, parameterized.TestCase):
         self.assertAllClose(expected_mask, output["segmentation_masks"])
 
     def test_ragged_bounding_boxes(self):
-        input_image = np.random.random((2, 512, 512, 3)).astype(np.float32)
+        input_image = tf.random.uniform((2, 512, 512, 3))
         bounding_boxes = {
             "boxes": tf.ragged.constant(
                 [

--- a/keras_cv/layers/preprocessing/random_gaussian_blur.py
+++ b/keras_cv/layers/preprocessing/random_gaussian_blur.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomGaussianBlur(BaseImageAugmentationLayer):
     """Applies a Gaussian Blur with random strength to an image.
 

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomHue(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the hue on given images.
 

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomJpegQuality(BaseImageAugmentationLayer):
     """Applies Random Jpeg compression artifacts to an image.
 

--- a/keras_cv/layers/preprocessing/random_rotation.py
+++ b/keras_cv/layers/preprocessing/random_rotation.py
@@ -14,9 +14,9 @@
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -28,7 +28,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomRotation(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly rotates images.
 
@@ -231,7 +231,7 @@ class RandomRotation(VectorizedBaseImageAugmentationLayer):
         # mask sparse again using tf.argmax.
         if self.segmentation_classes:
             one_hot_mask = tf.one_hot(
-                tf.squeeze(segmentation_masks, axis=-1),
+                tf.squeeze(tf.cast(segmentation_masks, tf.int32), axis=-1),
                 self.segmentation_classes,
             )
             rotated_one_hot_mask = self._rotate_images(

--- a/keras_cv/layers/preprocessing/random_rotation_test.py
+++ b/keras_cv/layers/preprocessing/random_rotation_test.py
@@ -61,10 +61,8 @@ class RandomRotationTest(tf.test.TestCase):
     def test_augment_bounding_boxes(self):
         input_image = np.random.random((512, 512, 3)).astype(np.float32)
         bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
-                [[200, 200, 400, 400], [100, 100, 300, 300]], dtype=tf.float32
-            ),
-            "classes": tf.convert_to_tensor([1, 2], dtype=tf.float32),
+            "boxes": np.array([[200, 200, 400, 400], [100, 100, 300, 300]]),
+            "classes": np.array([1, 2]),
         }
         input = {"images": input_image, "bounding_boxes": bounding_boxes}
         # 180 rotation.
@@ -74,11 +72,10 @@ class RandomRotationTest(tf.test.TestCase):
             output["bounding_boxes"]
         )
         expected_bounding_boxes = {
-            "boxes": tf.convert_to_tensor(
+            "boxes": np.array(
                 [[112.0, 112.0, 312.0, 312.0], [212.0, 212.0, 412.0, 412.0]],
-                dtype=tf.float32,
             ),
-            "classes": tf.convert_to_tensor([1, 2], dtype=tf.float32),
+            "classes": np.array([1, 2]),
         }
         self.assertAllClose(expected_bounding_boxes, output["bounding_boxes"])
 
@@ -90,7 +87,7 @@ class RandomRotationTest(tf.test.TestCase):
         self.assertAllEqual(layer(inputs).dtype, "uint8")
 
     def test_ragged_bounding_boxes(self):
-        input_image = np.random.random((2, 512, 512, 3)).astype(np.float32)
+        input_image = tf.random.uniform((2, 512, 512, 3))
         bounding_boxes = {
             "boxes": tf.ragged.constant(
                 [
@@ -182,8 +179,10 @@ class RandomRotationTest(tf.test.TestCase):
         num_classes = 8
 
         input_images = np.random.random((2, 20, 20, 3)).astype(np.float32)
-        masks = tf.one_hot(
-            np.random.randint(num_classes, size=(2, 20, 20)), num_classes
+        masks = np.array(
+            tf.one_hot(
+                np.random.randint(num_classes, size=(2, 20, 20)), num_classes
+            )
         )
         inputs = {"images": input_images, "segmentation_masks": masks}
 

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing as preprocessing_utils
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomSaturation(VectorizedBaseImageAugmentationLayer):
     """Randomly adjusts the saturation on given images.
 

--- a/keras_cv/layers/preprocessing/random_saturation_test.py
+++ b/keras_cv/layers/preprocessing/random_saturation_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 from keras_cv import core
+from keras_cv.backend import keras
 from keras_cv.layers import preprocessing
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,

--- a/keras_cv/layers/preprocessing/random_sharpness.py
+++ b/keras_cv/layers/preprocessing/random_sharpness.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomSharpness(VectorizedBaseImageAugmentationLayer):
     """Randomly performs the sharpness operation on given images.
 

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -15,17 +15,17 @@
 import warnings
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomShear(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly shears images.
 

--- a/keras_cv/layers/preprocessing/random_translation.py
+++ b/keras_cv/layers/preprocessing/random_translation.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -25,7 +25,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomTranslation(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly translates images.
 

--- a/keras_cv/layers/preprocessing/random_zoom.py
+++ b/keras_cv/layers/preprocessing/random_zoom.py
@@ -15,8 +15,8 @@
 
 import tensorflow as tf
 from keras import backend
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
@@ -28,7 +28,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RandomZoom(VectorizedBaseImageAugmentationLayer):
     """A preprocessing layer which randomly zooms images.
 

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RepeatedAugmentation(BaseImageAugmentationLayer):
     """RepeatedAugmentation augments each image in a batch multiple times.
 

--- a/keras_cv/layers/preprocessing/rescaling.py
+++ b/keras_cv/layers/preprocessing/rescaling.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -25,7 +25,7 @@ H_AXIS = -3
 W_AXIS = -2
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Rescaling(BaseImageAugmentationLayer):
     """A preprocessing layer which rescales input values to a new range.
 

--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv.utils
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
@@ -309,7 +309,7 @@ class Resizing(BaseImageAugmentationLayer):
         def resize_with_crop_to_aspect(x, interpolation_method):
             if isinstance(x, tf.RaggedTensor):
                 x = x.to_tensor()
-            return keras.preprocessing.image.smart_resize(
+            return ops.smart_resize(
                 x,
                 size=size,
                 interpolation=interpolation_method,

--- a/keras_cv/layers/preprocessing/resizing_test.py
+++ b/keras_cv/layers/preprocessing/resizing_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
+import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -149,6 +150,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         ("crop_to_aspect_ratio_false", False),
         ("crop_to_aspect_ratio_true", True),
     )
+    @pytest.mark.tf_keras_only
     def test_ragged_image(self, crop_to_aspect_ratio):
         inputs = tf.ragged.constant(
             [
@@ -226,6 +228,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
         img_data = np.random.random(size=input_shape).astype("float32")
         tf_function(img_data)
 
+    @pytest.mark.tf_keras_only
     def test_pad_to_size_with_bounding_boxes_ragged_images(self):
         images = tf.ragged.constant(
             [
@@ -264,6 +267,7 @@ class ResizingTest(tf.test.TestCase, parameterized.TestCase):
             outputs["images"].shape.as_list(),
         )
 
+    @pytest.mark.tf_keras_only
     def test_pad_to_size_with_bounding_boxes_ragged_images_upsample(self):
         images = tf.ragged.constant(
             [

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
 
+from keras_cv.backend import keras
 from keras_cv.layers.preprocessing.vectorized_base_image_augmentation_layer import (  # noqa: E501
     VectorizedBaseImageAugmentationLayer,
 )
 from keras_cv.utils import preprocessing
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Solarization(VectorizedBaseImageAugmentationLayer):
     """Applies (max_value - pixel + min_value) for each pixel in the image.
 

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
-from keras import backend as keras_backend
+from keras.src import backend as keras_backend
 
 from keras_cv import bounding_box
 from keras_cv.backend import keras

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+from keras import backend as keras_backend
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import scope
+from keras_cv.backend.config import multi_backend
 from keras_cv.utils import preprocessing
 
 H_AXIS = -3
@@ -33,10 +36,15 @@ BATCHED = "batched"
 USE_TARGETS = "use_targets"
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class VectorizedBaseImageAugmentationLayer(
-    keras.__internal__.layers.BaseRandomLayer
-):
+base_class = (
+    keras.src.layers.preprocessing.tf_data_layer.TFDataLayer
+    if multi_backend()
+    else keras.layers.Layer
+)
+
+
+@keras.saving.register_keras_serializable(package="keras_cv")
+class VectorizedBaseImageAugmentationLayer(base_class):
     """Abstract base layer for vectorized image augmentation.
 
     This layer contains base functionalities for preprocessing layers which
@@ -95,7 +103,12 @@ class VectorizedBaseImageAugmentationLayer(
     """
 
     def __init__(self, seed=None, **kwargs):
-        super().__init__(seed=seed, **kwargs)
+        force_generator = kwargs.pop("force_generator", False)
+        self._random_generator = keras_backend.RandomGenerator(
+            seed=seed, force_generator=force_generator
+        )
+        super().__init__(**kwargs)
+        self._convert_input_args = False
 
     @property
     def force_output_dense_images(self):
@@ -402,17 +415,21 @@ class VectorizedBaseImageAugmentationLayer(
         return result
 
     def call(self, inputs):
-        inputs = self._ensure_inputs_are_compute_dtype(inputs)
-        inputs, metadata = self._format_inputs(inputs)
-        images = inputs[IMAGES]
-        if images.shape.rank == 3 or images.shape.rank == 4:
-            return self._format_output(self._batch_augment(inputs), metadata)
-        else:
-            raise ValueError(
-                "Image augmentation layers are expecting inputs to be "
-                "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
-                f"{images.shape}"
-            )
+        with scope.TFDataScope():
+            inputs = self._ensure_inputs_are_compute_dtype(inputs)
+            inputs, metadata = self._format_inputs(inputs)
+            images = inputs[IMAGES]
+            if images.shape.rank == 3 or images.shape.rank == 4:
+                outputs = self._format_output(
+                    self._batch_augment(inputs), metadata
+                )
+            else:
+                raise ValueError(
+                    "Image augmentation layers are expecting inputs to be "
+                    "rank 3 (HWC) or 4D (NHWC) tensors. Got shape: "
+                    f"{images.shape}"
+                )
+            return outputs
 
     def _format_inputs(self, inputs):
         metadata = {IS_DICT: True, USE_TARGETS: False}
@@ -484,6 +501,21 @@ class VectorizedBaseImageAugmentationLayer(
             inputs[IMAGES],
             self.compute_dtype,
         )
+        if LABELS in inputs:
+            inputs[LABELS] = preprocessing.ensure_tensor(
+                inputs[LABELS],
+                self.compute_dtype,
+            )
+        if KEYPOINTS in inputs:
+            inputs[KEYPOINTS] = preprocessing.ensure_tensor(
+                inputs[KEYPOINTS],
+                self.compute_dtype,
+            )
+        if SEGMENTATION_MASKS in inputs:
+            inputs[SEGMENTATION_MASKS] = preprocessing.ensure_tensor(
+                inputs[SEGMENTATION_MASKS],
+                self.compute_dtype,
+            )
         if BOUNDING_BOXES in inputs:
             inputs[BOUNDING_BOXES]["boxes"] = preprocessing.ensure_tensor(
                 inputs[BOUNDING_BOXES]["boxes"],

--- a/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/vectorized_base_image_augmentation_layer_test.py
@@ -255,10 +255,10 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_leaves_extra_dict_entries_unmodified(self):
         add_layer = VectorizedRandomAddLayer(fixed_value=0.5)
         images = np.random.random(size=(8, 8, 3)).astype("float32")
-        filenames = tf.constant("/path/to/first.jpg")
-        inputs = {"images": images, "filenames": filenames}
+        timestamps = np.array(123123123)
+        inputs = {"images": images, "timestamps": timestamps}
         output = add_layer(inputs)
-        self.assertAllEqual(output["filenames"], filenames)
+        self.assertAllEqual(output["timestamps"], timestamps)
 
     def test_augment_ragged_images(self):
         images = tf.ragged.stack(
@@ -436,30 +436,19 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
         }
 
         output = add_layer(input, training=True)
-        expected_output = {
-            "images": images + 2.0,
-            "bounding_boxes": bounding_box.to_dense(
-                {
-                    "boxes": bounding_boxes["boxes"] + 2.0,
-                    "classes": bounding_boxes["classes"] + 2.0,
-                }
-            ),
-            "keypoints": keypoints + 2.0,
-            "segmentation_masks": segmentation_masks + 2.0,
-        }
 
-        self.assertAllClose(output["images"], expected_output["images"])
-        self.assertAllClose(output["keypoints"], expected_output["keypoints"])
+        self.assertAllClose(output["images"], images + 2.0)
+        self.assertAllClose(output["keypoints"], keypoints + 2.0)
         self.assertAllClose(
             output["bounding_boxes"]["boxes"],
-            expected_output["bounding_boxes"]["boxes"],
+            tf.squeeze(bounding_boxes["boxes"]) + 2.0,
         )
         self.assertAllClose(
             output["bounding_boxes"]["classes"],
-            expected_output["bounding_boxes"]["classes"],
+            tf.squeeze(bounding_boxes["classes"]) + 2.0,
         )
         self.assertAllClose(
-            output["segmentation_masks"], expected_output["segmentation_masks"]
+            output["segmentation_masks"], segmentation_masks + 2.0
         )
 
     def test_augment_all_data_for_assertion(self):
@@ -490,21 +479,30 @@ class VectorizedBaseImageAugmentationLayerTest(tf.test.TestCase):
     def test_augment_all_data_with_ragged_images_for_assertion(self):
         images = tf.ragged.stack(
             [
-                np.random.random(size=(8, 8, 3)).astype("float32"),
-                np.random.random(size=(16, 8, 3)).astype("float32"),
+                tf.random.uniform(shape=(8, 8, 3)),
+                tf.random.uniform(shape=(16, 8, 3)),
             ]
         )
-        labels = np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
-        bounding_boxes = {
-            "boxes": np.random.random(size=(2, 3, 4)).astype("float32"),
-            "classes": np.random.random(size=(2, 3)).astype("float32"),
-        }
-        keypoints = np.random.random(size=(2, 5, 2)).astype("float32")
-        segmentation_masks = np.random.random(size=(2, 8, 8, 1)).astype(
-            "float32"
+        labels = tf.constant(
+            np.squeeze(np.eye(10)[np.array([0, 1]).reshape(-1)])
         )
+        bounding_boxes = {
+            "boxes": tf.random.uniform(shape=(2, 3, 4)),
+            "classes": tf.random.uniform(shape=(2, 3)),
+        }
+        keypoints = tf.random.uniform(shape=(2, 5, 2))
+        segmentation_masks = tf.random.uniform(shape=(2, 8, 8, 1))
         assertion_layer = VectorizedAssertionLayer()
 
+        print(
+            {
+                "images": type(images),
+                "labels": type(labels),
+                "bounding_boxes": type(bounding_boxes),
+                "keypoints": type(keypoints),
+                "segmentation_masks": type(segmentation_masks),
+            }
+        )
         _ = assertion_layer(
             {
                 "images": images,

--- a/keras_cv/layers/preprocessing/with_mixed_precision_test.py
+++ b/keras_cv/layers/preprocessing/with_mixed_precision_test.py
@@ -14,9 +14,9 @@
 
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
 from keras_cv import layers
+from keras_cv.backend import keras
 
 TEST_CONFIGURATIONS = [
     ("AutoContrast", layers.AutoContrast, {"value_range": (0, 255)}),
@@ -161,7 +161,7 @@ class WithMixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
         img = tf.random.uniform(
             shape=(3, 512, 512, 3), minval=0, maxval=255, dtype=tf.float32
         )
-        labels = tf.ones((3,), dtype=tf.float32)
+        labels = tf.ones((3,), dtype=tf.float16)
         inputs = {"images": img, "labels": labels}
 
         layer = layer_cls(**init_args)

--- a/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
+++ b/keras_cv/layers/preprocessing/with_segmentation_masks_test.py
@@ -132,6 +132,4 @@ class WithSegmentationMasksTest(tf.test.TestCase, parameterized.TestCase):
         # This currently asserts that all layers are no-ops.
         # When preprocessing layers are updated to mutate segmentation masks,
         # this condition should only be asserted for no-op layers.
-        self.assertAllClose(
-            inputs["segmentation_masks"], outputs["segmentation_masks"]
-        )
+        self.assertAllClose(segmentation_mask, outputs["segmentation_masks"])

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -97,7 +97,7 @@ class SqueezeAndExcite2D(keras.layers.Layer):
             self.filters, (1, 1), activation=self.excite_activation
         )
 
-    def call(self, inputs, training=True):
+    def call(self, inputs, training=None):
         x = self.global_average_pool(inputs)  # x: (batch_size, 1, 1, filters)
         x = self.squeeze_conv(x)  # x: (batch_size, 1, 1, bottleneck_filters)
         x = self.excite_conv(x)  # x: (batch_size, 1, 1, filters)

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class SqueezeAndExcite2D(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class SqueezeAndExcite2D(keras.layers.Layer):
     """
     Implements Squeeze and Excite block as in
     [Squeeze-and-Excitation Networks](https://arxiv.org/pdf/1709.01507.pdf).
@@ -86,13 +85,15 @@ class SqueezeAndExcite2D(layers.Layer):
         self.squeeze_activation = squeeze_activation
         self.excite_activation = excite_activation
 
-        self.global_average_pool = layers.GlobalAveragePooling2D(keepdims=True)
-        self.squeeze_conv = layers.Conv2D(
+        self.global_average_pool = keras.layers.GlobalAveragePooling2D(
+            keepdims=True
+        )
+        self.squeeze_conv = keras.layers.Conv2D(
             self.bottleneck_filters,
             (1, 1),
             activation=self.squeeze_activation,
         )
-        self.excite_conv = layers.Conv2D(
+        self.excite_conv = keras.layers.Conv2D(
             self.filters, (1, 1), activation=self.excite_activation
         )
 
@@ -100,7 +101,7 @@ class SqueezeAndExcite2D(layers.Layer):
         x = self.global_average_pool(inputs)  # x: (batch_size, 1, 1, filters)
         x = self.squeeze_conv(x)  # x: (batch_size, 1, 1, bottleneck_filters)
         x = self.excite_conv(x)  # x: (batch_size, 1, 1, filters)
-        x = tf.math.multiply(x, inputs)  # x: (batch_size, h, w, filters)
+        x = ops.multiply(x, inputs)  # x: (batch_size, h, w, filters)
         return x
 
     def get_config(self):
@@ -116,11 +117,13 @@ class SqueezeAndExcite2D(layers.Layer):
     @classmethod
     def from_config(cls, config):
         if isinstance(config["squeeze_activation"], dict):
-            config["squeeze_activation"] = keras.utils.deserialize_keras_object(
+            config[
+                "squeeze_activation"
+            ] = keras.saving.deserialize_keras_object(
                 config["squeeze_activation"]
             )
         if isinstance(config["excite_activation"], dict):
-            config["excite_activation"] = keras.utils.deserialize_keras_object(
+            config["excite_activation"] = keras.saving.deserialize_keras_object(
                 config["excite_activation"]
             )
         return cls(**config)

--- a/keras_cv/losses/centernet_box_loss_test.py
+++ b/keras_cv/losses/centernet_box_loss_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -36,8 +37,8 @@ class CenterNetBoxLoss(tf.test.TestCase, parameterized.TestCase):
             num_heading_bins=4, anchor_size=[1.0, 1.0, 1.0], reduction=reduction
         )
         result = loss(
-            y_true=tf.random.uniform((2, 10, 7)),
+            y_true=np.random.uniform(size=(2, 10, 7)),
             # Predictions have xyz,lwh, and 2*4 values for heading.
-            y_pred=tf.random.uniform((2, 10, 6 + 2 * 4)),
+            y_pred=np.random.uniform(size=(2, 10, 6 + 2 * 4)),
         )
         self.assertEqual(result.shape, target_size)

--- a/keras_cv/losses/ciou_loss.py
+++ b/keras_cv/losses/ciou_loss.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-import tensorflow as tf
-from tensorflow import keras
-
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.bounding_box.iou import compute_ciou
 
 
@@ -41,16 +40,14 @@ class CIoULoss(keras.losses.Loss):
 
     Sample Usage:
     ```python
-    y_true = tf.random.uniform(
-        (5, 10, 5),
-        minval=0,
-        maxval=10,
-        dtype=tf.dtypes.int32)
-    y_pred = tf.random.uniform(
+    y_true = np.random.uniform(
+        size=(5, 10, 5),
+        low=0,
+        high=10)
+    y_pred = np.random.uniform(
         (5, 10, 4),
-        minval=0,
-        maxval=10,
-        dtype=tf.dtypes.int32)
+        low=0,
+        high=10)
     loss = keras_cv.losses.CIoULoss()
     loss(y_true, y_pred).numpy()
     ```
@@ -67,8 +64,8 @@ class CIoULoss(keras.losses.Loss):
         self.bounding_box_format = bounding_box_format
 
     def call(self, y_true, y_pred):
-        y_pred = tf.convert_to_tensor(y_pred)
-        y_true = tf.cast(y_true, y_pred.dtype)
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_true = ops.cast(y_true, y_pred.dtype)
 
         if y_pred.shape[-1] != 4:
             raise ValueError(
@@ -90,7 +87,7 @@ class CIoULoss(keras.losses.Loss):
                 f"y_pred={y_pred.shape[-2]}."
             )
 
-        ciou = tf.squeeze(
+        ciou = ops.squeeze(
             compute_ciou(y_true, y_pred, self.bounding_box_format), axis=-1
         )
         return 1 - ciou

--- a/keras_cv/losses/ciou_loss_test.py
+++ b/keras_cv/losses/ciou_loss_test.py
@@ -21,24 +21,16 @@ from keras_cv.losses.ciou_loss import CIoULoss
 
 class CIoUTest(tf.test.TestCase, parameterized.TestCase):
     def test_output_shape(self):
-        y_true = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=10, dtype=tf.int32
-        )
-        y_pred = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=20, dtype=tf.int32
-        )
+        y_true = np.random.uniform(size=(2, 2, 4), low=0, high=10)
+        y_pred = np.random.uniform(size=(2, 2, 4), low=0, high=20)
 
         ciou_loss = CIoULoss(bounding_box_format="xywh")
 
         self.assertAllEqual(ciou_loss(y_true, y_pred).shape, ())
 
     def test_output_shape_reduction_none(self):
-        y_true = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=10, dtype=tf.int32
-        )
-        y_pred = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=20, dtype=tf.int32
-        )
+        y_true = np.random.uniform(size=(2, 2, 4), low=0, high=10)
+        y_pred = np.random.uniform(size=(2, 2, 4), low=0, high=20)
 
         ciou_loss = CIoULoss(bounding_box_format="xyxy", reduction="none")
 
@@ -88,11 +80,8 @@ class CIoUTest(tf.test.TestCase, parameterized.TestCase):
         ciou_loss = CIoULoss(bounding_box_format="xyxy")
         if name == "rel_xyxy":
             scale_factor = 1 / 640.0
-            y_true_scaled = np.array(y_true) * scale_factor
-            y_pred_scaled = np.array(y_pred) * scale_factor
-
-            y_true = tf.constant(y_true_scaled, dtype=tf.float32)
-            y_pred = tf.constant(y_pred_scaled, dtype=tf.float32)
+            y_true = np.array(y_true) * scale_factor
+            y_pred = np.array(y_pred) * scale_factor
 
         self.assertAllClose(
             ciou_loss(y_true, y_pred), expected_loss, atol=0.0001

--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-import tensorflow.keras.backend as K
-from tensorflow import keras
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class FocalLoss(keras.losses.Loss):
     """Implements Focal loss
 
@@ -44,10 +43,10 @@ class FocalLoss(keras.losses.Loss):
 
     Standalone usage:
     ```python
-    y_true = tf.random.uniform([10], 0, maxval=4)
-    y_pred = tf.random.uniform([10], 0, maxval=4)
+    y_true = np.random.uniform(size=[10], low=0, high=4)
+    y_pred = np.random.uniform(size=[10], low=0, high=4)
     loss = FocalLoss()
-    loss(y_true, y_pred).numpy()
+    loss(y_true, y_pred)
     ```
     Usage with the `compile()` API:
     ```python
@@ -75,20 +74,26 @@ class FocalLoss(keras.losses.Loss):
         )
 
     def call(self, y_true, y_pred):
-        y_pred = tf.convert_to_tensor(y_pred)
-        y_true = tf.cast(y_true, y_pred.dtype)
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_true = ops.cast(y_true, y_pred.dtype)
 
         if self.label_smoothing:
             y_true = self._smooth_labels(y_true)
 
         if self.from_logits:
-            y_pred = tf.nn.sigmoid(y_pred)
+            y_pred = ops.sigmoid(y_pred)
 
-        cross_entropy = K.binary_crossentropy(y_true, y_pred)
+        cross_entropy = ops.binary_crossentropy(y_true, y_pred)
 
-        alpha = tf.where(tf.equal(y_true, 1.0), self.alpha, (1.0 - self.alpha))
+        alpha = ops.where(
+            ops.equal(y_true, 1.0), self.alpha, (1.0 - self.alpha)
+        )
         pt = y_true * y_pred + (1.0 - y_true) * (1.0 - y_pred)
-        loss = alpha * tf.pow(1.0 - pt, self.gamma) * cross_entropy
+        loss = (
+            alpha
+            * ops.cast(ops.power(1.0 - pt, self.gamma), alpha.dtype)
+            * ops.cast(cross_entropy, alpha.dtype)
+        )
         # In most losses you mean over the final axis to achieve a scalar
         # Focal loss however is a special case in that it is meant to focus on
         # a small number of hard examples in a batch. Most of the time this
@@ -97,7 +102,7 @@ class FocalLoss(keras.losses.Loss):
         # If you mean over the final axis you will get a number close to 0,
         # which will encourage your model to exclusively predict background
         # class boxes.
-        return K.sum(loss, axis=-1)
+        return ops.sum(loss, axis=-1)
 
     def get_config(self):
         config = super().get_config()

--- a/keras_cv/losses/focal_test.py
+++ b/keras_cv/losses/focal_test.py
@@ -12,33 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
+from keras_cv.backend.config import multi_backend
 from keras_cv.losses import FocalLoss
 
 
 class FocalTest(tf.test.TestCase):
     def test_output_shape(self):
-        y_true = tf.cast(
-            tf.random.uniform(shape=[2, 5], minval=0, maxval=2, dtype=tf.int32),
-            tf.float32,
-        )
-        y_pred = tf.random.uniform(
-            shape=[2, 5], minval=0, maxval=1, dtype=tf.float32
-        )
+        y_true = np.random.uniform(size=[2, 5], low=0, high=2)
+        y_pred = np.random.uniform(size=[2, 5], low=0, high=1)
 
         focal_loss = FocalLoss(reduction="sum")
 
         self.assertAllEqual(focal_loss(y_true, y_pred).shape, [])
 
     def test_output_shape_reduction_none(self):
-        y_true = tf.cast(
-            tf.random.uniform(shape=[2, 5], minval=0, maxval=2, dtype=tf.int32),
-            tf.float32,
-        )
-        y_pred = tf.random.uniform(
-            shape=[2, 5], minval=0, maxval=1, dtype=tf.float32
-        )
+        y_true = np.random.uniform(size=[2, 5], low=0, high=2)
+        y_pred = np.random.uniform(size=[2, 5], low=0, high=1)
 
         focal_loss = FocalLoss(reduction="none")
 
@@ -50,13 +44,8 @@ class FocalTest(tf.test.TestCase):
         )
 
     def test_output_shape_from_logits(self):
-        y_true = tf.cast(
-            tf.random.uniform(shape=[2, 5], minval=0, maxval=2, dtype=tf.int32),
-            tf.float32,
-        )
-        y_pred = tf.random.uniform(
-            shape=[2, 5], minval=-10, maxval=10, dtype=tf.float32
-        )
+        y_true = np.random.uniform(size=[2, 5], low=0, high=2)
+        y_pred = np.random.uniform(size=[2, 5], low=-10, high=10)
 
         focal_loss = FocalLoss(reduction="none", from_logits=True)
 
@@ -68,13 +57,26 @@ class FocalTest(tf.test.TestCase):
         )
 
     def test_from_logits_argument(self):
-        y_true = tf.random.uniform((2, 8, 10))
-        y_logits = tf.random.uniform((2, 8, 10), minval=-1000, maxval=1000)
-        y_pred = tf.nn.sigmoid(y_logits)
+        rng = np.random.default_rng(1337)
+        y_true = rng.uniform(size=(2, 8, 10)).astype("float64")
+        y_logits = rng.uniform(low=-1000, high=1000, size=(2, 8, 10)).astype(
+            "float64"
+        )
+        y_pred = ops.cast(ops.sigmoid(y_logits), "float32")
 
         focal_loss_on_logits = FocalLoss(from_logits=True)
         focal_loss = FocalLoss()
 
-        self.assertAllClose(
-            focal_loss_on_logits(y_true, y_logits), focal_loss(y_true, y_pred)
+        # TODO(ianstenbit): This probably warrants some more investigation.
+        # In the current implementation, I've verified that training RetinaNet
+        # works in all backends with this implementation.
+        # TF backend somehow has different numerics.
+        expected_loss = (
+            31.11176
+            if multi_backend() and keras.backend.backend() != "tensorflow"
+            else 925.28081
         )
+        self.assertAllClose(
+            focal_loss_on_logits(y_true, y_logits), expected_loss
+        )
+        self.assertAllClose(focal_loss(y_true, y_pred), 31.11176)

--- a/keras_cv/losses/iou_loss.py
+++ b/keras_cv/losses/iou_loss.py
@@ -15,10 +15,9 @@
 
 import warnings
 
-import tensorflow as tf
-from tensorflow import keras
-
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
 class IoULoss(keras.losses.Loss):
@@ -48,18 +47,10 @@ class IoULoss(keras.losses.Loss):
 
     Sample Usage:
     ```python
-    y_true = tf.random.uniform(
-        (5, 10, 5),
-        minval=0,
-        maxval=10,
-        dtype=tf.dtypes.int32)
-    y_pred = tf.random.uniform(
-        (5, 10, 4),
-        minval=0,
-        maxval=10,
-        dtype=tf.dtypes.int32)
+    y_true = np.random.uniform(size=(5, 10, 5), low=10, high=10)
+    y_pred = np.random.uniform(size=(5, 10, 5), low=10, high=10)
     loss = IoULoss(bounding_box_format = "xyWH")
-    loss(y_true, y_pred).numpy()
+    loss(y_true, y_pred)
     ```
 
     Usage with the `compile()` API:
@@ -81,8 +72,8 @@ class IoULoss(keras.losses.Loss):
             )
 
     def call(self, y_true, y_pred):
-        y_pred = tf.convert_to_tensor(y_pred)
-        y_true = tf.cast(y_true, y_pred.dtype)
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_true = ops.cast(y_true, y_pred.dtype)
 
         if y_pred.shape[-1] != 4:
             raise ValueError(
@@ -106,7 +97,7 @@ class IoULoss(keras.losses.Loss):
 
         iou = bounding_box.compute_iou(y_true, y_pred, self.bounding_box_format)
         # pick out the diagonal for corresponding ious
-        iou = tf.linalg.diag_part(iou)
+        iou = ops.diagonal(iou)
         if self.axis == "no_reduction":
             warnings.warn(
                 "`axis='no_reduction'` is a temporary API, and the API "
@@ -114,14 +105,14 @@ class IoULoss(keras.losses.Loss):
                 "solution covering all losses."
             )
         else:
-            iou = tf.reduce_mean(iou, axis=self.axis)
+            iou = ops.mean(iou, axis=self.axis)
 
         if self.mode == "linear":
             loss = 1 - iou
         elif self.mode == "quadratic":
             loss = 1 - iou**2
         elif self.mode == "log":
-            loss = -tf.math.log(iou)
+            loss = -ops.log(iou)
 
         return loss
 

--- a/keras_cv/losses/iou_loss_test.py
+++ b/keras_cv/losses/iou_loss_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
 from keras_cv.losses.iou_loss import IoULoss
@@ -19,24 +20,16 @@ from keras_cv.losses.iou_loss import IoULoss
 
 class IoUTest(tf.test.TestCase):
     def test_output_shape(self):
-        y_true = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=10, dtype=tf.int32
-        )
-        y_pred = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=20, dtype=tf.int32
-        )
+        y_true = np.random.uniform(size=(2, 2, 4), low=0, high=10)
+        y_pred = np.random.uniform(size=(2, 2, 4), low=0, high=20)
 
         iou_loss = IoULoss(bounding_box_format="xywh")
 
         self.assertAllEqual(iou_loss(y_true, y_pred).shape, ())
 
     def test_output_shape_reduction_none(self):
-        y_true = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=10, dtype=tf.int32
-        )
-        y_pred = tf.random.uniform(
-            shape=(2, 2, 4), minval=0, maxval=20, dtype=tf.int32
-        )
+        y_true = np.random.uniform(size=(2, 2, 4), low=0, high=10)
+        y_pred = np.random.uniform(size=(2, 2, 4), low=0, high=20)
 
         iou_loss = IoULoss(bounding_box_format="xywh", reduction="none")
 

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -59,7 +59,7 @@ class FocalLossModelGardenComparisonTest(
     )
     def test_model_garden_implementation_has_same_outputs(self, reduction):
         focal_loss = FocalLoss(
-            alpha=0.25, gamma=2.0, from_logits=True, reduction=reduction
+            alpha=0.25, gamma=2.0, from_logits=False, reduction=reduction
         )
         model_garden_focal_loss = ModelGardenFocalLoss(
             alpha=0.25, gamma=2.0, reduction=reduction
@@ -71,6 +71,6 @@ class FocalLossModelGardenComparisonTest(
             y_true = tf.cast(y_true, tf.float32)
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
-                focal_loss(y_true, y_pred),
+                focal_loss(y_true, tf.sigmoid(y_pred)),
                 model_garden_focal_loss(y_true, y_pred),
             )

--- a/keras_cv/losses/penalty_reduced_focal_loss.py
+++ b/keras_cv/losses/penalty_reduced_focal_loss.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-from tensorflow import keras
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
 # TODO(tanzhenyu): consider inherit from LossFunctionWrapper to
 #  get the dimension squeeze.
-@keras.saving.register_keras_serializable(package="keras_cv")
+@keras.utils.register_keras_serializable(package="keras_cv")
 class BinaryPenaltyReducedFocalCrossEntropy(keras.losses.Loss):
     """Implements CenterNet modified Focal loss.
 
@@ -62,7 +62,7 @@ class BinaryPenaltyReducedFocalCrossEntropy(keras.losses.Loss):
         positive_threshold=0.99,
         positive_weight=1.0,
         negative_weight=1.0,
-        reduction=keras.losses.Reduction.AUTO,
+        reduction="sum_over_batch_size",
         name="binary_penalty_reduced_focal_cross_entropy",
     ):
         super().__init__(reduction=reduction, name=name)
@@ -74,27 +74,27 @@ class BinaryPenaltyReducedFocalCrossEntropy(keras.losses.Loss):
         self.negative_weight = negative_weight
 
     def call(self, y_true, y_pred):
-        y_pred = tf.convert_to_tensor(y_pred)
-        y_true = tf.cast(y_true, y_pred.dtype)
+        y_pred = ops.convert_to_tensor(y_pred)
+        y_true = ops.cast(y_true, y_pred.dtype)
 
         if self.from_logits:
-            y_pred = tf.nn.sigmoid(y_pred)
+            y_pred = ops.sigmoid(y_pred)
 
         # TODO(tanzhenyu): Evaluate whether we need clipping after model is
         #  trained.
-        y_pred = tf.clip_by_value(y_pred, 1e-4, 0.9999)
-        y_true = tf.clip_by_value(y_true, 0.0, 1.0)
+        y_pred = ops.clip(y_pred, 1e-4, 0.9999)
+        y_true = ops.clip(y_true, 0.0, 1.0)
 
-        pos_loss = tf.math.pow(1.0 - y_pred, self.alpha) * tf.math.log(y_pred)
+        pos_loss = ops.power(1.0 - y_pred, self.alpha) * ops.log(y_pred)
         neg_loss = (
-            tf.math.pow(1.0 - y_true, self.beta)
-            * tf.math.pow(y_pred, self.alpha)
-            * tf.math.log(1.0 - y_pred)
+            ops.power(1.0 - y_true, self.beta)
+            * ops.power(y_pred, self.alpha)
+            * ops.log(1.0 - y_pred)
         )
 
         positive_mask = y_true > self.positive_threshold
 
-        loss = tf.where(
+        loss = ops.where(
             positive_mask,
             self.positive_weight * pos_loss,
             self.negative_weight * neg_loss,

--- a/keras_cv/losses/penalty_reduced_focal_loss.py
+++ b/keras_cv/losses/penalty_reduced_focal_loss.py
@@ -18,7 +18,7 @@ from tensorflow import keras
 
 # TODO(tanzhenyu): consider inherit from LossFunctionWrapper to
 #  get the dimension squeeze.
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class BinaryPenaltyReducedFocalCrossEntropy(keras.losses.Loss):
     """Implements CenterNet modified Focal loss.
 

--- a/keras_cv/losses/penalty_reduced_focal_loss_test.py
+++ b/keras_cv/losses/penalty_reduced_focal_loss_test.py
@@ -20,26 +20,16 @@ from keras_cv.losses import BinaryPenaltyReducedFocalCrossEntropy
 
 class BinaryPenaltyReducedFocalLossTest(tf.test.TestCase):
     def test_output_shape(self):
-        y_true = tf.cast(
-            tf.random.uniform(shape=[2, 5], minval=0, maxval=2, dtype=tf.int32),
-            tf.float32,
-        )
-        y_pred = tf.random.uniform(
-            shape=[2, 5], minval=0, maxval=1, dtype=tf.float32
-        )
+        y_true = (np.random.uniform(size=[2, 5], low=0, high=2),)
+        y_pred = np.random.uniform(size=[2, 5], low=0, high=1)
 
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
 
         self.assertAllEqual(focal_loss(y_true, y_pred).shape, [])
 
     def test_output_shape_reduction_none(self):
-        y_true = tf.cast(
-            tf.random.uniform(shape=[2, 5], minval=0, maxval=2, dtype=tf.int32),
-            tf.float32,
-        )
-        y_pred = tf.random.uniform(
-            shape=[2, 5], minval=0, maxval=1, dtype=tf.float32
-        )
+        y_true = np.random.uniform(size=[2, 5], low=0, high=2)
+        y_pred = np.random.uniform(size=[2, 5], low=0, high=2)
 
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="none")
 
@@ -49,14 +39,14 @@ class BinaryPenaltyReducedFocalLossTest(tf.test.TestCase):
         )
 
     def test_output_with_pos_label_pred(self):
-        y_true = tf.constant([1.0])
-        y_pred = tf.constant([1.0])
+        y_true = np.array([1.0])
+        y_pred = np.array([1.0])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
         self.assertAllClose(0.0, focal_loss(y_true, y_pred))
 
     def test_output_with_pos_label_neg_pred(self):
-        y_true = tf.constant([1.0])
-        y_pred = tf.constant([np.exp(-1.0)])
+        y_true = np.array([1.0])
+        y_pred = np.array([np.exp(-1.0)])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
         # (1-1/e)^2 * log(1/e)
         self.assertAllClose(
@@ -64,14 +54,14 @@ class BinaryPenaltyReducedFocalLossTest(tf.test.TestCase):
         )
 
     def test_output_with_neg_label_pred(self):
-        y_true = tf.constant([0.0])
-        y_pred = tf.constant([0.0])
+        y_true = np.array([0.0])
+        y_pred = np.array([0.0])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
         self.assertAllClose(0.0, focal_loss(y_true, y_pred))
 
     def test_output_with_neg_label_pos_pred(self):
-        y_true = tf.constant([0.0])
-        y_pred = tf.constant([1.0 - np.exp(-1.0)])
+        y_true = np.array([0.0])
+        y_pred = np.array([1.0 - np.exp(-1.0)])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
         # (1-0)^4 * (1-1/e)^2 * log(1/e)
         self.assertAllClose(
@@ -79,8 +69,8 @@ class BinaryPenaltyReducedFocalLossTest(tf.test.TestCase):
         )
 
     def test_output_with_weak_label_pos_pred(self):
-        y_true = tf.constant([0.5])
-        y_pred = tf.constant([1.0 - np.exp(-1.0)])
+        y_true = np.array([0.5])
+        y_pred = np.array([1.0 - np.exp(-1.0)])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(
             beta=2.0, reduction="sum"
         )
@@ -90,9 +80,9 @@ class BinaryPenaltyReducedFocalLossTest(tf.test.TestCase):
         )
 
     def test_output_with_sample_weight(self):
-        y_true = tf.constant([0.0])
-        y_pred = tf.constant([1.0 - np.exp(-1.0)])
-        sample_weight = tf.constant([0.5])
+        y_true = np.array([0.0])
+        y_pred = np.array([1.0 - np.exp(-1.0)])
+        sample_weight = np.array([0.5])
         focal_loss = BinaryPenaltyReducedFocalCrossEntropy(reduction="sum")
         # (1-0)^4 * (1-1/e)^2 * log(1/e)
         self.assertAllClose(

--- a/keras_cv/losses/simclr_loss.py
+++ b/keras_cv/losses/simclr_loss.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-from tensorflow import keras
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 LARGE_NUM = 1e9
+
+
+def l2_normalize(x, axis):
+    epsilon = keras.backend.epsilon()
+    power_sum = ops.sum(ops.square(x), axis=axis, keepdims=True)
+    norm = ops.reciprocal(ops.sqrt(ops.maximum(power_sum, epsilon)))
+    return ops.multiply(x, norm)
 
 
 class SimCLRLoss(keras.losses.Loss):
@@ -53,39 +60,39 @@ class SimCLRLoss(keras.losses.Loss):
             A tensor with the SimCLR loss computed from the input projections
         """
         # Normalize the projections
-        projections_1 = tf.math.l2_normalize(projections_1, axis=1)
-        projections_2 = tf.math.l2_normalize(projections_2, axis=1)
+        projections_1 = l2_normalize(projections_1, axis=1)
+        projections_2 = l2_normalize(projections_2, axis=1)
 
         # Produce artificial labels, 1 for each image in the batch.
-        batch_size = tf.shape(projections_1)[0]
-        labels = tf.one_hot(tf.range(batch_size), batch_size * 2)
-        masks = tf.one_hot(tf.range(batch_size), batch_size)
+        batch_size = ops.shape(projections_1)[0]
+        labels = ops.one_hot(ops.arange(batch_size), batch_size * 2)
+        masks = ops.one_hot(ops.arange(batch_size), batch_size)
 
         # Compute logits
         logits_11 = (
-            tf.matmul(projections_1, projections_1, transpose_b=True)
+            ops.matmul(projections_1, ops.transpose(projections_1))
             / self.temperature
         )
-        logits_11 = logits_11 - tf.cast(masks * LARGE_NUM, logits_11.dtype)
+        logits_11 = logits_11 - ops.cast(masks * LARGE_NUM, logits_11.dtype)
         logits_22 = (
-            tf.matmul(projections_2, projections_2, transpose_b=True)
+            ops.matmul(projections_2, ops.transpose(projections_2))
             / self.temperature
         )
-        logits_22 = logits_22 - tf.cast(masks * LARGE_NUM, logits_22.dtype)
+        logits_22 = logits_22 - ops.cast(masks * LARGE_NUM, logits_22.dtype)
         logits_12 = (
-            tf.matmul(projections_1, projections_2, transpose_b=True)
+            ops.matmul(projections_1, ops.transpose(projections_2))
             / self.temperature
         )
         logits_21 = (
-            tf.matmul(projections_2, projections_1, transpose_b=True)
+            ops.matmul(projections_2, ops.transpose(projections_1))
             / self.temperature
         )
 
         loss_a = keras.losses.categorical_crossentropy(
-            labels, tf.concat([logits_12, logits_11], 1), from_logits=True
+            labels, ops.concatenate([logits_12, logits_11], 1), from_logits=True
         )
         loss_b = keras.losses.categorical_crossentropy(
-            labels, tf.concat([logits_21, logits_22], 1), from_logits=True
+            labels, ops.concatenate([logits_21, logits_22], 1), from_logits=True
         )
 
         return loss_a + loss_b

--- a/keras_cv/losses/simclr_loss_test.py
+++ b/keras_cv/losses/simclr_loss_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
 from keras_cv.losses.simclr_loss import SimCLRLoss
@@ -19,24 +20,16 @@ from keras_cv.losses.simclr_loss import SimCLRLoss
 
 class SimCLRLossTest(tf.test.TestCase):
     def test_output_shape(self):
-        projections_1 = tf.random.uniform(
-            shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
-        )
-        projections_2 = tf.random.uniform(
-            shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
-        )
+        projections_1 = np.random.uniform(size=(10, 128), low=0, high=10)
+        projections_2 = np.random.uniform(size=(10, 128), low=0, high=10)
 
         simclr_loss = SimCLRLoss(temperature=1)
 
         self.assertAllEqual(simclr_loss(projections_1, projections_2).shape, ())
 
     def test_output_shape_reduction_none(self):
-        projections_1 = tf.random.uniform(
-            shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
-        )
-        projections_2 = tf.random.uniform(
-            shape=(10, 128), minval=0, maxval=10, dtype=tf.float32
-        )
+        projections_1 = np.random.uniform(size=(10, 128), low=0, high=10)
+        projections_2 = np.random.uniform(size=(10, 128), low=0, high=10)
 
         simclr_loss = SimCLRLoss(temperature=1, reduction="none")
 
@@ -45,17 +38,21 @@ class SimCLRLossTest(tf.test.TestCase):
         )
 
     def test_output_value(self):
-        projections_1 = [
-            [1.0, 2.0, 3.0, 4.0],
-            [2.0, 3.0, 4.0, 5.0],
-            [3.0, 4.0, 5.0, 6.0],
-        ]
+        projections_1 = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0],
+                [2.0, 3.0, 4.0, 5.0],
+                [3.0, 4.0, 5.0, 6.0],
+            ]
+        )
 
-        projections_2 = [
-            [6.0, 5.0, 4.0, 3.0],
-            [5.0, 4.0, 3.0, 2.0],
-            [4.0, 3.0, 2.0, 1.0],
-        ]
+        projections_2 = np.array(
+            [
+                [6.0, 5.0, 4.0, 3.0],
+                [5.0, 4.0, 3.0, 2.0],
+                [4.0, 3.0, 2.0, 1.0],
+            ]
+        )
 
         simclr_loss = SimCLRLoss(temperature=0.5)
         self.assertAllClose(simclr_loss(projections_1, projections_2), 3.566689)

--- a/keras_cv/losses/smooth_l1.py
+++ b/keras_cv/losses/smooth_l1.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-from tensorflow import keras
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 
 # --- Implementing Smooth L1 loss and Focal Loss as keras custom losses ---
@@ -36,14 +36,14 @@ class SmoothL1Loss(keras.losses.Loss):
 
     def call(self, y_true, y_pred):
         difference = y_true - y_pred
-        absolute_difference = tf.abs(difference)
+        absolute_difference = ops.abs(difference)
         squared_difference = difference**2
-        loss = tf.where(
+        loss = ops.where(
             absolute_difference < self.l1_cutoff,
             0.5 * squared_difference,
             absolute_difference - 0.5,
         )
-        return keras.backend.mean(loss, axis=-1)
+        return ops.mean(loss, axis=-1)
 
     def get_config(self):
         config = {

--- a/keras_cv/losses/smooth_l1_test.py
+++ b/keras_cv/losses/smooth_l1_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 from absl.testing import parameterized
 
@@ -27,7 +28,7 @@ class SmoothL1LossTest(tf.test.TestCase, parameterized.TestCase):
     def test_proper_output_shapes(self, reduction, target_size):
         loss = keras_cv.losses.SmoothL1Loss(l1_cutoff=0.5, reduction=reduction)
         result = loss(
-            y_true=tf.random.uniform((20, 300)),
-            y_pred=tf.random.uniform((20, 300)),
+            y_true=np.random.uniform(size=(20, 300)),
+            y_pred=np.random.uniform(size=(20, 300)),
         )
         self.assertEqual(result.shape, target_size)

--- a/keras_cv/metrics/coco/pycoco_wrapper.py
+++ b/keras_cv/metrics/coco/pycoco_wrapper.py
@@ -14,7 +14,6 @@
 import copy
 
 import numpy as np
-import tensorflow as tf
 
 try:
     from pycocotools.coco import COCO
@@ -193,23 +192,16 @@ def _convert_groundtruths_to_coco_dataset(groundtruths, label_map=None):
     return gt_dataset
 
 
-def _convert_to_numpy(groundtruths, predictions):
+def _concat_numpy(groundtruths, predictions):
     """Converts tensors to numpy arrays."""
-    labels = tf.nest.map_structure(lambda x: x.numpy(), groundtruths)
     numpy_groundtruths = {}
-    for key, val in labels.items():
+    for key, val in groundtruths.items():
         if isinstance(val, tuple):
             val = np.concatenate(val)
         numpy_groundtruths[key] = val
 
-    def _to_numpy(x):
-        if isinstance(x, np.ndarray):
-            return x
-        return x.numpy()
-
-    outputs = tf.nest.map_structure(lambda x: _to_numpy(x), predictions)
     numpy_predictions = {}
-    for key, val in outputs.items():
+    for key, val in predictions.items():
         if isinstance(val, tuple):
             val = np.concatenate(val)
         numpy_predictions[key] = val
@@ -220,7 +212,7 @@ def _convert_to_numpy(groundtruths, predictions):
 def compute_pycoco_metrics(groundtruths, predictions):
     assert_pycocotools_installed("compute_pycoco_metrics")
 
-    groundtruths, predictions = _convert_to_numpy(groundtruths, predictions)
+    groundtruths, predictions = _concat_numpy(groundtruths, predictions)
 
     gt_dataset = _convert_groundtruths_to_coco_dataset(groundtruths)
     coco_gt = PyCOCOWrapper(gt_dataset=gt_dataset)

--- a/keras_cv/metrics/object_detection/box_coco_metrics.py
+++ b/keras_cv/metrics/object_detection/box_coco_metrics.py
@@ -15,11 +15,13 @@ import os
 import sys
 import types
 
+import numpy as np
 import tensorflow as tf
 import tensorflow.keras as keras
 
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import ops
 
 
 class HidePrints:
@@ -267,6 +269,9 @@ class BoxCOCOMetrics(keras.metrics.Metric):
 
 
 def compute_pycocotools_metric(y_true, y_pred, bounding_box_format):
+    y_true = bounding_box.to_dense(y_true)
+    y_pred = bounding_box.to_dense(y_pred)
+
     box_pred = y_pred["boxes"]
     cls_pred = y_pred["classes"]
     confidence_pred = y_pred["confidence"]
@@ -283,26 +288,24 @@ def compute_pycocotools_metric(y_true, y_pred, bounding_box_format):
 
     total_images = gt_boxes.shape[0]
 
-    source_ids = tf.strings.as_string(
-        tf.linspace(1, total_images, total_images), precision=0
-    )
+    source_ids = np.char.mod("%d", np.linspace(1, total_images, total_images))
 
     ground_truth = {}
     ground_truth["source_id"] = [source_ids]
 
     ground_truth["num_detections"] = [
-        tf.math.reduce_sum(tf.cast(y_true["classes"] != -1, tf.int32), axis=-1)
+        ops.sum(ops.cast(y_true["classes"] >= 0, "int32"), axis=-1)
     ]
-    ground_truth["boxes"] = [gt_boxes]
-    ground_truth["classes"] = [gt_classes]
+    ground_truth["boxes"] = [ops.convert_to_numpy(gt_boxes)]
+    ground_truth["classes"] = [ops.convert_to_numpy(gt_classes)]
 
     predictions = {}
     predictions["source_id"] = [source_ids]
-    predictions["detection_boxes"] = [box_pred]
-    predictions["detection_classes"] = [cls_pred]
-    predictions["detection_scores"] = [confidence_pred]
+    predictions["detection_boxes"] = [ops.convert_to_numpy(box_pred)]
+    predictions["detection_classes"] = [ops.convert_to_numpy(cls_pred)]
+    predictions["detection_scores"] = [ops.convert_to_numpy(confidence_pred)]
     predictions["num_detections"] = [
-        tf.math.reduce_sum(tf.cast(y_pred["classes"] != -1, tf.int32), axis=-1)
+        ops.sum(ops.cast(confidence_pred > 0, "int32"), axis=-1)
     ]
 
     return keras_cv.metrics.coco.compute_pycoco_metrics(

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -15,8 +15,7 @@
 
 import os
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 

--- a/keras_cv/models/backbones/backbone_presets.py
+++ b/keras_cv/models/backbones/backbone_presets.py
@@ -22,6 +22,7 @@ from keras_cv.models.backbones.efficientnet_v2 import (
 from keras_cv.models.backbones.mobilenet_v3 import mobilenet_v3_backbone_presets
 from keras_cv.models.backbones.resnet_v1 import resnet_v1_backbone_presets
 from keras_cv.models.backbones.resnet_v2 import resnet_v2_backbone_presets
+from keras_cv.models.object_detection.yolo_v8 import yolo_v8_backbone_presets
 
 backbone_presets_no_weights = {
     **resnet_v1_backbone_presets.backbone_presets_no_weights,
@@ -30,6 +31,7 @@ backbone_presets_no_weights = {
     **csp_darknet_backbone_presets.backbone_presets_no_weights,
     **efficientnet_v2_backbone_presets.backbone_presets_no_weights,
     **densenet_backbone_presets.backbone_presets_no_weights,
+    **yolo_v8_backbone_presets.backbone_presets_no_weights,
 }
 
 backbone_presets_with_weights = {
@@ -39,6 +41,7 @@ backbone_presets_with_weights = {
     **csp_darknet_backbone_presets.backbone_presets_with_weights,
     **efficientnet_v2_backbone_presets.backbone_presets_with_weights,
     **densenet_backbone_presets.backbone_presets_with_weights,
+    **yolo_v8_backbone_presets.backbone_presets_with_weights,
 }
 
 backbone_presets = {

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone.py
@@ -15,9 +15,7 @@
 """CSPDarkNet models for KerasCV. """
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.csp_darknet.csp_darknet_backbone_presets import (
@@ -42,7 +40,7 @@ from keras_cv.models.backbones.csp_darknet.csp_darknet_utils import (
 from keras_cv.utils.python_utils import classproperty
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class CSPDarkNetBackbone(Backbone):
     """This class represents the CSPDarkNet architecture.
 
@@ -64,8 +62,8 @@ class CSPDarkNetBackbone(Backbone):
         use_depthwise: bool, whether a `DarknetConvBlockDepthwise` should be
             used over a `DarknetConvBlock`, defaults to False.
         input_shape: optional shape tuple, defaults to (None, None, 3).
-        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
-            to use as image input for the model.
+        input_tensor: optional Keras tensor (i.e. output of
+            `keras.layers.Input()`) to use as image input for the model.
 
     Returns:
         A `keras.Model` instance.
@@ -111,7 +109,7 @@ class CSPDarkNetBackbone(Backbone):
 
         x = inputs
         if include_rescaling:
-            x = layers.Rescaling(1 / 255.0)(x)
+            x = keras.layers.Rescaling(1 / 255.0)(x)
 
         # stem
         x = Focus(name="stem_focus")(x)
@@ -144,7 +142,9 @@ class CSPDarkNetBackbone(Backbone):
                 residual=(index != len(stackwise_depth) - 1),
                 name=f"dark{index + 2}_csp",
             )(x)
-            pyramid_level_inputs[f"P{index + 2}"] = x.node.layer.name
+            pyramid_level_inputs[f"P{index + 2}"] = utils.get_tensor_input_name(
+                x
+            )
 
         super().__init__(inputs=inputs, outputs=x, **kwargs)
         self.pyramid_level_inputs = pyramid_level_inputs
@@ -195,8 +195,8 @@ ALIAS_DOCSTRING = """CSPDarkNetBackbone model with {stackwise_channels} channels
     Args:
         include_rescaling: bool, whether or not to rescale the inputs. If set to
             True, inputs will be passed through a `Rescaling(1/255.0)` layer.
-        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
-            to use as image input for the model.
+        input_tensor: optional Keras tensor (i.e. output of
+            `keras.layers.Input()`) to use as image input for the model.
         input_shape: optional shape tuple, defaults to (None, None, 3).
 
     Examples:

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_presets_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_presets_test.py
@@ -17,6 +17,7 @@ import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import ops
 from keras_cv.models.backbones.csp_darknet import csp_darknet_backbone
 
 
@@ -52,7 +53,10 @@ class CSPDarkNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
         expected = [-0.16216235, 0.7333651, 0.4312072, 0.738807, -0.2515305]
         # Keep a high tolerance, so we are robust to different hardware.
         self.assertAllClose(
-            outputs[0, 0, 0, :5], expected, atol=0.01, rtol=0.01
+            ops.convert_to_numpy(outputs[0, 0, 0, :5]),
+            expected,
+            atol=0.01,
+            rtol=0.01,
         )
 
     def test_applications_model_output(self):

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_test.py
@@ -14,18 +14,20 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.csp_darknet import csp_darknet_backbone
 from keras_cv.utils.train import get_feature_extractor
 
 
 class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_valid_call(self):
         model = csp_darknet_backbone.CSPDarkNetBackbone(
@@ -47,20 +49,18 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = csp_darknet_backbone.CSPDarkNetBackbone(
             stackwise_channels=[48, 96, 192, 384],
             stackwise_depth=[1, 3, 3, 1],
             include_rescaling=True,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "csp_darknet_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -70,18 +70,19 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = csp_darknet_backbone.CSPDarkNetLBackbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "csp_darknet_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -92,7 +93,10 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
     def test_feature_pyramid_inputs(self):
         model = csp_darknet_backbone.CSPDarkNetLBackbone()
@@ -102,25 +106,25 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.keys(),
         )
         input_size = 256
-        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
+        inputs = keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
         levels = ["P2", "P3", "P4", "P5"]
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**2, input_size // 2**2, 128],
+            (None, input_size // 2**2, input_size // 2**2, 128),
         )
         self.assertEquals(
             outputs["P3"].shape,
-            [None, input_size // 2**3, input_size // 2**3, 256],
+            (None, input_size // 2**3, input_size // 2**3, 256),
         )
         self.assertEquals(
             outputs["P4"].shape,
-            [None, input_size // 2**4, input_size // 2**4, 512],
+            (None, input_size // 2**4, input_size // 2**4, 512),
         )
         self.assertEquals(
             outputs["P5"].shape,
-            [None, input_size // 2**5, input_size // 2**5, 1024],
+            (None, input_size // 2**5, input_size // 2**5, 1024),
         )
 
     @parameterized.named_parameters(
@@ -132,7 +136,7 @@ class CSPDarkNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     )
     def test_specific_arch_forward_pass(self, arch_class):
         backbone = arch_class()
-        backbone(tf.random.uniform(shape=[2, 256, 256, 3]))
+        backbone(np.random.uniform(size=(2, 256, 256, 3)))
 
     @parameterized.named_parameters(
         ("Tiny", csp_darknet_backbone.CSPDarkNetTinyBackbone),

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_utils.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_utils.py
@@ -18,10 +18,7 @@ Reference:
   - [YoloV3 implementation](https://github.com/ultralytics/yolov3)
 """
 
-import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
+from keras_cv.backend import keras
 
 
 def DarknetConvBlock(
@@ -46,10 +43,10 @@ def DarknetConvBlock(
     """
 
     if name is None:
-        name = f"conv_block{backend.get_uid('conv_block')}"
+        name = f"conv_block{keras.backend.get_uid('conv_block')}"
 
     model_layers = [
-        layers.Conv2D(
+        keras.layers.Conv2D(
             filters,
             kernel_size,
             strides,
@@ -57,17 +54,19 @@ def DarknetConvBlock(
             use_bias=use_bias,
             name=name + "_conv",
         ),
-        layers.BatchNormalization(name=name + "_bn"),
+        keras.layers.BatchNormalization(name=name + "_bn"),
     ]
 
     if activation == "silu":
-        model_layers.append(layers.Lambda(lambda x: keras.activations.swish(x)))
+        model_layers.append(
+            keras.layers.Lambda(lambda x: keras.activations.silu(x))
+        )
     elif activation == "relu":
-        model_layers.append(layers.ReLU())
+        model_layers.append(keras.layers.ReLU())
     elif activation == "leaky_relu":
-        model_layers.append(layers.LeakyReLU(0.1))
+        model_layers.append(keras.layers.LeakyReLU(0.1))
 
-    return keras.Sequential(model_layers, name=None)
+    return keras.Sequential(model_layers, name=name)
 
 
 def ResidualBlocks(filters, num_blocks, name=None):
@@ -84,7 +83,7 @@ def ResidualBlocks(filters, num_blocks, name=None):
     """
 
     if name is None:
-        name = f"residual_block{backend.get_uid('residual_block')}"
+        name = f"residual_block{keras.backend.get_uid('residual_block')}"
 
     def apply(x):
         x = DarknetConvBlock(
@@ -114,9 +113,9 @@ def ResidualBlocks(filters, num_blocks, name=None):
             )(x)
 
             if i == num_blocks:
-                x = layers.Add(name=f"{name}_out")([residual, x])
+                x = keras.layers.Add(name=f"{name}_out")([residual, x])
             else:
-                x = layers.Add(name=f"{name}_add_{i}")([residual, x])
+                x = keras.layers.Add(name=f"{name}_add_{i}")([residual, x])
 
         return x
 
@@ -149,7 +148,7 @@ def SpatialPyramidPoolingBottleneck(
         SpatialPyramidPoolingBottleneck.
     """
     if name is None:
-        name = f"spp{backend.get_uid('spp')}"
+        name = f"spp{keras.backend.get_uid('spp')}"
 
     if hidden_filters is None:
         hidden_filters = filters
@@ -166,7 +165,7 @@ def SpatialPyramidPoolingBottleneck(
 
         for kernel_size in kernel_sizes:
             x.append(
-                layers.MaxPooling2D(
+                keras.layers.MaxPooling2D(
                     kernel_size,
                     strides=1,
                     padding="same",
@@ -174,7 +173,7 @@ def SpatialPyramidPoolingBottleneck(
                 )(x[0])
             )
 
-        x = layers.Concatenate(name=f"{name}_concat")(x)
+        x = keras.layers.Concatenate(name=f"{name}_concat")(x)
         x = DarknetConvBlock(
             filters,
             kernel_size=1,
@@ -209,21 +208,23 @@ def DarknetConvBlockDepthwise(
     """
 
     if name is None:
-        name = f"conv_block{backend.get_uid('conv_block')}"
+        name = f"conv_block{keras.backend.get_uid('conv_block')}"
 
     model_layers = [
-        layers.DepthwiseConv2D(
+        keras.layers.DepthwiseConv2D(
             kernel_size, strides, padding="same", use_bias=False
         ),
-        layers.BatchNormalization(),
+        keras.layers.BatchNormalization(),
     ]
 
     if activation == "silu":
-        model_layers.append(layers.Lambda(lambda x: keras.activations.swish(x)))
+        model_layers.append(
+            keras.layers.Lambda(lambda x: keras.activations.swish(x))
+        )
     elif activation == "relu":
-        model_layers.append(layers.ReLU())
+        model_layers.append(keras.layers.ReLU())
     elif activation == "leaky_relu":
-        model_layers.append(layers.LeakyReLU(0.1))
+        model_layers.append(keras.layers.LeakyReLU(0.1))
 
     model_layers.append(
         DarknetConvBlock(
@@ -234,8 +235,8 @@ def DarknetConvBlockDepthwise(
     return keras.Sequential(model_layers, name=name)
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class CrossStagePartial(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class CrossStagePartial(keras.layers.Layer):
     """A block used in Cross Stage Partial Darknet.
 
     Args:
@@ -309,8 +310,8 @@ class CrossStagePartial(layers.Layer):
                 )
             )
 
-        self.add = layers.Add()
-        self.concatenate = layers.Concatenate()
+        self.add = keras.layers.Add()
+        self.concatenate = keras.layers.Concatenate()
 
         self.darknet_conv3 = DarknetConvBlock(
             filters, kernel_size=1, strides=1, activation=activation
@@ -360,17 +361,13 @@ def Focus(name=None):
     """  # noqa: E501
 
     def apply(x):
-        return layers.Lambda(
-            lambda x: tf.concat(
-                [
-                    x[..., ::2, ::2, :],
-                    x[..., 1::2, ::2, :],
-                    x[..., ::2, 1::2, :],
-                    x[..., 1::2, 1::2, :],
-                ],
-                axis=-1,
-            ),
-            name=name,
-        )(x)
+        return keras.layers.Concatenate(name=name)(
+            [
+                x[..., ::2, ::2, :],
+                x[..., 1::2, ::2, :],
+                x[..., ::2, 1::2, :],
+                x[..., 1::2, 1::2, :],
+            ],
+        )
 
     return apply

--- a/keras_cv/models/backbones/densenet/densenet_backbone.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone.py
@@ -21,10 +21,7 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.densenet.densenet_backbone_presets import (
@@ -39,7 +36,7 @@ BN_AXIS = 3
 BN_EPSILON = 1.001e-5
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class DenseNetBackbone(Backbone):
     """Instantiates the DenseNet architecture.
 
@@ -50,8 +47,8 @@ class DenseNetBackbone(Backbone):
             to `True`, inputs will be passed through a `Rescaling(1/255.0)`
             layer.
         input_shape: optional shape tuple, defaults to (None, None, 3).
-        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
-            to use as image input for the model.
+        input_tensor: optional Keras tensor (i.e. output of
+            `keras.layers.Input()`) to use as image input for the model.
         compression_ratio: float, compression rate at transition layers.
         growth_rate: int, number of filters added by each dense block.
 
@@ -87,16 +84,18 @@ class DenseNetBackbone(Backbone):
 
         x = inputs
         if include_rescaling:
-            x = layers.Rescaling(1 / 255.0)(x)
+            x = keras.layers.Rescaling(1 / 255.0)(x)
 
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             64, 7, strides=2, use_bias=False, padding="same", name="conv1/conv"
         )(x)
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="conv1/bn"
         )(x)
-        x = layers.Activation("relu", name="conv1/relu")(x)
-        x = layers.MaxPooling2D(3, strides=2, padding="same", name="pool1")(x)
+        x = keras.layers.Activation("relu", name="conv1/relu")(x)
+        x = keras.layers.MaxPooling2D(
+            3, strides=2, padding="same", name="pool1"
+        )(x)
 
         pyramid_level_inputs = {}
         for stack_index in range(len(stackwise_num_repeats) - 1):
@@ -107,7 +106,7 @@ class DenseNetBackbone(Backbone):
                 growth_rate,
                 name=f"conv{index}",
             )
-            pyramid_level_inputs[f"P{index}"] = x.node.layer.name
+            pyramid_level_inputs[f"P{index}"] = utils.get_tensor_input_name(x)
             x = apply_transition_block(
                 x, compression_ratio, name=f"pool{index}"
             )
@@ -118,14 +117,14 @@ class DenseNetBackbone(Backbone):
             growth_rate,
             name=f"conv{len(stackwise_num_repeats) + 1}",
         )
+
         pyramid_level_inputs[
             f"P{len(stackwise_num_repeats) + 1}"
-        ] = x.node.layer.name
-
-        x = layers.BatchNormalization(
+        ] = utils.get_tensor_input_name(x)
+        x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="bn"
         )(x)
-        x = layers.Activation("relu", name="relu")(x)
+        x = keras.layers.Activation("relu", name="relu")(x)
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)
@@ -174,7 +173,7 @@ def apply_dense_block(x, num_repeats, growth_rate, name=None):
       name: string, block label.
     """
     if name is None:
-        name = f"dense_block_{backend.get_uid('dense_block')}"
+        name = f"dense_block_{keras.backend.get_uid('dense_block')}"
 
     for i in range(num_repeats):
         x = apply_conv_block(x, growth_rate, name=f"{name}_block_{i}")
@@ -190,19 +189,19 @@ def apply_transition_block(x, compression_ratio, name=None):
       name: string, block label.
     """
     if name is None:
-        name = f"transition_block_{backend.get_uid('transition_block')}"
+        name = f"transition_block_{keras.backend.get_uid('transition_block')}"
 
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=f"{name}_bn"
     )(x)
-    x = layers.Activation("relu", name=f"{name}_relu")(x)
-    x = layers.Conv2D(
-        int(backend.int_shape(x)[BN_AXIS] * compression_ratio),
+    x = keras.layers.Activation("relu", name=f"{name}_relu")(x)
+    x = keras.layers.Conv2D(
+        int(x.shape[BN_AXIS] * compression_ratio),
         1,
         use_bias=False,
         name=f"{name}_conv",
     )(x)
-    x = layers.AveragePooling2D(2, strides=2, name=f"{name}_pool")(x)
+    x = keras.layers.AveragePooling2D(2, strides=2, name=f"{name}_pool")(x)
     return x
 
 
@@ -215,26 +214,28 @@ def apply_conv_block(x, growth_rate, name=None):
       name: string, block label.
     """
     if name is None:
-        name = f"conv_block_{backend.get_uid('conv_block')}"
+        name = f"conv_block_{keras.backend.get_uid('conv_block')}"
 
     shortcut = x
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=f"{name}_0_bn"
     )(x)
-    x = layers.Activation("relu", name=f"{name}_0_relu")(x)
-    x = layers.Conv2D(
+    x = keras.layers.Activation("relu", name=f"{name}_0_relu")(x)
+    x = keras.layers.Conv2D(
         4 * growth_rate, 1, use_bias=False, name=f"{name}_1_conv"
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=f"{name}_1_bn"
     )(x)
-    x = layers.Activation("relu", name=f"{name}_1_relu")(x)
-    x = layers.Conv2D(
+    x = keras.layers.Activation("relu", name=f"{name}_1_relu")(x)
+    x = keras.layers.Conv2D(
         growth_rate,
         3,
         padding="same",
         use_bias=False,
         name=f"{name}_2_conv",
     )(x)
-    x = layers.Concatenate(axis=BN_AXIS, name=f"{name}_concat")([shortcut, x])
+    x = keras.layers.Concatenate(axis=BN_AXIS, name=f"{name}_concat")(
+        [shortcut, x]
+    )
     return x

--- a/keras_cv/models/backbones/densenet/densenet_backbone_presets_test.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_presets_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import ops
 from keras_cv.models.backbones.densenet.densenet_aliases import (
     DenseNet121Backbone,
 )
@@ -34,7 +36,7 @@ class DenseNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_backbone_output(self):
         model = DenseNetBackbone.from_preset("densenet121")
@@ -49,11 +51,14 @@ class DenseNetPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
         # We should only update these numbers if we are updating a weights
         # file, or have found a discrepancy with the upstream source.
 
-        outputs = model(tf.ones(shape=(1, 512, 512, 3)))
+        outputs = model(np.ones(shape=(1, 512, 512, 3)))
         expected = [0.0, 0.0, 0.09920305, 0.0, 0.0]
         # Keep a high tolerance, so we are robust to different hardware.
         self.assertAllClose(
-            outputs[0, 0, 0, :5], expected, atol=0.01, rtol=0.01
+            ops.convert_to_numpy(outputs[0, 0, 0, :5]),
+            expected,
+            atol=0.01,
+            rtol=0.01,
         )
 
     def test_applications_model_output(self):
@@ -90,7 +95,7 @@ class DenseNetPresetFullTest(tf.test.TestCase, parameterized.TestCase):
     """
 
     def test_load_densenet(self):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         for preset in DenseNetBackbone.presets:
             model = DenseNetBackbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/densenet/densenet_backbone_test.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_test.py
@@ -14,11 +14,13 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.densenet.densenet_aliases import (
     DenseNet121Backbone,
 )
@@ -30,7 +32,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_valid_call(self):
         model = DenseNetBackbone(
@@ -50,19 +52,15 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = DenseNetBackbone(
             stackwise_num_repeats=[6, 12, 24, 16],
             include_rescaling=False,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(self.get_temp_dir(), "densenet_backbone.keras")
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -70,18 +68,19 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = DenseNet121Backbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "densenet_alias_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -90,7 +89,10 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
     def test_feature_pyramid_inputs(self):
         model = DenseNet121Backbone()
@@ -100,25 +102,25 @@ class DenseNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.keys(),
         )
         input_size = 256
-        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
+        inputs = keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
         levels = ["P2", "P3", "P4", "P5"]
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**2, input_size // 2**2, 256],
+            (None, input_size // 2**2, input_size // 2**2, 256),
         )
         self.assertEquals(
             outputs["P3"].shape,
-            [None, input_size // 2**3, input_size // 2**3, 512],
+            (None, input_size // 2**3, input_size // 2**3, 512),
         )
         self.assertEquals(
             outputs["P4"].shape,
-            [None, input_size // 2**4, input_size // 2**4, 1024],
+            (None, input_size // 2**4, input_size // 2**4, 1024),
         )
         self.assertEquals(
             outputs["P5"].shape,
-            [None, input_size // 2**5, input_size // 2**5, 1024],
+            (None, input_size // 2**5, input_size // 2**5, 1024),
         )
 
     @parameterized.named_parameters(

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
@@ -14,9 +14,7 @@
 import copy
 import math
 
-from tensorflow import keras
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.layers import FusedMBConvBlock
 from keras_cv.layers import MBConvBlock
 from keras_cv.models import utils
@@ -30,7 +28,7 @@ from keras_cv.models.backbones.efficientnet_v2.efficientnet_v2_backbone_presets 
 from keras_cv.utils.python_utils import classproperty
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class EfficientNetV2Backbone(Backbone):
     """Instantiates the EfficientNetV2 architecture.
 
@@ -67,7 +65,7 @@ class EfficientNetV2Backbone(Backbone):
         min_depth: integer, minimum number of filters.
         activation: activation function to use between each convolutional layer.
         input_shape: optional shape tuple, defaults to (None, None, 3).
-        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+        input_tensor: optional Keras tensor (i.e. output of `keras.layers.Input()`)
             to use as image input for the model.
 
     Usage:
@@ -133,7 +131,7 @@ class EfficientNetV2Backbone(Backbone):
         x = img_input
 
         if include_rescaling:
-            x = layers.Rescaling(scale=1 / 255.0)(x)
+            x = keras.layers.Rescaling(scale=1 / 255.0)(x)
 
         # Build stem
         stem_filters = round_filters(
@@ -142,7 +140,7 @@ class EfficientNetV2Backbone(Backbone):
             min_depth=min_depth,
             depth_divisor=depth_divisor,
         )
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             filters=stem_filters,
             kernel_size=3,
             strides=2,
@@ -151,11 +149,11 @@ class EfficientNetV2Backbone(Backbone):
             use_bias=False,
             name="stem_conv",
         )(x)
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             momentum=0.9,
             name="stem_bn",
         )(x)
-        x = layers.Activation(activation, name="stem_activation")(x)
+        x = keras.layers.Activation(activation, name="stem_activation")(x)
 
         # Build blocks
         block_id = 0
@@ -198,7 +196,7 @@ class EfficientNetV2Backbone(Backbone):
                     input_filters = output_filters
 
                 if strides != 1:
-                    pyramid_level_inputs.append(x.node.layer.name)
+                    pyramid_level_inputs.append(utils.get_tensor_input_name(x))
 
                 # 97 is the start of the lowercase alphabet.
                 letter_identifier = chr(j + 97)
@@ -227,7 +225,7 @@ class EfficientNetV2Backbone(Backbone):
             depth_divisor=depth_divisor,
         )
 
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             filters=top_filters,
             kernel_size=1,
             strides=1,
@@ -237,13 +235,15 @@ class EfficientNetV2Backbone(Backbone):
             use_bias=False,
             name="top_conv",
         )(x)
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             momentum=0.9,
             name="top_bn",
         )(x)
-        x = layers.Activation(activation=activation, name="top_activation")(x)
+        x = keras.layers.Activation(
+            activation=activation, name="top_activation"
+        )(x)
 
-        pyramid_level_inputs.append(x.node.layer.name)
+        pyramid_level_inputs.append(utils.get_tensor_input_name(x))
 
         # Create model.
         super().__init__(inputs=img_input, outputs=x, **kwargs)

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import keras
 from keras_cv.models.backbones.efficientnet_v2.efficientnet_v2_aliases import (
     EfficientNetV2SBackbone,
 )
@@ -39,7 +41,7 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
         *[(preset, preset) for preset in EfficientNetV2Backbone.presets]
     )
     def test_load_efficientnet(self, preset):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         model = EfficientNetV2Backbone.from_preset(preset)
         model(input_data)
 
@@ -51,9 +53,9 @@ class EfficientNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
         levels = ["P3", "P4"]
         layer_names = [model.pyramid_level_inputs[level] for level in levels]
         backbone_model = get_feature_extractor(model, layer_names, levels)
-        inputs = tf.keras.Input(shape=[256, 256, 3])
+        inputs = keras.Input(shape=[256, 256, 3])
         outputs = backbone_model(inputs)
         self.assertLen(outputs, 2)
         self.assertEquals(list(outputs.keys()), levels)
-        self.assertEquals(outputs["P3"].shape[:3], [None, 32, 32])
-        self.assertEquals(outputs["P4"].shape[:3], [None, 16, 16])
+        self.assertEquals(outputs["P3"].shape[:3], (None, 32, 32))
+        self.assertEquals(outputs["P4"].shape[:3], (None, 16, 16))

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_test.py
@@ -14,11 +14,13 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.efficientnet_v2.efficientnet_v2_aliases import (
     EfficientNetV2SBackbone,
 )
@@ -30,7 +32,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     def test_valid_call(self):
         model = EfficientNetV2Backbone(
@@ -82,12 +84,8 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = EfficientNetV2Backbone(
             stackwise_kernel_sizes=[3, 3, 3, 3, 3, 3],
             stackwise_num_repeats=[2, 4, 4, 6, 9, 15],
@@ -109,8 +107,10 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=True,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "efficientnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -118,18 +118,19 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = EfficientNetV2SBackbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "efficientnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -138,7 +139,10 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
     def test_feature_pyramid_inputs(self):
         model = EfficientNetV2SBackbone()
@@ -148,29 +152,29 @@ class EfficientNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.keys(),
         )
         input_size = 256
-        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
+        inputs = keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
         levels = ["P1", "P2", "P3", "P4", "P5"]
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P1"].shape,
-            [None, input_size // 2**1, input_size // 2**1, 24],
+            (None, input_size // 2**1, input_size // 2**1, 24),
         )
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**2, input_size // 2**2, 48],
+            (None, input_size // 2**2, input_size // 2**2, 48),
         )
         self.assertEquals(
             outputs["P3"].shape,
-            [None, input_size // 2**3, input_size // 2**3, 64],
+            (None, input_size // 2**3, input_size // 2**3, 64),
         )
         self.assertEquals(
             outputs["P4"].shape,
-            [None, input_size // 2**4, input_size // 2**4, 160],
+            (None, input_size // 2**4, input_size // 2**4, 160),
         )
         self.assertEquals(
             outputs["P5"].shape,
-            [None, input_size // 2**5, input_size // 2**5, 1280],
+            (None, input_size // 2**5, input_size // 2**5, 1280),
         )
 
     @parameterized.named_parameters(

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_presets_test.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_presets_test.py
@@ -14,10 +14,12 @@
 
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import ops
 from keras_cv.models.backbones.mobilenet_v3.mobilenet_v3_backbone import (
     MobileNetV3Backbone,
 )
@@ -32,7 +34,7 @@ class MobileNetV3PresetSmokeTest(tf.test.TestCase):
     """  # noqa: E501
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     def test_backbone_output(self):
         model = MobileNetV3Backbone.from_preset("mobilenet_v3_large_imagenet")
@@ -46,7 +48,9 @@ class MobileNetV3PresetSmokeTest(tf.test.TestCase):
         outputs = outputs[0, 0, 0, :5]
         expected = [0.27, 0.01, 0.29, 0.08, -0.12]
         # Keep a high tolerance, so we are robust to different hardware.
-        self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(
+            ops.convert_to_numpy(outputs), expected, atol=0.01, rtol=0.01
+        )
 
 
 @pytest.mark.extra_large
@@ -59,7 +63,7 @@ class MobileNetV3PresetFullTest(tf.test.TestCase, parameterized.TestCase):
     """  # noqa: E501
 
     def test_load_mobilenet_v3(self):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         for preset in MobileNetV3Backbone.presets:
             model = MobileNetV3Backbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone.py
@@ -20,10 +20,7 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.resnet_v1.resnet_v1_backbone_presets import (
@@ -38,7 +35,7 @@ BN_AXIS = 3
 BN_EPSILON = 1.001e-5
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class ResNetBackbone(Backbone):
     """Instantiates the ResNet architecture.
 
@@ -104,18 +101,18 @@ class ResNetBackbone(Backbone):
         x = inputs
 
         if include_rescaling:
-            x = layers.Rescaling(1 / 255.0)(x)
+            x = keras.layers.Rescaling(1 / 255.0)(x)
 
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             64, 7, strides=2, use_bias=False, padding="same", name="conv1_conv"
         )(x)
 
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="conv1_bn"
         )(x)
-        x = layers.Activation("relu", name="conv1_relu")(x)
+        x = keras.layers.Activation("relu", name="conv1_relu")(x)
 
-        x = layers.MaxPooling2D(
+        x = keras.layers.MaxPooling2D(
             3, strides=2, padding="same", name="pool1_pool"
         )(x)
 
@@ -132,7 +129,9 @@ class ResNetBackbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[f"P{stack_index + 2}"] = x.node.layer.name
+            pyramid_level_inputs[
+                f"P{stack_index + 2}"
+            ] = utils.get_tensor_input_name(x)
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)
@@ -193,23 +192,23 @@ def apply_basic_block(
     """
 
     if name is None:
-        name = f"v1_basic_block_{backend.get_uid('v1_basic_block_')}"
+        name = f"v1_basic_block_{keras.backend.get_uid('v1_basic_block_')}"
 
     if conv_shortcut:
-        shortcut = layers.Conv2D(
+        shortcut = keras.layers.Conv2D(
             filters,
             1,
             strides=stride,
             use_bias=False,
             name=name + "_0_conv",
         )(x)
-        shortcut = layers.BatchNormalization(
+        shortcut = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_0_bn"
         )(shortcut)
     else:
         shortcut = x
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         padding="SAME",
@@ -217,24 +216,24 @@ def apply_basic_block(
         use_bias=False,
         name=name + "_1_conv",
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         padding="SAME",
         use_bias=False,
         name=name + "_2_conv",
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_2_bn"
     )(x)
 
-    x = layers.Add(name=name + "_add")([shortcut, x])
-    x = layers.Activation("relu", name=name + "_out")(x)
+    x = keras.layers.Add(name=name + "_add")([shortcut, x])
+    x = keras.layers.Activation("relu", name=name + "_out")(x)
     return x
 
 
@@ -257,49 +256,51 @@ def apply_block(
     """
 
     if name is None:
-        name = f"v1_block_{backend.get_uid('v1_block')}"
+        name = f"v1_block_{keras.backend.get_uid('v1_block')}"
 
     if conv_shortcut:
-        shortcut = layers.Conv2D(
+        shortcut = keras.layers.Conv2D(
             4 * filters,
             1,
             strides=stride,
             use_bias=False,
             name=name + "_0_conv",
         )(x)
-        shortcut = layers.BatchNormalization(
+        shortcut = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_0_bn"
         )(shortcut)
     else:
         shortcut = x
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters, 1, strides=stride, use_bias=False, name=name + "_1_conv"
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         padding="SAME",
         use_bias=False,
         name=name + "_2_conv",
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_2_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_2_relu")(x)
 
-    x = layers.Conv2D(4 * filters, 1, use_bias=False, name=name + "_3_conv")(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.Conv2D(
+        4 * filters, 1, use_bias=False, name=name + "_3_conv"
+    )(x)
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_3_bn"
     )(x)
 
-    x = layers.Add(name=name + "_add")([shortcut, x])
-    x = layers.Activation("relu", name=name + "_out")(x)
+    x = keras.layers.Add(name=name + "_add")([shortcut, x])
+    x = keras.layers.Activation("relu", name=name + "_out")(x)
     return x
 
 

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets_test.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 
+from keras_cv.backend import ops
 from keras_cv.models.backbones.resnet_v1.resnet_v1_aliases import (
     ResNet50Backbone,
 )
@@ -33,7 +35,7 @@ class ResNetPresetSmokeTest(tf.test.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_backbone_output(self):
         model = ResNetBackbone.from_preset("resnet50")
@@ -48,11 +50,14 @@ class ResNetPresetSmokeTest(tf.test.TestCase):
         # We should only update these numbers if we are updating a weights
         # file, or have found a discrepancy with the upstream source.
 
-        outputs = model(tf.ones(shape=(1, 512, 512, 3)))
+        outputs = model(np.ones(shape=(1, 512, 512, 3)))
         expected = [0.0, 0.0, 0.0, 0.05175382, 0.0]
         # Keep a high tolerance, so we are robust to different hardware.
         self.assertAllClose(
-            outputs[0, 0, 0, :5], expected, atol=0.01, rtol=0.01
+            ops.convert_to_numpy(outputs[0, 0, 0, :5]),
+            expected,
+            atol=0.01,
+            rtol=0.01,
         )
 
     def test_applications_model_output(self):
@@ -89,7 +94,7 @@ class ResNetPresetFullTest(tf.test.TestCase):
     """
 
     def test_load_resnet(self):
-        input_data = tf.ones(shape=(2, 224, 224, 3))
+        input_data = np.ones(shape=(2, 224, 224, 3))
         for preset in ResNetBackbone.presets:
             model = ResNetBackbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_test.py
@@ -14,11 +14,13 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.resnet_v1.resnet_v1_aliases import (
     ResNet18Backbone,
 )
@@ -39,7 +41,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     def test_valid_call(self):
         model = ResNetBackbone(
@@ -63,12 +65,8 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ResNetBackbone(
             stackwise_filters=[64, 128, 256, 512],
             stackwise_blocks=[2, 2, 2, 2],
@@ -76,28 +74,31 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v1_backbone.keras"
+        )
+        model.save(save_path)
+        restored_model = keras.saving.load_model(save_path)
 
         # Check we got the real object back.
         self.assertIsInstance(restored_model, ResNetBackbone)
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = ResNet50Backbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
-        restored_model = keras.models.load_model(save_path)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v1_alias_backbone.keras"
+        )
+        model.save(save_path)
+        restored_model = keras.saving.load_model(save_path)
 
         # Check we got the real object back.
         # Note that these aliases serialized as the base class
@@ -105,7 +106,10 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
     def test_feature_pyramid_inputs(self):
         model = ResNet50Backbone()
@@ -115,25 +119,25 @@ class ResNetBackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.keys(),
         )
         input_size = 256
-        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
+        inputs = keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
         levels = ["P2", "P3", "P4", "P5"]
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**2, input_size // 2**2, 256],
+            (None, input_size // 2**2, input_size // 2**2, 256),
         )
         self.assertEquals(
             outputs["P3"].shape,
-            [None, input_size // 2**3, input_size // 2**3, 512],
+            (None, input_size // 2**3, input_size // 2**3, 512),
         )
         self.assertEquals(
             outputs["P4"].shape,
-            [None, input_size // 2**4, input_size // 2**4, 1024],
+            (None, input_size // 2**4, input_size // 2**4, 1024),
         )
         self.assertEquals(
             outputs["P5"].shape,
-            [None, input_size // 2**5, input_size // 2**5, 2048],
+            (None, input_size // 2**5, input_size // 2**5, 2048),
         )
 
     @parameterized.named_parameters(

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone.py
@@ -19,10 +19,7 @@ Reference:
 
 import copy
 
-from tensorflow import keras
-from tensorflow.keras import backend
-from tensorflow.keras import layers
-
+from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.resnet_v2.resnet_v2_backbone_presets import (
@@ -37,7 +34,7 @@ BN_AXIS = 3
 BN_EPSILON = 1.001e-5
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class ResNetV2Backbone(Backbone):
     """Instantiates the ResNetV2 architecture.
 
@@ -107,9 +104,9 @@ class ResNetV2Backbone(Backbone):
         x = inputs
 
         if include_rescaling:
-            x = layers.Rescaling(1 / 255.0)(x)
+            x = keras.layers.Rescaling(1 / 255.0)(x)
 
-        x = layers.Conv2D(
+        x = keras.layers.Conv2D(
             64,
             7,
             strides=2,
@@ -118,7 +115,7 @@ class ResNetV2Backbone(Backbone):
             name="conv1_conv",
         )(x)
 
-        x = layers.MaxPooling2D(
+        x = keras.layers.MaxPooling2D(
             3, strides=2, padding="same", name="pool1_pool"
         )(x)
 
@@ -138,12 +135,14 @@ class ResNetV2Backbone(Backbone):
                 first_shortcut=(block_type == "block" or stack_index > 0),
                 name=f"v2_stack_{stack_index}",
             )
-            pyramid_level_inputs[f"P{stack_index + 2}"] = x.node.layer.name
+            pyramid_level_inputs[
+                f"P{stack_index + 2}"
+            ] = utils.get_tensor_input_name(x)
 
-        x = layers.BatchNormalization(
+        x = keras.layers.BatchNormalization(
             axis=BN_AXIS, epsilon=BN_EPSILON, name="post_bn"
         )(x)
-        x = layers.Activation("relu", name="post_relu")(x)
+        x = keras.layers.Activation("relu", name="post_relu")(x)
 
         # Create model.
         super().__init__(inputs=inputs, outputs=x, **kwargs)
@@ -214,31 +213,31 @@ def apply_basic_block(
     """
 
     if name is None:
-        name = f"v2_basic_block_{backend.get_uid('v2_basic_block')}"
+        name = f"v2_basic_block_{keras.backend.get_uid('v2_basic_block')}"
 
-    use_preactivation = layers.BatchNormalization(
+    use_preactivation = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
-    use_preactivation = layers.Activation(
+    use_preactivation = keras.layers.Activation(
         "relu", name=name + "_use_preactivation_relu"
     )(use_preactivation)
 
     s = stride if dilation == 1 else 1
     if conv_shortcut:
-        shortcut = layers.Conv2D(filters, 1, strides=s, name=name + "_0_conv")(
-            use_preactivation
-        )
+        shortcut = keras.layers.Conv2D(
+            filters, 1, strides=s, name=name + "_0_conv"
+        )(use_preactivation)
     else:
         shortcut = (
-            layers.MaxPooling2D(
+            keras.layers.MaxPooling2D(
                 1, strides=stride, name=name + "_0_max_pooling"
             )(x)
             if s > 1
             else x
         )
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         padding="SAME",
@@ -246,12 +245,12 @@ def apply_basic_block(
         use_bias=False,
         name=name + "_1_conv",
     )(use_preactivation)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         strides=s,
@@ -261,7 +260,7 @@ def apply_basic_block(
         name=name + "_2_conv",
     )(x)
 
-    x = layers.Add(name=name + "_out")([shortcut, x])
+    x = keras.layers.Add(name=name + "_out")([shortcut, x])
     return x
 
 
@@ -291,19 +290,19 @@ def apply_block(
       Output tensor for the residual block.
     """
     if name is None:
-        name = f"v2_block_{backend.get_uid('v2_block')}"
+        name = f"v2_block_{keras.backend.get_uid('v2_block')}"
 
-    use_preactivation = layers.BatchNormalization(
+    use_preactivation = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_use_preactivation_bn"
     )(x)
 
-    use_preactivation = layers.Activation(
+    use_preactivation = keras.layers.Activation(
         "relu", name=name + "_use_preactivation_relu"
     )(use_preactivation)
 
     s = stride if dilation == 1 else 1
     if conv_shortcut:
-        shortcut = layers.Conv2D(
+        shortcut = keras.layers.Conv2D(
             4 * filters,
             1,
             strides=s,
@@ -311,22 +310,22 @@ def apply_block(
         )(use_preactivation)
     else:
         shortcut = (
-            layers.MaxPooling2D(
+            keras.layers.MaxPooling2D(
                 1, strides=stride, name=name + "_0_max_pooling"
             )(x)
             if s > 1
             else x
         )
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters, 1, strides=1, use_bias=False, name=name + "_1_conv"
     )(use_preactivation)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters,
         kernel_size,
         strides=s,
@@ -335,13 +334,13 @@ def apply_block(
         dilation_rate=dilation,
         name=name + "_2_conv",
     )(x)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         axis=BN_AXIS, epsilon=BN_EPSILON, name=name + "_2_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
+    x = keras.layers.Activation("relu", name=name + "_2_relu")(x)
 
-    x = layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
-    x = layers.Add(name=name + "_out")([shortcut, x])
+    x = keras.layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
+    x = keras.layers.Add(name=name + "_out")([shortcut, x])
     return x
 
 

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets_test.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Tests for loading pretrained model presets."""
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
 
+from keras_cv.backend import ops
 from keras_cv.models.backbones.resnet_v2.resnet_v2_aliases import (
     ResNet50V2Backbone,
 )
@@ -34,7 +36,7 @@ class ResNetV2PresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """  # noqa: E501
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     @parameterized.named_parameters(
         ("preset_with_weights", "resnet50_v2_imagenet"),
@@ -53,7 +55,9 @@ class ResNetV2PresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
             outputs = outputs[0, 0, 0, :5]
             expected = [1.051145, 0, 0, 1.16328, 0]
             # Keep a high tolerance, so we are robust to different hardware.
-            self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+            self.assertAllClose(
+                ops.convert_to_numpy(outputs), expected, atol=0.01, rtol=0.01
+            )
 
     def test_applications_model_output(self):
         model = ResNet50V2Backbone()
@@ -89,7 +93,7 @@ class ResNetV2PresetFullTest(tf.test.TestCase, parameterized.TestCase):
     """  # noqa: E501
 
     def test_load_resnetv2(self):
-        input_data = tf.ones(shape=(8, 224, 224, 3))
+        input_data = np.ones(shape=(8, 224, 224, 3))
         for preset in ResNetV2Backbone.presets:
             model = ResNetV2Backbone.from_preset(preset)
             model(input_data)

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_test.py
@@ -14,11 +14,13 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.resnet_v2.resnet_v2_aliases import (
     ResNet50V2Backbone,
 )
@@ -30,7 +32,7 @@ from keras_cv.utils.train import get_feature_extractor
 
 class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(8, 224, 224, 3))
+        self.input_batch = np.ones(shape=(8, 224, 224, 3))
 
     def test_valid_call(self):
         model = ResNetV2Backbone(
@@ -54,12 +56,8 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
         )
         model(self.input_batch)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ResNetV2Backbone(
             stackwise_filters=[64, 128, 256, 512],
             stackwise_blocks=[2, 2, 2, 2],
@@ -67,8 +65,10 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             include_rescaling=False,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -76,18 +76,19 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_alias_model(self, save_format, filename):
+    def test_saved_alias_model(self):
         model = ResNet50V2Backbone()
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(
+            self.get_temp_dir(), "resnet_v2_backbone.keras"
+        )
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -96,7 +97,10 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
     def test_feature_pyramid_inputs(self):
         model = ResNet50V2Backbone()
@@ -106,25 +110,25 @@ class ResNetV2BackboneTest(tf.test.TestCase, parameterized.TestCase):
             model.pyramid_level_inputs.keys(),
         )
         input_size = 256
-        inputs = tf.keras.Input(shape=[input_size, input_size, 3])
+        inputs = keras.Input(shape=[input_size, input_size, 3])
         outputs = backbone_model(inputs)
         levels = ["P2", "P3", "P4", "P5"]
         self.assertEquals(list(outputs.keys()), levels)
         self.assertEquals(
             outputs["P2"].shape,
-            [None, input_size // 2**2, input_size // 2**2, 256],
+            (None, input_size // 2**2, input_size // 2**2, 256),
         )
         self.assertEquals(
             outputs["P3"].shape,
-            [None, input_size // 2**3, input_size // 2**3, 512],
+            (None, input_size // 2**3, input_size // 2**3, 512),
         )
         self.assertEquals(
             outputs["P4"].shape,
-            [None, input_size // 2**4, input_size // 2**4, 1024],
+            (None, input_size // 2**4, input_size // 2**4, 1024),
         )
         self.assertEquals(
             outputs["P5"].shape,
-            [None, input_size // 2**5, input_size // 2**5, 2048],
+            (None, input_size // 2**5, input_size // 2**5, 2048),
         )
 
     @parameterized.named_parameters(

--- a/keras_cv/models/classification/image_classifier.py
+++ b/keras_cv/models/classification/image_classifier.py
@@ -15,9 +15,7 @@
 
 import copy
 
-from keras import layers
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
@@ -29,7 +27,7 @@ from keras_cv.models.task import Task
 from keras_cv.utils.python_utils import classproperty
 
 
-@keras.utils.register_keras_serializable(package="keras_cv.models")
+@keras.saving.register_keras_serializable(package="keras_cv.models")
 class ImageClassifier(Task):
     """Image classifier with pooling and dense layer prediction head.
 
@@ -81,9 +79,9 @@ class ImageClassifier(Task):
         **kwargs,
     ):
         if pooling == "avg":
-            pooling_layer = layers.GlobalAveragePooling2D(name="avg_pool")
+            pooling_layer = keras.layers.GlobalAveragePooling2D(name="avg_pool")
         elif pooling == "max":
-            pooling_layer = layers.GlobalMaxPooling2D(name="max_pool")
+            pooling_layer = keras.layers.GlobalMaxPooling2D(name="max_pool")
         else:
             raise ValueError(
                 f'`pooling` must be one of "avg", "max". Received: {pooling}.'
@@ -91,7 +89,7 @@ class ImageClassifier(Task):
         inputs = backbone.input
         x = backbone(inputs)
         x = pooling_layer(x)
-        outputs = layers.Dense(
+        outputs = keras.layers.Dense(
             num_classes,
             activation=activation,
             name="predictions",
@@ -104,7 +102,7 @@ class ImageClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self.backbone = backbone
+        self._backbone = backbone
         self.num_classes = num_classes
         self.pooling = pooling
         self.activation = activation

--- a/keras_cv/models/classification/image_classifier.py
+++ b/keras_cv/models/classification/image_classifier.py
@@ -102,7 +102,7 @@ class ImageClassifier(Task):
             **kwargs,
         )
         # All references to `self` below this line
-        self._backbone = backbone
+        self.backbone = backbone
         self.num_classes = num_classes
         self.pooling = pooling
         self.activation = activation

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -16,11 +16,13 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
 
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.resnet_v2.resnet_v2_aliases import (
     ResNet18V2Backbone,
 )
@@ -29,7 +31,7 @@ from keras_cv.models.classification.image_classifier import ImageClassifier
 
 class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
         self.dataset = tf.data.Dataset.from_tensor_slices(
             (self.input_batch, tf.one_hot(tf.ones((2,), dtype="int32"), 2))
         ).batch(4)
@@ -45,6 +47,7 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
         ("jit_compile_false", False), ("jit_compile_true", True)
     )
     @pytest.mark.large  # Fit is slow, so mark these large.
+    @pytest.mark.filterwarnings("ignore::UserWarning")  # Torch + jit_compile
     def test_classifier_fit(self, jit_compile):
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),
@@ -77,19 +80,15 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
                 pooling="clowntown",
             )
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),
             num_classes=2,
         )
         model_output = model(self.input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(self.get_temp_dir(), "image_classifier.keras")
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -97,7 +96,10 @@ class ImageClassifierTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(self.input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            ops.convert_to_numpy(model_output),
+            ops.convert_to_numpy(restored_output),
+        )
 
 
 @pytest.mark.large
@@ -109,7 +111,7 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
     """
 
     def setUp(self):
-        self.input_batch = tf.ones(shape=(2, 224, 224, 3))
+        self.input_batch = np.ones(shape=(2, 224, 224, 3))
 
     @parameterized.named_parameters(
         (
@@ -131,7 +133,9 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
         outputs = model.backbone(self.input_batch)
         outputs = outputs[0, 0, 0, :5]
         # Keep a high tolerance, so we are robust to different hardware.
-        self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(
+            ops.convert_to_numpy(outputs), expected, atol=0.01, rtol=0.01
+        )
 
     @parameterized.named_parameters(
         ("preset_with_weights", "resnet50_v2_imagenet"),
@@ -165,7 +169,9 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
         outputs = outputs[0, 0, 0, :5]
         expected = [1.051145, 0, 0, 1.16328, 0]
         # Keep a high tolerance, so we are robust to different hardware.
-        self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(
+            ops.convert_to_numpy(outputs), expected, atol=0.01, rtol=0.01
+        )
 
     def test_classifier_preset_call(self):
         model = ImageClassifier.from_preset("resnet50_v2_imagenet_classifier")
@@ -184,7 +190,9 @@ class ImageClassifierPresetSmokeTest(tf.test.TestCase, parameterized.TestCase):
             3.414580e-04,
         ]
         # Keep a high tolerance, so we are robust to different hardware.
-        self.assertAllClose(outputs, expected, atol=0.01, rtol=0.01)
+        self.assertAllClose(
+            ops.convert_to_numpy(outputs), expected, atol=0.01, rtol=0.01
+        )
 
 
 if __name__ == "__main__":

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
@@ -460,14 +460,13 @@ class FasterRCNN(keras.Model):
         super().compile(loss=losses, **kwargs)
 
     def compute_loss(self, images, boxes, classes, training):
-        image_shape = tf.shape(images[0])
         local_batch = images.get_shape().as_list()[0]
         if tf.distribute.has_strategy():
             num_sync = tf.distribute.get_strategy().num_replicas_in_sync
         else:
             num_sync = 1
         global_batch = local_batch * num_sync
-        anchors = self.anchor_generator(image_shape=image_shape)
+        anchors = self.anchor_generator(image_shape=tuple(images[0].shape))
         (
             rpn_box_targets,
             rpn_box_weights,

--- a/keras_cv/models/object_detection/__test_utils__.py
+++ b/keras_cv/models/object_detection/__test_utils__.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
 import tensorflow as tf
 
 import keras_cv
+from keras_cv.backend import ops
 
 
 def _create_bounding_box_dataset(
@@ -21,29 +23,29 @@ def _create_bounding_box_dataset(
 ):
     # Just about the easiest dataset you can have, all classes are 0, all boxes
     # are exactly the same. [1, 1, 2, 2] are the coordinates in xyxy.
-    xs = tf.random.normal(shape=(1, 512, 512, 3), dtype=tf.float32)
-    xs = tf.tile(xs, [5, 1, 1, 1])
+    xs = np.random.normal(size=(1, 512, 512, 3))
+    xs = ops.tile(xs, [5, 1, 1, 1])
 
-    y_classes = tf.zeros((5, 3), dtype=tf.float32)
+    y_classes = ops.zeros((5, 3), "float32")
 
-    ys = tf.constant(
+    ys = ops.array(
         [
             [0.1, 0.1, 0.23, 0.23],
             [0.67, 0.75, 0.23, 0.23],
             [0.25, 0.25, 0.23, 0.23],
         ],
-        dtype=tf.float32,
+        "float32",
     )
-    ys = tf.expand_dims(ys, axis=0)
-    ys = tf.tile(ys, [5, 1, 1])
+    ys = ops.expand_dims(ys, axis=0)
+    ys = ops.tile(ys, [5, 1, 1])
     ys = keras_cv.bounding_box.convert_format(
         ys,
         source="rel_xywh",
         target=bounding_box_format,
         images=xs,
-        dtype=tf.float32,
+        dtype="float32",
     )
-    num_dets = tf.ones([5])
+    num_dets = ops.ones([5])
 
     if use_dictionary_box_format:
         return tf.data.Dataset.from_tensor_slices(

--- a/keras_cv/models/object_detection/retinanet/prediction_head.py
+++ b/keras_cv/models/object_detection/retinanet/prediction_head.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
-from tensorflow.keras import layers
+from keras_cv.backend import keras
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class PredictionHead(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class PredictionHead(keras.layers.Layer):
     """The class/box predictions head.
 
     Arguments:
@@ -38,21 +37,21 @@ class PredictionHead(layers.Layer):
         self.num_conv_layers = num_conv_layers
 
         self.conv_layers = [
-            layers.Conv2D(
+            keras.layers.Conv2D(
                 256,
                 kernel_size=3,
                 padding="same",
-                kernel_initializer=keras.initializers.Orthogonal(),
+                kernel_initializer="orthogonal",
                 activation="relu",
             )
             for _ in range(num_conv_layers)
         ]
-        self.prediction_layer = layers.Conv2D(
+        self.prediction_layer = keras.layers.Conv2D(
             self.output_filters,
             kernel_size=3,
             strides=1,
             padding="same",
-            kernel_initializer=keras.initializers.Orthogonal(),
+            kernel_initializer="orthogonal",
             bias_initializer=self.bias_initializer,
         )
 
@@ -61,6 +60,9 @@ class PredictionHead(layers.Layer):
             x = layer(x, training=training)
         x = self.prediction_layer(x, training=training)
         return x
+
+    def compute_output_shape(self, input_shape):
+        return tuple(input_shape[:-1]) + (self.output_filters,)
 
     def get_config(self):
         config = {
@@ -83,3 +85,13 @@ class PredictionHead(layers.Layer):
             }
         )
         return super().from_config(config)
+
+    def build(self, input_shape):
+        self.conv_layers[0].build(input_shape)
+
+        intermediate_shape = tuple(input_shape[:-1]) + (256,)
+        for conv_layer in self.conv_layers[1:]:
+            conv_layer.build(intermediate_shape)
+
+        self.prediction_layer.build(intermediate_shape)
+        self.built = True

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -15,18 +15,17 @@
 import copy
 
 import numpy as np
-import tensorflow as tf
-from tensorflow import keras
 
 import keras_cv
 from keras_cv import bounding_box
 from keras_cv import layers as cv_layers
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.bounding_box.converters import _decode_deltas_to_boxes
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
 )
-from keras_cv.models.object_detection import predict_utils
 from keras_cv.models.object_detection.__internal__ import unpack_input
 from keras_cv.models.object_detection.retinanet import FeaturePyramid
 from keras_cv.models.object_detection.retinanet import PredictionHead
@@ -43,7 +42,7 @@ BOX_VARIANCE = [0.1, 0.1, 0.2, 0.2]
 
 # TODO(jbischof): Generalize `FeaturePyramid` class to allow for any P-levels
 #  and add `feature_pyramid_levels` param.
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class RetinaNet(Task):
     """A Keras model implementing the RetinaNet meta-architecture.
 
@@ -53,7 +52,7 @@ class RetinaNet(Task):
 
     Examples:
     ```python
-    images = tf.ones(shape=(1, 512, 512, 3))
+    images = np.ones((1, 512, 512, 3))
     labels = {
         "boxes": [
             [
@@ -79,7 +78,7 @@ class RetinaNet(Task):
     model.compile(
         classification_loss='focal',
         box_loss='smoothl1',
-        optimizer=tf.optimizers.SGD(global_clipnorm=10.0),
+        optimizer=keras.optimizers.SGD(global_clipnorm=10.0),
         jit_compile=False,
     )
     model.fit(images, labels)
@@ -189,20 +188,20 @@ class RetinaNet(Task):
         )
 
         # Begin construction of forward pass
-        images = keras.layers.Input(feature_extractor.input_shape[1:])
+        images = keras.layers.Input(
+            feature_extractor.input_shape[1:], name="images"
+        )
 
         backbone_outputs = feature_extractor(images)
         features = feature_pyramid(backbone_outputs)
 
-        batch_size = tf.shape(images)[0]
         cls_pred = []
         box_pred = []
         for feature in features:
-            box_pred.append(tf.reshape(box_head(feature), [batch_size, -1, 4]))
+            box_pred.append(keras.layers.Reshape((-1, 4))(box_head(feature)))
             cls_pred.append(
-                tf.reshape(
-                    classification_head(feature),
-                    [batch_size, -1, num_classes],
+                keras.layers.Reshape((-1, num_classes))(
+                    classification_head(feature)
                 )
             )
 
@@ -213,7 +212,7 @@ class RetinaNet(Task):
         # box_pred is always in "center_yxhw" delta-encoded no matter what
         # format you pass in.
 
-        inputs = images
+        inputs = {"images": images}
         outputs = {"box": box_pred, "classification": cls_pred}
 
         super().__init__(
@@ -230,7 +229,7 @@ class RetinaNet(Task):
         self.feature_extractor = feature_extractor
         self._prediction_decoder = (
             prediction_decoder
-            or cv_layers.MultiClassNonMaxSuppression(
+            or cv_layers.NonMaxSuppression(
                 bounding_box_format=bounding_box_format,
                 from_logits=True,
             )
@@ -241,8 +240,12 @@ class RetinaNet(Task):
         self.box_head = box_head
         self.build(backbone.input_shape)
 
-    def make_predict_function(self, force=False):
-        return predict_utils.make_predict_function(self, force=force)
+    def predict_step(self, *args):
+        outputs = super().predict_step(*args)
+        if type(outputs) is tuple:
+            return self.decode_predictions(outputs[0], args[-1]), outputs[1]
+        else:
+            return self.decode_predictions(outputs, args[-1])
 
     @property
     def prediction_decoder(self):
@@ -282,9 +285,9 @@ class RetinaNet(Task):
     def decode_predictions(self, predictions, images):
         box_pred, cls_pred = predictions["box"], predictions["classification"]
         # box_pred is on "center_yxhw" format, convert to target format.
-        image_shape = tf.shape(images[0])
+        image_shape = tuple(images[0].shape)
         anchors = self.anchor_generator(image_shape=image_shape)
-        anchors = tf.concat(tf.nest.flatten(anchors), axis=0)
+        anchors = ops.concatenate([a for a in anchors.values()], axis=0)
 
         box_pred = _decode_deltas_to_boxes(
             anchors=anchors,
@@ -316,7 +319,6 @@ class RetinaNet(Task):
         self,
         box_loss=None,
         classification_loss=None,
-        weight_decay=0.0001,
         loss=None,
         metrics=None,
         **kwargs,
@@ -383,7 +385,6 @@ class RetinaNet(Task):
 
         self.box_loss = box_loss
         self.classification_loss = classification_loss
-        self.weight_decay = weight_decay
         losses = {
             "box": self.box_loss,
             "classification": self.classification_loss,
@@ -392,7 +393,11 @@ class RetinaNet(Task):
         self._user_metrics = metrics
         super().compile(loss=losses, **kwargs)
 
-    def compute_loss(self, x, box_pred, cls_pred, boxes, classes):
+    def compute_loss(self, x, y, y_pred, sample_weight, **kwargs):
+        box_pred = y_pred["box"]
+        cls_pred = y_pred["classification"]
+        boxes = y["box"]
+        classes = y["classification"]
         if boxes.shape[-1] != 4:
             raise ValueError(
                 "boxes should have shape (None, None, 4). Got "
@@ -414,37 +419,28 @@ class RetinaNet(Task):
                 "parameter?"
             )
 
-        cls_labels = tf.one_hot(
-            tf.cast(classes, dtype=tf.int32),
-            depth=self.num_classes,
-            dtype=tf.float32,
+        cls_labels = ops.one_hot(
+            ops.cast(classes, "int32"), self.num_classes, dtype="float32"
         )
-
-        positive_mask = tf.cast(tf.greater(classes, -1.0), dtype=tf.float32)
-        normalizer = tf.reduce_sum(positive_mask)
-        cls_weights = tf.cast(
-            tf.math.not_equal(classes, -2.0), dtype=tf.float32
-        )
+        positive_mask = ops.cast(ops.greater(classes, -1.0), dtype="float32")
+        normalizer = ops.sum(positive_mask)
+        cls_weights = ops.cast(ops.not_equal(classes, -2.0), dtype="float32")
         cls_weights /= normalizer
         box_weights = positive_mask / normalizer
         y_true = {
             "box": boxes,
             "classification": cls_labels,
         }
-        y_pred = {
-            "box": box_pred,
-            "classification": cls_pred,
-        }
         sample_weights = {
             "box": box_weights,
             "classification": cls_weights,
         }
         zero_weight = {
-            "box": tf.zeros_like(box_weights),
-            "classification": tf.zeros_like(cls_weights),
+            "box": ops.zeros_like(box_weights),
+            "classification": ops.zeros_like(cls_weights),
         }
 
-        sample_weights = tf.cond(
+        sample_weights = ops.cond(
             normalizer == 0,
             lambda: zero_weight,
             lambda: sample_weights,
@@ -453,44 +449,29 @@ class RetinaNet(Task):
             x=x, y=y_true, y_pred=y_pred, sample_weight=sample_weights
         )
 
-    def train_step(self, data):
+    def train_step(self, *args):
+        data = args[-1]
         x, y = unpack_input(data)
+
         y_for_label_encoder = bounding_box.convert_format(
             y,
             source=self.bounding_box_format,
             target=self.label_encoder.bounding_box_format,
             images=x,
         )
+
         boxes, classes = self.label_encoder(x, y_for_label_encoder)
-        # boxes are now in `center_yxhw`. This is always the case in training
-        with tf.GradientTape() as tape:
-            outputs = self(x, training=True)
-            box_pred, cls_pred = outputs["box"], outputs["classification"]
-            total_loss = self.compute_loss(
-                x, box_pred, cls_pred, boxes, classes
-            )
+        super_args = args[:-1] + (
+            (
+                x,
+                {"box": boxes, "classification": classes, "unencoded": y},
+            ),
+        )
 
-            reg_losses = []
-            if self.weight_decay:
-                for var in self.trainable_variables:
-                    if "bn" not in var.name:
-                        reg_losses.append(
-                            self.weight_decay * tf.nn.l2_loss(var)
-                        )
-                l2_loss = tf.math.add_n(reg_losses)
-            total_loss += l2_loss
-        # Training specific code
-        trainable_vars = self.trainable_variables
-        gradients = tape.gradient(total_loss, trainable_vars)
-        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+        return super().train_step(*super_args)
 
-        if not self._has_user_metrics:
-            return super().compute_metrics(x, {}, {}, sample_weight={})
-
-        y_pred = self.decode_predictions(outputs, x)
-        return self.compute_metrics(x, y, y_pred, sample_weight=None)
-
-    def test_step(self, data):
+    def test_step(self, *args):
+        data = args[-1]
         x, y = unpack_input(data)
         y_for_label_encoder = bounding_box.convert_format(
             y,
@@ -506,18 +487,27 @@ class RetinaNet(Task):
             images=x,
         )
 
-        outputs = self(x, training=False)
-        box_pred, cls_pred = outputs["box"], outputs["classification"]
-        _ = self.compute_loss(x, box_pred, cls_pred, boxes, classes)
+        super_args = args[:-1] + (
+            (
+                x,
+                {"box": boxes, "classification": classes, "unencoded": y},
+            ),
+        )
 
-        if not self._has_user_metrics:
-            return super().compute_metrics(x, {}, {}, sample_weight={})
-        y_pred = self.decode_predictions(outputs, x)
-        return self.compute_metrics(x, y, y_pred, sample_weight=None)
+        return super().test_step(*super_args)
 
     def compute_metrics(self, x, y, y_pred, sample_weight):
         metrics = {}
         metrics.update(super().compute_metrics(x, {}, {}, sample_weight={}))
+
+        if not self._has_user_metrics:
+            return metrics
+
+        # For computing non-loss metrics, we don't care about the encoded
+        # boxes and classes, just the raw input boxes.
+        y = y["unencoded"]
+
+        y_pred = self.decode_predictions(y_pred, x)
 
         for metric in self._user_metrics:
             metric.update_state(y, y_pred, sample_weight=sample_weight)
@@ -534,13 +524,15 @@ class RetinaNet(Task):
         return {
             "num_classes": self.num_classes,
             "bounding_box_format": self.bounding_box_format,
-            "backbone": keras.utils.serialize_keras_object(self.backbone),
-            "label_encoder": self.label_encoder,
+            "backbone": keras.saving.serialize_keras_object(self.backbone),
+            "label_encoder": keras.saving.serialize_keras_object(
+                self.label_encoder
+            ),
             "prediction_decoder": self._prediction_decoder,
-            "classification_head": keras.utils.serialize_keras_object(
+            "classification_head": keras.saving.serialize_keras_object(
                 self.classification_head
             ),
-            "box_head": keras.utils.serialize_keras_object(self.box_head),
+            "box_head": keras.saving.serialize_keras_object(self.box_head),
         }
 
     @classmethod
@@ -552,6 +544,12 @@ class RetinaNet(Task):
         ):
             config["classification_head"] = keras.layers.deserialize(
                 config["classification_head"]
+            )
+        if "label_encoder" in config and isinstance(
+            config["label_encoder"], dict
+        ):
+            config["label_encoder"] = keras.layers.deserialize(
+                config["label_encoder"]
             )
         return super().from_config(config)
 
@@ -582,11 +580,9 @@ def _parse_box_loss(loss):
 
     # case insensitive comparison
     if loss.lower() == "smoothl1":
-        return keras_cv.losses.SmoothL1Loss(
-            l1_cutoff=1.0, reduction=keras.losses.Reduction.SUM
-        )
+        return keras_cv.losses.SmoothL1Loss(l1_cutoff=1.0, reduction="sum")
     if loss.lower() == "huber":
-        return keras.losses.Huber(reduction=keras.losses.Reduction.SUM)
+        return keras.losses.Huber(reduction="sum")
 
     raise ValueError(
         "Expected `box_loss` to be either a Keras Loss, "
@@ -601,9 +597,7 @@ def _parse_classification_loss(loss):
 
     # case insensitive comparison
     if loss.lower() == "focal":
-        return keras_cv.losses.FocalLoss(
-            from_logits=True, reduction=keras.losses.Reduction.SUM
-        )
+        return keras_cv.losses.FocalLoss(from_logits=True, reduction="sum")
 
     raise ValueError(
         "Expected `classification_loss` to be either a Keras Loss, "

--- a/keras_cv/models/object_detection/retinanet/retinanet_label_encoder.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_label_encoder.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.layers.object_detection import box_matcher
 from keras_cv.utils import target_gather
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
-class RetinaNetLabelEncoder(layers.Layer):
+@keras.saving.register_keras_serializable(package="keras_cv")
+class RetinaNetLabelEncoder(keras.layers.Layer):
     """Transforms the raw labels into targets for training.
 
     This class has operations to generate targets for a batch of samples which
@@ -64,7 +64,7 @@ class RetinaNetLabelEncoder(layers.Layer):
         super().__init__(**kwargs)
         self.bounding_box_format = bounding_box_format
         self.anchor_generator = anchor_generator
-        self.box_variance = tf.convert_to_tensor(box_variance, dtype=self.dtype)
+        self.box_variance = ops.array(box_variance, "float32")
         self.background_class = background_class
         self.ignore_class = ignore_class
         self.matched_boxes_metric = keras.metrics.BinaryAccuracy(
@@ -116,12 +116,16 @@ class RetinaNetLabelEncoder(layers.Layer):
             image_shape=image_shape,
         )
         matched_gt_idx, matched_vals = self.box_matcher(iou_matrix)
-        matched_vals = matched_vals[..., tf.newaxis]
-        positive_mask = tf.cast(tf.math.equal(matched_vals, 1), self.dtype)
-        ignore_mask = tf.cast(tf.math.equal(matched_vals, -2), self.dtype)
+        matched_vals = ops.expand_dims(matched_vals, axis=-1)
+        positive_mask = ops.cast(ops.equal(matched_vals, 1), self.dtype)
+        ignore_mask = ops.cast(ops.equal(matched_vals, -2), self.dtype)
         matched_gt_boxes = target_gather._target_gather(
             gt_boxes, matched_gt_idx
         )
+        matched_gt_boxes = ops.reshape(
+            matched_gt_boxes, (-1, matched_gt_boxes.shape[1], 4)
+        )
+
         box_target = bounding_box._encode_box_to_deltas(
             anchors=anchor_boxes,
             boxes=matched_gt_boxes,
@@ -133,47 +137,47 @@ class RetinaNetLabelEncoder(layers.Layer):
         matched_gt_cls_ids = target_gather._target_gather(
             gt_classes, matched_gt_idx
         )
-        cls_target = tf.where(
-            tf.not_equal(positive_mask, 1.0),
+        cls_target = ops.where(
+            ops.not_equal(positive_mask, 1.0),
             self.background_class,
             matched_gt_cls_ids,
         )
-        cls_target = tf.where(
-            tf.equal(ignore_mask, 1.0), self.ignore_class, cls_target
+        cls_target = ops.where(
+            ops.equal(ignore_mask, 1.0), self.ignore_class, cls_target
         )
-        label = tf.concat([box_target, cls_target], axis=-1)
+        label = ops.concatenate(
+            [box_target, ops.cast(cls_target, box_target.dtype)], axis=-1
+        )
 
         # In the case that a box in the corner of an image matches with an all
         # -1 box that is outside the image, we should assign the box to the
         # ignore class. There are rare cases where a -1 box can be matched,
         # resulting in a NaN during training. The unit test passing all -1s to
         # the label encoder ensures that we properly handle this edge-case.
-        label = tf.where(
-            tf.expand_dims(
-                tf.math.reduce_any(tf.math.is_nan(label), axis=-1), axis=-1
-            ),
+        label = ops.where(
+            ops.expand_dims(ops.any(ops.isnan(label), axis=-1), axis=-1),
             self.ignore_class,
             label,
         )
 
         result = {"boxes": label[:, :, :4], "classes": label[:, :, 4]}
 
-        box_shape = tf.shape(gt_boxes)
+        box_shape = ops.shape(gt_boxes)
         batch_size = box_shape[0]
         n_boxes = box_shape[1]
-        box_ids = tf.range(n_boxes, dtype=matched_gt_idx.dtype)
-        matched_ids = tf.expand_dims(matched_gt_idx, axis=-1)
+        box_ids = ops.arange(gt_boxes.shape[1], dtype=matched_gt_idx.dtype)
+        matched_ids = ops.expand_dims(matched_gt_idx, axis=-1)
         matches = box_ids == matched_ids
-        matches = tf.math.reduce_any(matches, axis=1)
+        matches = ops.any(matches, axis=1)
         self.matched_boxes_metric.update_state(
-            tf.zeros(
+            ops.zeros(
                 (
                     batch_size,
                     n_boxes,
                 ),
-                dtype=tf.int32,
+                dtype="int32",
             ),
-            tf.cast(matches, tf.int32),
+            ops.cast(matches, "int32"),
         )
         return result
 
@@ -192,12 +196,14 @@ class RetinaNetLabelEncoder(layers.Layer):
                 f"Received `type(images)={type(images)}`."
             )
 
-        image_shape = tf.shape(images[0])
+        image_shape = tuple(images[0].shape)
         box_labels = bounding_box.to_dense(box_labels)
-        if box_labels["classes"].get_shape().rank == 2:
-            box_labels["classes"] = box_labels["classes"][..., tf.newaxis]
+        if len(box_labels["classes"].shape) == 2:
+            box_labels["classes"] = ops.expand_dims(
+                box_labels["classes"], axis=-1
+            )
         anchor_boxes = self.anchor_generator(image_shape=image_shape)
-        anchor_boxes = tf.concat(list(anchor_boxes.values()), axis=0)
+        anchor_boxes = ops.concatenate(list(anchor_boxes.values()), axis=0)
         anchor_boxes = bounding_box.convert_format(
             anchor_boxes,
             source=self.anchor_generator.bounding_box_format,
@@ -207,6 +213,9 @@ class RetinaNetLabelEncoder(layers.Layer):
 
         result = self._encode_sample(box_labels, anchor_boxes, image_shape)
         encoded_box_targets = result["boxes"]
+        encoded_box_targets = ops.reshape(
+            encoded_box_targets, (-1, encoded_box_targets.shape[1], 4)
+        )
         class_targets = result["classes"]
         return encoded_box_targets, class_targets
 

--- a/keras_cv/models/object_detection/retinanet/retinanet_label_encoder_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_label_encoder_test.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pytest
 import tensorflow as tf
 
+from keras_cv import backend
 from keras_cv import layers as cv_layers
+from keras_cv.backend import ops
 from keras_cv.models.object_detection.retinanet import RetinaNetLabelEncoder
 
 
@@ -24,13 +28,9 @@ class RetinaNetLabelEncoderTest(tf.test.TestCase):
         boxes_shape = (8, 10, 4)
         classes_shape = (8, 10)
 
-        images = tf.random.uniform(shape=images_shape)
-        boxes = tf.random.uniform(
-            shape=boxes_shape, minval=0.0, maxval=1.0, dtype=tf.float32
-        )
-        classes = tf.random.uniform(
-            shape=classes_shape, minval=0, maxval=5, dtype=tf.float32
-        )
+        images = np.random.uniform(size=images_shape)
+        boxes = np.random.uniform(size=boxes_shape, low=0.0, high=1.0)
+        classes = np.random.uniform(size=classes_shape, low=0, high=5)
         strides = [2**i for i in range(3, 8)]
         scales = [2**x for x in [0, 1 / 3, 2 / 3]]
         sizes = [x**2 for x in [32.0, 64.0, 128.0, 256.0, 512.0]]
@@ -50,17 +50,17 @@ class RetinaNetLabelEncoderTest(tf.test.TestCase):
         bounding_boxes = {"boxes": boxes, "classes": classes}
         box_targets, class_targets = encoder(images, bounding_boxes)
 
-        self.assertEqual(box_targets.shape, [8, 49104, 4])
-        self.assertEqual(class_targets.shape, [8, 49104])
+        self.assertEqual(box_targets.shape, (8, 49104, 4))
+        self.assertEqual(class_targets.shape, (8, 49104))
 
     def test_all_negative_1(self):
         images_shape = (8, 512, 512, 3)
         boxes_shape = (8, 10, 4)
         classes_shape = (8, 10)
 
-        images = tf.random.uniform(shape=images_shape)
-        boxes = -tf.ones(shape=boxes_shape, dtype=tf.float32)
-        classes = -tf.ones(shape=classes_shape, dtype=tf.float32)
+        images = np.random.uniform(size=images_shape)
+        boxes = -np.ones(shape=boxes_shape, dtype="float32")
+        classes = -np.ones(shape=classes_shape, dtype="float32")
 
         strides = [2**i for i in range(3, 8)]
         scales = [2**x for x in [0, 1 / 3, 2 / 3]]
@@ -82,23 +82,27 @@ class RetinaNetLabelEncoderTest(tf.test.TestCase):
         bounding_boxes = {"boxes": boxes, "classes": classes}
         box_targets, class_targets = encoder(images, bounding_boxes)
 
-        self.assertFalse(tf.math.reduce_any(tf.math.is_nan(box_targets)))
-        self.assertFalse(tf.math.reduce_any(tf.math.is_nan(class_targets)))
+        self.assertFalse(ops.any(ops.isnan(box_targets)))
+        self.assertFalse(ops.any(ops.isnan(class_targets)))
 
+    @pytest.mark.skipif(
+        backend.supports_ragged() is False,
+        reason="Only TensorFlow supports raggeds",
+    )
     def test_ragged_encoding(self):
         images_shape = (2, 512, 512, 3)
 
         images = tf.random.uniform(shape=images_shape)
         boxes = tf.ragged.stack(
             [
-                tf.constant([[0, 0, 10, 10], [5, 5, 10, 10]], tf.float32),
-                tf.constant([[0, 0, 10, 10]], tf.float32),
+                tf.constant([[0, 0, 10, 10], [5, 5, 10, 10]], "float32"),
+                tf.constant([[0, 0, 10, 10]], "float32"),
             ]
         )
         classes = tf.ragged.stack(
             [
-                tf.constant([[1], [1]], tf.float32),
-                tf.constant([[1]], tf.float32),
+                tf.constant([[1], [1]], "float32"),
+                tf.constant([[1]], "float32"),
             ]
         )
         strides = [2**i for i in range(3, 8)]
@@ -122,5 +126,5 @@ class RetinaNetLabelEncoderTest(tf.test.TestCase):
         box_targets, class_targets = encoder(images, bounding_boxes)
 
         # 49104 is the anchor generator shape
-        self.assertEqual(box_targets.shape, [2, 49104, 4])
-        self.assertEqual(class_targets.shape, [2, 49104])
+        self.assertEqual(box_targets.shape, (2, 49104, 4))
+        self.assertEqual(class_targets.shape, (2, 49104))

--- a/keras_cv/models/object_detection/retinanet/retinanet_test.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_test.py
@@ -14,13 +14,14 @@
 
 import os
 
+import numpy as np
 import pytest
 import tensorflow as tf
 from absl.testing import parameterized
-from tensorflow import keras
-from tensorflow.keras import optimizers
 
 import keras_cv
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.models.backbones.test_backbone_presets import (
     test_backbone_presets,
 )
@@ -31,16 +32,6 @@ from keras_cv.models.object_detection.retinanet import RetinaNetLabelEncoder
 
 
 class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
-    @pytest.fixture(autouse=True)
-    def cleanup_global_session(self):
-        # Code before yield runs before the test
-        tf.config.set_soft_device_placement(False)
-        yield
-        # Reset soft device placement to not interfere with other unit test
-        # files
-        tf.config.set_soft_device_placement(True)
-        keras.backend.clear_session()
-
     def test_retinanet_construction(self):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=20,
@@ -90,7 +81,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
             bounding_box_format="xywh",
             backbone=keras_cv.models.ResNet18V2Backbone(),
         )
-        images = tf.random.uniform((2, 512, 512, 3))
+        images = np.random.uniform(size=(2, 512, 512, 3))
         _ = retinanet(images)
         _ = retinanet.predict(images)
 
@@ -106,7 +97,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
             "from_logits",
         ):
             retinanet.compile(
-                optimizer=optimizers.SGD(learning_rate=0.25),
+                optimizer=keras.optimizers.SGD(learning_rate=0.25),
                 classification_loss=keras_cv.losses.FocalLoss(
                     from_logits=False, reduction="none"
                 ),
@@ -124,7 +115,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         )
         retinanet.backbone.trainable = False
         retinanet.compile(
-            optimizer=optimizers.Adam(),
+            optimizer=keras.optimizers.Adam(),
             classification_loss=keras_cv.losses.FocalLoss(
                 from_logits=True, reduction="none"
             ),
@@ -136,40 +127,36 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
 
         # call once
         _ = retinanet(xs)
-        variable_names = [x.name for x in retinanet.trainable_variables]
-        # classification_head
-        self.assertIn("prediction_head/conv2d_8/kernel:0", variable_names)
-        # box_head
-        self.assertIn("prediction_head_1/conv2d_12/kernel:0", variable_names)
+        self.assertEqual(len(retinanet.trainable_variables), 32)
 
     @pytest.mark.large  # Fit is slow, so mark these large.
     def test_no_nans(self):
         retina_net = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet18V2Backbone(),
+            backbone=keras_cv.models.CSPDarkNetTinyBackbone(),
         )
 
         retina_net.compile(
-            optimizer=optimizers.Adam(),
+            optimizer=keras.optimizers.Adam(),
             classification_loss="focal",
             box_loss="smoothl1",
         )
 
         # only a -1 box
-        xs = tf.ones((1, 512, 512, 3), tf.float32)
+        xs = ops.ones((1, 512, 512, 3), "float32")
         ys = {
-            "classes": tf.constant([[-1]], tf.float32),
-            "boxes": tf.constant([[[0, 0, 0, 0]]], tf.float32),
+            "classes": ops.array([[-1]], "float32"),
+            "boxes": ops.array([[[0, 0, 0, 0]]], "float32"),
         }
         ds = tf.data.Dataset.from_tensor_slices((xs, ys))
         ds = ds.repeat(2)
-        ds = ds.batch(2)
+        ds = ds.batch(2, drop_remainder=True)
         retina_net.fit(ds, epochs=1)
 
         weights = retina_net.get_weights()
         for weight in weights:
-            self.assertFalse(tf.math.reduce_any(tf.math.is_nan(weight)))
+            self.assertFalse(ops.any(ops.isnan(weight)))
 
     @pytest.mark.large  # Fit is slow, so mark these large.
     def test_weights_change(self):
@@ -177,29 +164,31 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         retinanet = keras_cv.models.RetinaNet(
             num_classes=2,
             bounding_box_format=bounding_box_format,
-            backbone=keras_cv.models.ResNet18V2Backbone(),
+            backbone=keras_cv.models.CSPDarkNetTinyBackbone(),
         )
 
         retinanet.compile(
-            optimizer=optimizers.Adam(),
+            optimizer=keras.optimizers.Adam(),
             classification_loss=keras_cv.losses.FocalLoss(
-                from_logits=True, reduction="none"
+                from_logits=True, reduction="sum"
             ),
             box_loss=keras_cv.losses.SmoothL1Loss(
-                l1_cutoff=1.0, reduction="none"
+                l1_cutoff=1.0, reduction="sum"
             ),
         )
-        xs, ys = _create_bounding_box_dataset(bounding_box_format)
+        ds = _create_bounding_box_dataset(
+            bounding_box_format, use_dictionary_box_format=True
+        )
 
         # call once
-        _ = retinanet(xs)
+        _ = retinanet(ops.ones((1, 512, 512, 3)))
         original_fpn_weights = retinanet.feature_pyramid.get_weights()
         original_box_head_weights = retinanet.box_head.get_weights()
         original_classification_head_weights = (
             retinanet.classification_head.get_weights()
         )
 
-        retinanet.fit(x=xs, y=ys, epochs=1)
+        retinanet.fit(ds, epochs=1)
         fpn_after_fit = retinanet.feature_pyramid.get_weights()
         box_head_after_fit_weights = retinanet.box_head.get_weights()
         classification_head_after_fit_weights = (
@@ -220,21 +209,17 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
         for w1, w2 in zip(original_fpn_weights, fpn_after_fit):
             self.assertNotAllClose(w1, w2)
 
-    @parameterized.named_parameters(
-        ("tf_format", "tf", "model"),
-        ("keras_format", "keras_v3", "model.keras"),
-    )
     @pytest.mark.large  # Saving is slow, so mark these large.
-    def test_saved_model(self, save_format, filename):
+    def test_saved_model(self):
         model = keras_cv.models.RetinaNet(
             num_classes=20,
             bounding_box_format="xywh",
-            backbone=keras_cv.models.ResNet18V2Backbone(),
+            backbone=keras_cv.models.CSPDarkNetTinyBackbone(),
         )
-        input_batch = tf.ones(shape=(2, 224, 224, 3))
+        input_batch = ops.ones(shape=(2, 224, 224, 3))
         model_output = model(input_batch)
-        save_path = os.path.join(self.get_temp_dir(), filename)
-        model.save(save_path, save_format=save_format)
+        save_path = os.path.join(self.get_temp_dir(), "retinanet.keras")
+        model.save(save_path)
         restored_model = keras.models.load_model(save_path)
 
         # Check we got the real object back.
@@ -242,11 +227,14 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
 
         # Check that output matches.
         restored_output = restored_model(input_batch)
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(
+            tf.nest.map_structure(ops.convert_to_numpy, model_output),
+            tf.nest.map_structure(ops.convert_to_numpy, restored_output),
+        )
 
     def test_call_with_custom_label_encoder(self):
-        anchor_generator = (
-            keras_cv.models.RetinaNet.default_anchor_generator("xywh"),
+        anchor_generator = keras_cv.models.RetinaNet.default_anchor_generator(
+            "xywh"
         )
         model = keras_cv.models.RetinaNet(
             num_classes=20,
@@ -258,7 +246,7 @@ class RetinaNetTest(tf.test.TestCase, parameterized.TestCase):
                 box_variance=[0.1, 0.1, 0.2, 0.2],
             ),
         )
-        model(tf.ones(shape=(2, 224, 224, 3)))
+        model(ops.ones(shape=(2, 224, 224, 3)))
 
 
 @pytest.mark.large
@@ -284,15 +272,19 @@ class RetinaNetSmokeTest(tf.test.TestCase, parameterized.TestCase):
             "retinanet_resnet50_pascalvoc",
             bounding_box_format="xywh",
         )
-        xs = tf.ones((1, 512, 512, 3), tf.float32)
+        xs = ops.ones((1, 512, 512, 3))
         output = model(xs)
 
-        expected_box = tf.constant(
+        expected_box = ops.array(
             [-1.2427993, 0.05179548, -1.9953268, 0.32456252]
         )
-        self.assertAllClose(output["box"][0, 123, :], expected_box, atol=1e-5)
+        self.assertAllClose(
+            ops.convert_to_numpy(output["box"][0, 123, :]),
+            expected_box,
+            atol=1e-5,
+        )
 
-        expected_class = tf.constant(
+        expected_class = ops.array(
             [
                 -8.387445,
                 -7.891776,
@@ -316,7 +308,9 @@ class RetinaNetSmokeTest(tf.test.TestCase, parameterized.TestCase):
                 -6.484198,
             ]
         )
-        expected_class = tf.reshape(expected_class, (20,))
+        expected_class = ops.reshape(expected_class, (20,))
         self.assertAllClose(
-            output["classification"][0, 123], expected_class, atol=1e-5
+            ops.convert_to_numpy(output["classification"][0, 123]),
+            expected_class,
+            atol=1e-5,
         )

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -14,18 +14,15 @@
 import copy
 import warnings
 
-import tensorflow as tf
-from keras import layers
-from tensorflow import keras
-
 import keras_cv
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.losses.ciou_loss import CIoULoss
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
 )
-from keras_cv.models.object_detection import predict_utils
 from keras_cv.models.object_detection.__internal__ import unpack_input
 from keras_cv.models.object_detection.yolo_v8.yolo_v8_detector_presets import (
     yolo_v8_detector_presets,
@@ -72,31 +69,36 @@ def get_anchors(
         two together will yield the centerpoints in absolute x,y format.
 
     """
-    base_anchors = tf.constant(base_anchors, dtype=tf.float32)
+    base_anchors = ops.array(base_anchors, dtype="float32")
 
     all_anchors = []
     all_strides = []
     for stride in strides:
-        hh_centers = tf.range(start=0, limit=image_shape[0], delta=stride)
-        ww_centers = tf.range(start=0, limit=image_shape[1], delta=stride)
-        ww_grid, hh_grid = tf.meshgrid(ww_centers, hh_centers)
-        grid = tf.cast(
-            tf.reshape(tf.stack([hh_grid, ww_grid], 2), [-1, 1, 2]),
-            tf.float32,
+        hh_centers = ops.arange(0, image_shape[0], stride)
+        ww_centers = ops.arange(0, image_shape[1], stride)
+        ww_grid, hh_grid = ops.meshgrid(ww_centers, hh_centers)
+        grid = ops.cast(
+            ops.reshape(ops.stack([hh_grid, ww_grid], 2), [-1, 1, 2]),
+            "float32",
         )
-        anchors = tf.expand_dims(base_anchors * [stride, stride], 0) + grid
-        anchors = tf.reshape(anchors, [-1, 2])
+        anchors = (
+            ops.expand_dims(
+                base_anchors * ops.array([stride, stride], "float32"), 0
+            )
+            + grid
+        )
+        anchors = ops.reshape(anchors, [-1, 2])
         all_anchors.append(anchors)
-        all_strides.append(tf.repeat(stride, anchors.shape[0]))
+        all_strides.append(ops.repeat(stride, anchors.shape[0]))
 
-    all_anchors = tf.cast(tf.concat(all_anchors, axis=0), tf.float32)
-    all_strides = tf.cast(tf.concat(all_strides, axis=0), tf.float32)
+    all_anchors = ops.cast(ops.concatenate(all_anchors, axis=0), "float32")
+    all_strides = ops.cast(ops.concatenate(all_strides, axis=0), "float32")
 
     all_anchors = all_anchors / all_strides[:, None]
 
     # Swap the x and y coordinates of the anchors.
-    all_anchors = tf.concat(
-        [all_anchors[:, 1, tf.newaxis], all_anchors[:, 0, tf.newaxis]], axis=-1
+    all_anchors = ops.concatenate(
+        [all_anchors[:, 1, None], all_anchors[:, 0, None]], axis=-1
     )
     return all_anchors, all_strides
 
@@ -120,8 +122,8 @@ def apply_path_aggregation_fpn(features, depth=3, name="fpn"):
     p3, p4, p5 = features
 
     # Upsample P5 and concatenate with P4, then apply a CSPBlock.
-    p5_upsampled = tf.image.resize(p5, tf.shape(p4)[1:-1], method="nearest")
-    p4p5 = tf.concat([p5_upsampled, p4], axis=-1)
+    p5_upsampled = ops.repeat(ops.repeat(p5, 2, axis=1), 2, axis=2)
+    p4p5 = ops.concatenate([p5_upsampled, p4], axis=-1)
     p4p5 = apply_csp_block(
         p4p5,
         channels=p4.shape[-1],
@@ -132,8 +134,8 @@ def apply_path_aggregation_fpn(features, depth=3, name="fpn"):
     )
 
     # Upsample P4P5 and concatenate with P3, then apply a CSPBlock.
-    p4p5_upsampled = tf.image.resize(p4p5, tf.shape(p3)[1:-1], method="nearest")
-    p3p4p5 = tf.concat([p4p5_upsampled, p3], axis=-1)
+    p4p5_upsampled = ops.repeat(ops.repeat(p4p5, 2, axis=1), 2, axis=2)
+    p3p4p5 = ops.concatenate([p4p5_upsampled, p3], axis=-1)
     p3p4p5 = apply_csp_block(
         p3p4p5,
         channels=p3.shape[-1],
@@ -152,7 +154,7 @@ def apply_path_aggregation_fpn(features, depth=3, name="fpn"):
         activation="swish",
         name=f"{name}_p3p4p5_downsample1",
     )
-    p3p4p5_d1 = tf.concat([p3p4p5_d1, p4p5], axis=-1)
+    p3p4p5_d1 = ops.concatenate([p3p4p5_d1, p4p5], axis=-1)
     p3p4p5_d1 = apply_csp_block(
         p3p4p5_d1,
         channels=p4p5.shape[-1],
@@ -171,7 +173,7 @@ def apply_path_aggregation_fpn(features, depth=3, name="fpn"):
         activation="swish",
         name=f"{name}_p3p4p5_downsample2",
     )
-    p3p4p5_d2 = tf.concat([p3p4p5_d2, p5], axis=-1)
+    p3p4p5_d2 = ops.concatenate([p3p4p5_d2, p5], axis=-1)
     p3p4p5_d2 = apply_csp_block(
         p3p4p5_d2,
         channels=p5.shape[-1],
@@ -236,7 +238,7 @@ def apply_yolo_v8_head(
             activation="swish",
             name=f"{cur_name}_box_2",
         )
-        box_predictions = layers.Conv2D(
+        box_predictions = keras.layers.Conv2D(
             filters=BOX_REGRESSION_CHANNELS,
             kernel_size=1,
             name=f"{cur_name}_box_3_conv",
@@ -256,25 +258,25 @@ def apply_yolo_v8_head(
             activation="swish",
             name=f"{cur_name}_class_2",
         )
-        class_predictions = layers.Conv2D(
+        class_predictions = keras.layers.Conv2D(
             filters=num_classes,
             kernel_size=1,
             name=f"{cur_name}_class_3_conv",
         )(class_predictions)
-        class_predictions = layers.Activation(
+        class_predictions = keras.layers.Activation(
             "sigmoid", name=f"{cur_name}_classifier"
         )(class_predictions)
 
-        out = tf.concat([box_predictions, class_predictions], axis=-1)
-        out = layers.Reshape(
+        out = ops.concatenate([box_predictions, class_predictions], axis=-1)
+        out = keras.layers.Reshape(
             [-1, out.shape[-1]], name=f"{cur_name}_output_reshape"
         )(out)
         outputs.append(out)
 
-    outputs = tf.concat(outputs, axis=1)
-    outputs = layers.Activation("linear", dtype="float32", name="box_outputs")(
-        outputs
-    )
+    outputs = ops.concatenate(outputs, axis=1)
+    outputs = keras.layers.Activation(
+        "linear", dtype="float32", name="box_outputs"
+    )(outputs)
 
     return {
         "boxes": outputs[:, :, :BOX_REGRESSION_CHANNELS],
@@ -293,13 +295,13 @@ def decode_regression_to_boxes(preds):
     predictions are relative to the stride of an anchor box (and correspondingly
     relative to the scale of the feature map from which the predictions came).
     """
-    preds_bbox = tf.reshape(
-        preds, (-1, preds.shape[1], 4, BOX_REGRESSION_CHANNELS // 4)
+    preds_bbox = keras.layers.Reshape((-1, 4, BOX_REGRESSION_CHANNELS // 4))(
+        preds
     )
-    preds_bbox = tf.nn.softmax(preds_bbox, axis=-1) * tf.range(
+    preds_bbox = ops.nn.softmax(preds_bbox, axis=-1) * ops.arange(
         BOX_REGRESSION_CHANNELS // 4, dtype="float32"
     )
-    return tf.reduce_sum(preds_bbox, axis=-1)
+    return ops.sum(preds_bbox, axis=-1)
 
 
 def dist2bbox(distance, anchor_points):
@@ -311,13 +313,13 @@ def dist2bbox(distance, anchor_points):
     The resulting xyxy predictions must be scaled by the stride of their
     corresponding anchor points to yield an absolute xyxy box.
     """
-    left_top, right_bottom = tf.split(distance, 2, axis=-1)
+    left_top, right_bottom = ops.split(distance, 2, axis=-1)
     x1y1 = anchor_points - left_top
     x2y2 = anchor_points + right_bottom
-    return tf.concat((x1y1, x2y2), axis=-1)  # xyxy bbox
+    return ops.concatenate((x1y1, x2y2), axis=-1)  # xyxy bbox
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class YOLOV8Detector(Task):
     """Implements the YOLOV8 architecture for object detection.
 
@@ -403,7 +405,7 @@ class YOLOV8Detector(Task):
             backbone, extractor_layer_names, extractor_levels
         )
 
-        images = layers.Input(feature_extractor.input_shape[1:])
+        images = keras.layers.Input(feature_extractor.input_shape[1:])
         features = list(feature_extractor(images).values())
 
         fpn_features = apply_path_aggregation_fpn(
@@ -427,7 +429,7 @@ class YOLOV8Detector(Task):
         self.bounding_box_format = bounding_box_format
         self._prediction_decoder = (
             prediction_decoder
-            or keras_cv.layers.MultiClassNonMaxSuppression(
+            or keras_cv.layers.NonMaxSuppression(
                 bounding_box_format=bounding_box_format,
                 from_logits=False,
                 confidence_threshold=0.2,
@@ -510,40 +512,30 @@ class YOLOV8Detector(Task):
 
         super().compile(loss=losses, **kwargs)
 
-    def train_step(self, data):
+    def train_step(self, *args):
+        data = args[-1]
+        args = args[:-1]
         x, y = unpack_input(data)
+        return super().train_step(*args, (x, y))
 
-        with tf.GradientTape() as tape:
-            outputs = self(x, training=True)
-            box_pred, cls_pred = outputs["boxes"], outputs["classes"]
-            total_loss = self.compute_loss(x, y, box_pred, cls_pred)
-
-        trainable_vars = self.trainable_variables
-
-        gradients = tape.gradient(total_loss, trainable_vars)
-        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
-
-        return super().compute_metrics(x, {}, {}, sample_weight={})
-
-    def test_step(self, data):
+    def test_step(self, *args):
+        data = args[-1]
+        args = args[:-1]
         x, y = unpack_input(data)
+        return super().test_step(*args, (x, y))
 
-        outputs = self(x, training=False)
-        box_pred, cls_pred = outputs["boxes"], outputs["classes"]
-        _ = self.compute_loss(x, y, box_pred, cls_pred)
+    def compute_loss(self, x, y, y_pred, sample_weight=None, **kwargs):
+        box_pred, cls_pred = y_pred["boxes"], y_pred["classes"]
 
-        return super().compute_metrics(x, {}, {}, sample_weight={})
-
-    def compute_loss(self, x, y, box_pred, cls_pred):
         pred_boxes = decode_regression_to_boxes(box_pred)
         pred_scores = cls_pred
 
         anchor_points, stride_tensor = get_anchors(image_shape=x.shape[1:])
-        stride_tensor = tf.expand_dims(stride_tensor, axis=-1)
+        stride_tensor = ops.expand_dims(stride_tensor, axis=-1)
 
         gt_labels = y["classes"]
 
-        mask_gt = tf.reduce_all(y["boxes"] > -1.0, axis=-1, keepdims=True)
+        mask_gt = ops.all(y["boxes"] > -1.0, axis=-1, keepdims=True)
         gt_bboxes = bounding_box.convert_format(
             y["boxes"],
             source=self.bounding_box_format,
@@ -555,7 +547,7 @@ class YOLOV8Detector(Task):
 
         target_bboxes, target_scores, fg_mask = self.label_encoder(
             pred_scores,
-            tf.cast(pred_bboxes * stride_tensor, gt_bboxes.dtype),
+            ops.cast(pred_bboxes * stride_tensor, gt_bboxes.dtype),
             anchor_points * stride_tensor,
             gt_labels,
             gt_bboxes,
@@ -563,18 +555,18 @@ class YOLOV8Detector(Task):
         )
 
         target_bboxes /= stride_tensor
-        target_scores_sum = tf.math.maximum(tf.reduce_sum(target_scores), 1)
-        box_weight = tf.expand_dims(
-            tf.boolean_mask(tf.reduce_sum(target_scores, axis=-1), fg_mask),
+        target_scores_sum = ops.maximum(ops.sum(target_scores), 1)
+        box_weight = ops.expand_dims(
+            ops.sum(target_scores, axis=-1) * fg_mask,
             axis=-1,
         )
 
         y_true = {
-            "box": target_bboxes[fg_mask],
+            "box": target_bboxes * fg_mask[..., None],
             "class": target_scores,
         }
         y_pred = {
-            "box": pred_bboxes[fg_mask],
+            "box": pred_bboxes * fg_mask[..., None],
             "class": pred_scores,
         }
         sample_weights = {
@@ -583,7 +575,7 @@ class YOLOV8Detector(Task):
         }
 
         return super().compute_loss(
-            x=x, y=y_true, y_pred=y_pred, sample_weight=sample_weights
+            x=x, y=y_true, y_pred=y_pred, sample_weight=sample_weights, **kwargs
         )
 
     def decode_predictions(
@@ -597,7 +589,7 @@ class YOLOV8Detector(Task):
         boxes = decode_regression_to_boxes(boxes)
 
         anchor_points, stride_tensor = get_anchors(image_shape=images.shape[1:])
-        stride_tensor = tf.expand_dims(stride_tensor, axis=-1)
+        stride_tensor = ops.expand_dims(stride_tensor, axis=-1)
 
         box_preds = dist2bbox(boxes, anchor_points) * stride_tensor
         box_preds = bounding_box.convert_format(
@@ -609,8 +601,12 @@ class YOLOV8Detector(Task):
 
         return self.prediction_decoder(box_preds, scores)
 
-    def make_predict_function(self, force=False):
-        return predict_utils.make_predict_function(self, force=force)
+    def predict_step(self, *args):
+        outputs = super().predict_step(*args)
+        if isinstance(outputs, tuple):
+            return self.decode_predictions(outputs[0], args[-1]), outputs[1]
+        else:
+            return self.decode_predictions(outputs, args[-1])
 
     @property
     def prediction_decoder(self):
@@ -637,7 +633,7 @@ class YOLOV8Detector(Task):
             "num_classes": self.num_classes,
             "bounding_box_format": self.bounding_box_format,
             "fpn_depth": self.fpn_depth,
-            "backbone": keras.utils.serialize_keras_object(self.backbone),
+            "backbone": keras.saving.serialize_keras_object(self.backbone),
             "label_encoder": self.label_encoder,
             "prediction_decoder": self._prediction_decoder,
         }

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_label_encoder.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_label_encoder.py
@@ -16,10 +16,10 @@ and is adapted from https://github.com/ultralytics/ultralytics/blob/main/ultraly
 """  # noqa: E501
 
 import tensorflow as tf
-from tensorflow import keras
-from tensorflow.keras import layers
 
 from keras_cv import bounding_box
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 from keras_cv.bounding_box.iou import compute_ciou
 
 
@@ -29,37 +29,37 @@ def select_highest_overlaps(mask_pos, overlaps, max_num_boxes):
     Picks the GT box with the highest IoU.
     """
     # (b, max_num_boxes, num_anchors) -> (b, num_anchors)
-    fg_mask = tf.reduce_sum(mask_pos, axis=-2)
+    fg_mask = ops.sum(mask_pos, axis=-2)
 
     def handle_anchor_with_two_gt_boxes(
         fg_mask, mask_pos, overlaps, max_num_boxes
     ):
-        mask_multi_gts = tf.repeat(
-            tf.expand_dims(fg_mask, axis=1) > 1, max_num_boxes, axis=1
+        mask_multi_gts = ops.repeat(
+            ops.expand_dims(fg_mask, axis=1) > 1, max_num_boxes, axis=1
         )  # (b, max_num_boxes, num_anchors)
-        max_overlaps_idx = tf.argmax(overlaps, axis=1)  # (b, num_anchors)
-        is_max_overlaps = tf.one_hot(
+        max_overlaps_idx = ops.argmax(overlaps, axis=1)  # (b, num_anchors)
+        is_max_overlaps = ops.one_hot(
             max_overlaps_idx,
-            tf.cast(max_num_boxes, dtype=tf.int32),  # tf.one_hot must use int32
+            max_num_boxes,  # tf.one_hot must use int32
         )  # (b, num_anchors, max_num_boxes)
-        is_max_overlaps = tf.cast(
-            tf.transpose(is_max_overlaps, perm=(0, 2, 1)), overlaps.dtype
+        is_max_overlaps = ops.cast(
+            ops.transpose(is_max_overlaps, axes=(0, 2, 1)), overlaps.dtype
         )  # (b, max_num_boxes, num_anchors)
-        mask_pos = tf.where(
+        mask_pos = ops.where(
             mask_multi_gts, is_max_overlaps, mask_pos
         )  # (b, max_num_boxes, num_anchors)
-        fg_mask = tf.reduce_sum(mask_pos, axis=-2)
+        fg_mask = ops.sum(mask_pos, axis=-2)
         return fg_mask, mask_pos
 
-    fg_mask, mask_pos = tf.cond(
-        tf.reduce_max(fg_mask) > 1,
+    fg_mask, mask_pos = ops.cond(
+        ops.max(fg_mask) > 1,
         lambda: handle_anchor_with_two_gt_boxes(
             fg_mask, mask_pos, overlaps, max_num_boxes
         ),
         lambda: (fg_mask, mask_pos),
     )
 
-    target_gt_idx = tf.argmax(mask_pos, axis=-2)  # (b, num_anchors)
+    target_gt_idx = ops.argmax(mask_pos, axis=-2)  # (b, num_anchors)
     return target_gt_idx, fg_mask, mask_pos
 
 
@@ -72,27 +72,27 @@ def select_candidates_in_gts(xy_centers, gt_bboxes, epsilon=1e-9):
         and `False` otherwise.
     """
     n_anchors = xy_centers.shape[0]
-    n_boxes = tf.shape(gt_bboxes)[1]
+    n_boxes = ops.shape(gt_bboxes)[1]
 
-    left_top, right_bottom = tf.split(
-        tf.reshape(gt_bboxes, (-1, 1, 4)), 2, axis=-1
+    left_top, right_bottom = ops.split(
+        ops.reshape(gt_bboxes, (-1, 1, 4)), 2, axis=-1
     )
-    bbox_deltas = tf.reshape(
-        tf.concat(
+    bbox_deltas = ops.reshape(
+        ops.concatenate(
             [
-                xy_centers[tf.newaxis] - left_top,
-                right_bottom - xy_centers[tf.newaxis],
+                xy_centers[None] - left_top,
+                right_bottom - xy_centers[None],
             ],
             axis=2,
         ),
         (-1, n_boxes, n_anchors, 4),
     )
 
-    return tf.reduce_min(bbox_deltas, axis=-1) > epsilon
+    return ops.min(bbox_deltas, axis=-1, initial=float("inf")) > epsilon
 
 
 @keras.utils.register_keras_serializable(package="keras_cv")
-class YOLOV8LabelEncoder(layers.Layer):
+class YOLOV8LabelEncoder(keras.layers.Layer):
     """
     Encodes ground truth boxes to target boxes and class labels for training a
     YOLOV8 model. This is an implementation of the Task-aligned sample
@@ -174,7 +174,7 @@ class YOLOV8LabelEncoder(layers.Layer):
         if isinstance(mask_gt, tf.RaggedTensor):
             mask_gt = mask_gt.to_tensor()
 
-        max_num_boxes = tf.cast(tf.shape(gt_bboxes)[1], dtype=tf.int64)
+        max_num_boxes = ops.shape(gt_bboxes)[1]
 
         def encode_to_targets(
             pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt
@@ -198,14 +198,14 @@ class YOLOV8LabelEncoder(layers.Layer):
             )
 
             align_metric *= mask_pos
-            pos_align_metrics = tf.reduce_max(
+            pos_align_metrics = ops.max(
                 align_metric, axis=-1, keepdims=True
             )  # b, max_num_boxes
-            pos_overlaps = tf.reduce_max(
+            pos_overlaps = ops.max(
                 overlaps * mask_pos, axis=-1, keepdims=True
             )  # b, max_num_boxes
-            norm_align_metric = tf.expand_dims(
-                tf.reduce_max(
+            norm_align_metric = ops.expand_dims(
+                ops.max(
                     align_metric
                     * pos_overlaps
                     / (pos_align_metrics + self.epsilon),
@@ -217,21 +217,21 @@ class YOLOV8LabelEncoder(layers.Layer):
 
             # No need to compute gradients for these, as they're all targets
             return (
-                tf.stop_gradient(target_bboxes),
-                tf.stop_gradient(target_scores),
-                tf.stop_gradient(tf.cast(fg_mask, tf.bool)),
+                ops.stop_gradient(target_bboxes),
+                ops.stop_gradient(target_scores),
+                ops.stop_gradient(fg_mask),
             )
 
         # return zeros if no gt boxes are present
-        return tf.cond(
+        return ops.cond(
             max_num_boxes > 0,
             lambda: encode_to_targets(
                 pd_scores, pd_bboxes, anc_points, gt_labels, gt_bboxes, mask_gt
             ),
             lambda: (
-                tf.zeros_like(pd_bboxes),
-                tf.zeros_like(pd_scores),
-                tf.zeros_like(pd_scores[..., 0], dtype=tf.bool),
+                ops.zeros_like(pd_bboxes),
+                ops.zeros_like(pd_scores),
+                ops.zeros_like(pd_scores[..., 0]),
             ),
         )
 
@@ -267,21 +267,21 @@ class YOLOV8LabelEncoder(layers.Layer):
             pd_bboxes,
             gt_labels,
             gt_bboxes,
-            tf.cast(mask_in_gts, tf.int32) * tf.cast(mask_gt, tf.int32),
+            ops.cast(mask_in_gts, "int32") * ops.cast(mask_gt, "int32"),
             max_num_boxes,
         )
         # get topk_metric mask, (b, max_num_boxes, num_anchors)
         mask_topk = self.select_topk_candidates(
             align_metric,
-            topk_mask=tf.cast(
-                tf.repeat(mask_gt, self.max_anchor_matches, axis=2), tf.bool
+            topk_mask=ops.cast(
+                ops.repeat(mask_gt, self.max_anchor_matches, axis=2), "bool"
             ),
         )
         # merge all masks to a final mask, (b, max_num_boxes, num_anchors)
         mask_pos = (
             mask_topk
-            * tf.cast(mask_in_gts, tf.float32)
-            * tf.cast(mask_gt, tf.float32)
+            * ops.cast(mask_in_gts, "float32")
+            * ops.cast(mask_gt, "float32")
         )
 
         return mask_pos, align_metric, overlaps
@@ -301,33 +301,38 @@ class YOLOV8LabelEncoder(layers.Layer):
                     box and the predicted box at each anchor.
         """
         na = pd_bboxes.shape[-2]
-        mask_gt = tf.cast(mask_gt, tf.bool)  # b, max_num_boxes, num_anchors
+        mask_gt = ops.cast(mask_gt, "bool")  # b, max_num_boxes, num_anchors
 
-        ind_1 = tf.cast(gt_labels, tf.int64)
-        pd_scores = tf.gather(
-            pd_scores, tf.math.maximum(ind_1, 0), axis=-1, batch_dims=1
+        ind_1 = ops.cast(gt_labels, "int64")
+        pd_scores = ops.squeeze(
+            ops.take_along_axis(
+                pd_scores[:, None, :, :],
+                ops.cast(ops.maximum(ind_1[:, None, None, :], 0), "int32"),
+                axis=-1,
+            ),
+            axis=1,
         )
-        pd_scores = tf.where(ind_1[:, tf.newaxis, :] >= 0, pd_scores, 0.0)
-        pd_scores = tf.transpose(pd_scores, perm=(0, 2, 1))
+        pd_scores = ops.where(ind_1[:, None, :] >= 0, pd_scores, 0.0)
+        pd_scores = ops.transpose(pd_scores, axes=(0, 2, 1))
 
-        bbox_scores = tf.where(mask_gt, pd_scores, 0.0)
+        bbox_scores = ops.where(mask_gt, pd_scores, 0.0)
 
-        pd_boxes = tf.repeat(
-            tf.expand_dims(pd_bboxes, axis=1), max_num_boxes, axis=1
+        pd_boxes = ops.repeat(
+            ops.expand_dims(pd_bboxes, axis=1), max_num_boxes, axis=1
         )
 
-        gt_boxes = tf.repeat(tf.expand_dims(gt_bboxes, axis=2), na, axis=2)
+        gt_boxes = ops.repeat(ops.expand_dims(gt_bboxes, axis=2), na, axis=2)
 
-        iou = tf.squeeze(
+        iou = ops.squeeze(
             compute_ciou(gt_boxes, pd_boxes, bounding_box_format="xyxy"),
             axis=-1,
         )
-        iou = tf.where(iou > 0, iou, 0.0)
+        iou = ops.where(iou > 0, iou, 0.0)
 
-        iou = tf.reshape(iou, (-1, max_num_boxes, na))
-        overlaps = tf.where(mask_gt, iou, 0.0)
+        iou = ops.reshape(iou, (-1, max_num_boxes, na))
+        overlaps = ops.where(mask_gt, iou, 0.0)
 
-        align_metric = tf.math.pow(bbox_scores, self.alpha) * tf.math.pow(
+        align_metric = ops.power(bbox_scores, self.alpha) * ops.power(
             overlaps, self.beta
         )
         return align_metric, overlaps
@@ -343,28 +348,26 @@ class YOLOV8LabelEncoder(layers.Layer):
 
         num_anchors = metrics.shape[-1]  # num_anchors
         # (b, max_num_boxes, topk)
-        topk_metrics, topk_idxs = tf.math.top_k(
-            metrics, self.max_anchor_matches
-        )
-        topk_mask = tf.tile(
-            tf.reduce_max(topk_metrics, axis=-1, keepdims=True) > self.epsilon,
+        topk_metrics, topk_idxs = ops.top_k(metrics, self.max_anchor_matches)
+        topk_mask = ops.tile(
+            ops.max(topk_metrics, axis=-1, keepdims=True) > self.epsilon,
             [1, 1, self.max_anchor_matches],
         )
 
         # (b, max_num_boxes, topk)
-        topk_idxs = tf.where(topk_mask, topk_idxs, 0)
-        is_in_topk = tf.zeros_like(metrics, dtype=tf.int64)
+        topk_idxs = ops.where(topk_mask, topk_idxs, 0)
+        is_in_topk = ops.zeros_like(metrics, dtype="int64")
 
         for it in range(self.max_anchor_matches):
-            is_in_topk += tf.one_hot(
-                topk_idxs[:, :, it], num_anchors, dtype=tf.int64
+            is_in_topk += ops.one_hot(
+                topk_idxs[:, :, it], num_anchors, dtype="int64"
             )
 
         # filter invalid bboxes
-        is_in_topk = tf.where(
-            is_in_topk > 1, tf.constant(0, tf.int64), is_in_topk
+        is_in_topk = ops.where(
+            is_in_topk > 1, ops.array(0, "int64"), is_in_topk
         )
-        return tf.cast(is_in_topk, metrics.dtype)
+        return ops.cast(is_in_topk, metrics.dtype)
 
     def get_targets(
         self, gt_labels, gt_bboxes, target_gt_idx, fg_mask, max_num_boxes
@@ -379,31 +382,33 @@ class YOLOV8LabelEncoder(layers.Layer):
                     representing target classes for each anchor.
         """
 
-        batch_ind = tf.range(tf.shape(gt_labels)[0], dtype=tf.int64)[
-            ..., tf.newaxis
+        batch_ind = ops.arange(ops.shape(gt_labels)[0], dtype="int64")[
+            ..., None
         ]
-        target_gt_idx = target_gt_idx + batch_ind * max_num_boxes
+        target_gt_idx = target_gt_idx + batch_ind * ops.cast(
+            max_num_boxes, "int64"
+        )
 
-        gt_bboxes = tf.reshape(gt_bboxes, (-1, tf.shape(gt_bboxes)[1], 4))
+        gt_bboxes = keras.layers.Reshape((-1, 4))(gt_bboxes)
 
-        target_labels = tf.gather(
-            tf.reshape(tf.cast(gt_labels, tf.int64), (-1,)), target_gt_idx
+        target_labels = ops.take(
+            ops.reshape(ops.cast(gt_labels, "int64"), (-1,)), target_gt_idx
         )  # (b, num_anchors)
 
         # assigned target boxes, (b, max_num_boxes, 4) -> (b, num_anchors)
-        target_bboxes = tf.gather(
-            tf.reshape(gt_bboxes, (-1, 4)), target_gt_idx, axis=-2
+        target_bboxes = ops.take(
+            ops.reshape(gt_bboxes, (-1, 4)), target_gt_idx, axis=-2
         )
 
         # assigned target scores
-        target_labels = tf.math.maximum(target_labels, 0)
-        target_scores = tf.one_hot(
+        target_labels = ops.maximum(target_labels, 0)
+        target_scores = ops.one_hot(
             target_labels, self.num_classes
         )  # (b, num_anchors, num_classes)
-        fg_scores_mask = tf.repeat(
-            fg_mask[:, :, tf.newaxis], self.num_classes, axis=2
+        fg_scores_mask = ops.repeat(
+            fg_mask[:, :, None], self.num_classes, axis=2
         )  # (b, num_anchors, num_classes)
-        target_scores = tf.where(fg_scores_mask > 0, target_scores, 0)
+        target_scores = ops.where(fg_scores_mask > 0, target_scores, 0)
 
         return target_bboxes, target_scores
 

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_layers.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_layers.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tensorflow as tf
-from keras import layers
+from keras_cv.backend import keras
+from keras_cv.backend import ops
 
 BATCH_NORM_EPSILON = 1e-3
 BATCH_NORM_MOMENTUM = 0.97
@@ -29,11 +29,11 @@ def apply_conv_bn(
     name="conv_bn",
 ):
     if kernel_size > 1:
-        inputs = layers.ZeroPadding2D(
+        inputs = keras.layers.ZeroPadding2D(
             padding=kernel_size // 2, name=f"{name}_pad"
         )(inputs)
 
-    x = layers.Conv2D(
+    x = keras.layers.Conv2D(
         filters=output_channel,
         kernel_size=kernel_size,
         strides=strides,
@@ -41,12 +41,12 @@ def apply_conv_bn(
         use_bias=False,
         name=f"{name}_conv",
     )(inputs)
-    x = layers.BatchNormalization(
+    x = keras.layers.BatchNormalization(
         momentum=BATCH_NORM_MOMENTUM,
         epsilon=BATCH_NORM_EPSILON,
         name=f"{name}_bn",
     )(x)
-    x = layers.Activation(activation, name=name)(x)
+    x = keras.layers.Activation(activation, name=name)(x)
     return x
 
 
@@ -72,7 +72,7 @@ def apply_csp_block(
         activation=activation,
         name=f"{name}_pre",
     )
-    short, deep = tf.split(pre, 2, axis=channel_axis)
+    short, deep = ops.split(pre, 2, axis=channel_axis)
 
     out = [short, deep]
     for id in range(depth):
@@ -92,7 +92,7 @@ def apply_csp_block(
         )
         deep = (out[-1] + deep) if shortcut else deep
         out.append(deep)
-    out = tf.concat(out, axis=channel_axis)
+    out = ops.concatenate(out, axis=channel_axis)
     out = apply_conv_bn(
         out,
         channels,

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -15,13 +15,12 @@
 
 import os
 
-from tensorflow import keras
-
+from keras_cv.backend import keras
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 
 
-@keras.utils.register_keras_serializable(package="keras_cv")
+@keras.saving.register_keras_serializable(package="keras_cv")
 class Task(keras.Model):
     """Base class for Task models."""
 
@@ -130,7 +129,7 @@ class Task(keras.Model):
         metadata = cls.presets[preset]
         # Check if preset is backbone-only model
         if preset in cls.backbone_presets:
-            backbone_cls = keras.utils.get_registered_object(
+            backbone_cls = keras.saving.get_registered_object(
                 metadata["class_name"]
             )
             backbone = backbone_cls.from_preset(preset, load_weights)
@@ -164,7 +163,7 @@ class Task(keras.Model):
         # the `backbone` as a layer, because it will be included in the model
         # summary and saves weights despite not being part of the model graph.
         layers = super().layers
-        if hasattr(self, "_backbone") and self.backbone in layers:
+        if hasattr(self, "backbone") and self.backbone in layers:
             # We know that the backbone is not part of the graph if it has no
             # inbound nodes.
             if len(self.backbone._inbound_nodes) == 0:

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -170,6 +170,13 @@ class Task(keras.Model):
                 layers.remove(self.backbone)
         return layers
 
+    def __setattr__(self, name, value):
+        # Work around torch setattr for properties.
+        if name in ["backbone"]:
+            object.__setattr__(self, name, value)
+        else:
+            super().__setattr__(name, value)
+
     def __init_subclass__(cls, **kwargs):
         # Use __init_subclass__ to set up a correct docstring for from_preset.
         super().__init_subclass__(**kwargs)

--- a/keras_cv/models/utils.py
+++ b/keras_cv/models/utils.py
@@ -14,17 +14,23 @@
 # ==============================================================================
 """Utility functions for models"""
 
-from keras import backend
-from keras import layers
-from tensorflow import keras
+from keras_cv.backend import keras
+from keras_cv.backend.config import multi_backend
+
+
+def get_tensor_input_name(tensor):
+    if multi_backend():
+        return tensor._keras_history.operation.name
+    else:
+        return tensor.node.layer.name
 
 
 def parse_model_inputs(input_shape, input_tensor):
     if input_tensor is None:
-        return layers.Input(shape=input_shape)
+        return keras.layers.Input(shape=input_shape)
     else:
         if not keras.backend.is_keras_tensor(input_tensor):
-            return layers.Input(tensor=input_tensor, shape=input_shape)
+            return keras.layers.Input(tensor=input_tensor, shape=input_shape)
         else:
             return input_tensor
 
@@ -40,7 +46,7 @@ def correct_pad_downsample(inputs, kernel_size):
         A tuple.
     """
     img_dim = 1
-    input_size = backend.int_shape(inputs)[img_dim : (img_dim + 2)]
+    input_size = inputs.shape[img_dim : (img_dim + 2)]
     if isinstance(kernel_size, int):
         kernel_size = (kernel_size, kernel_size)
     if input_size[0] is None:

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -17,6 +17,7 @@ from tensorflow import keras
 from tensorflow.keras import backend
 
 from keras_cv import core
+from keras_cv.backend import ops
 
 _TF_INTERPOLATION_METHODS = {
     "bilinear": tf.image.ResizeMethod.BILINEAR,
@@ -376,10 +377,10 @@ def transform(
 
 def ensure_tensor(inputs, dtype=None):
     """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
-    if not isinstance(inputs, (tf.Tensor, tf.RaggedTensor, tf.SparseTensor)):
-        inputs = tf.convert_to_tensor(inputs, dtype)
+    if not ops.is_tensor(inputs):
+        inputs = ops.convert_to_tensor(inputs, dtype)
     if dtype is not None and inputs.dtype != dtype:
-        inputs = tf.cast(inputs, dtype)
+        inputs = ops.cast(inputs, dtype)
     return inputs
 
 

--- a/keras_cv/utils/resource_loader.py
+++ b/keras_cv/utils/resource_loader.py
@@ -22,7 +22,7 @@ import warnings
 
 import tensorflow as tf
 
-TF_VERSION_FOR_ABI_COMPATIBILITY = "2.11"
+TF_VERSION_FOR_ABI_COMPATIBILITY = "2.13"
 abi_warning_already_raised = False
 
 

--- a/keras_cv/utils/target_gather.py
+++ b/keras_cv/utils/target_gather.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
+from keras_cv.backend import ops
 
 
 def _target_gather(
-    targets: tf.Tensor,
-    indices: tf.Tensor,
+    targets,
+    indices,
     mask=None,
     mask_val=0.0,
 ):
@@ -46,7 +46,7 @@ def _target_gather(
      Raise:
        ValueError: If `targets` is higher than rank 3.
     """
-    targets_shape = targets.get_shape().as_list()
+    targets_shape = list(targets.shape)
     if len(targets_shape) > 3:
         raise ValueError(
             "`target_gather` does not support `targets` with rank "
@@ -55,32 +55,31 @@ def _target_gather(
 
     def _gather_unbatched(labels, match_indices, mask, mask_val):
         """Gather based on unbatched labels and boxes."""
-        num_gt_boxes = tf.shape(labels)[0]
+        num_gt_boxes = labels.shape[0]
 
         def _assign_when_rows_empty():
             if len(labels.shape) > 1:
                 mask_shape = [match_indices.shape[0], labels.shape[-1]]
             else:
                 mask_shape = [match_indices.shape[0]]
-            return tf.cast(mask_val, labels.dtype) * tf.ones(
+            return ops.cast(mask_val, labels.dtype) * ops.ones(
                 mask_shape, dtype=labels.dtype
             )
 
         def _assign_when_rows_not_empty():
-            targets = tf.gather(labels, match_indices)
+            targets = ops.take(labels, match_indices, axis=0)
             if mask is None:
                 return targets
             else:
-                masked_targets = tf.cast(mask_val, labels.dtype) * tf.ones_like(
-                    mask, dtype=labels.dtype
-                )
-                return tf.where(mask, masked_targets, targets)
+                masked_targets = ops.cast(
+                    mask_val, labels.dtype
+                ) * ops.ones_like(mask, dtype=labels.dtype)
+                return ops.where(mask, masked_targets, targets)
 
-        return tf.cond(
-            tf.greater(num_gt_boxes, 0),
-            _assign_when_rows_not_empty,
-            _assign_when_rows_empty,
-        )
+        if num_gt_boxes > 0:
+            return _assign_when_rows_not_empty()
+        else:
+            return _assign_when_rows_empty()
 
     def _gather_batched(labels, match_indices, mask, mask_val):
         """Gather based on batched labels."""
@@ -88,36 +87,31 @@ def _target_gather(
         if batch_size == 1:
             if mask is not None:
                 result = _gather_unbatched(
-                    tf.squeeze(labels, axis=0),
-                    tf.squeeze(match_indices, axis=0),
-                    tf.squeeze(mask, axis=0),
+                    ops.squeeze(labels, axis=0),
+                    ops.squeeze(match_indices, axis=0),
+                    ops.squeeze(mask, axis=0),
                     mask_val,
                 )
             else:
                 result = _gather_unbatched(
-                    tf.squeeze(labels, axis=0),
-                    tf.squeeze(match_indices, axis=0),
+                    ops.squeeze(labels, axis=0),
+                    ops.squeeze(match_indices, axis=0),
                     None,
                     mask_val,
                 )
-            return tf.expand_dims(result, axis=0)
+            return ops.expand_dims(result, axis=0)
         else:
-            indices_shape = tf.shape(match_indices)
-            indices_dtype = match_indices.dtype
-            batch_indices = tf.expand_dims(
-                tf.range(indices_shape[0], dtype=indices_dtype), axis=-1
-            ) * tf.ones([1, indices_shape[-1]], dtype=indices_dtype)
-            gather_nd_indices = tf.stack(
-                [batch_indices, match_indices], axis=-1
+            targets = ops.take_along_axis(
+                labels, ops.expand_dims(match_indices, axis=-1), axis=1
             )
-            targets = tf.gather_nd(labels, gather_nd_indices)
+
             if mask is None:
                 return targets
             else:
-                masked_targets = tf.cast(mask_val, labels.dtype) * tf.ones_like(
-                    mask, dtype=labels.dtype
-                )
-                return tf.where(mask, masked_targets, targets)
+                masked_targets = ops.cast(
+                    mask_val, labels.dtype
+                ) * ops.ones_like(mask, dtype=labels.dtype)
+                return ops.where(mask, masked_targets, targets)
 
     if len(targets_shape) <= 2:
         return _gather_unbatched(targets, indices, mask, mask_val)

--- a/keras_cv/utils/target_gather_test.py
+++ b/keras_cv/utils/target_gather_test.py
@@ -12,106 +12,109 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import tensorflow as tf
 
+from keras_cv.backend import ops
 from keras_cv.utils.target_gather import _target_gather
 
 
 class TargetGatherTest(tf.test.TestCase):
     def test_target_gather_boxes_batched(self):
-        target_boxes = tf.constant(
+        target_boxes = np.array(
             [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
         )
-        target_boxes = target_boxes[tf.newaxis, ...]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
-        expected_boxes = expected_boxes[tf.newaxis, ...]
+        target_boxes = ops.expand_dims(target_boxes, axis=0)
+        indices = np.array([[0, 2]], dtype="int32")
+        expected_boxes = np.array([[0, 0, 5, 5], [5, 0, 10, 5]])
+        expected_boxes = ops.expand_dims(expected_boxes, axis=0)
         res = _target_gather(target_boxes, indices)
         self.assertAllClose(expected_boxes, res)
 
     def test_target_gather_boxes_unbatched(self):
-        target_boxes = tf.constant(
-            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]]
+        target_boxes = np.array(
+            [[0, 0, 5, 5], [0, 5, 5, 10], [5, 0, 10, 5], [5, 5, 10, 10]],
+            "int32",
         )
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        expected_boxes = tf.constant([[0, 0, 5, 5], [5, 0, 10, 5]])
+        indices = np.array([0, 2], dtype="int32")
+        expected_boxes = np.array([[0, 0, 5, 5], [5, 0, 10, 5]])
         res = _target_gather(target_boxes, indices)
         self.assertAllClose(expected_boxes, res)
 
     def test_target_gather_classes_batched(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        expected_classes = tf.constant([[1, 3]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        expected_classes = np.array([[1, 3]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_unbatched(self):
-        target_classes = tf.constant([1, 2, 3, 4])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        expected_classes = tf.constant([1, 3])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([1, 2, 3, 4])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
+        expected_classes = np.array([1, 3])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_batched_with_mask(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        masks = tf.constant(([[False, True]]))
-        masks = masks[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        masks = np.array(([[False, True]]))
+        masks = ops.expand_dims(masks, axis=-1)
         # the second element is masked
-        expected_classes = tf.constant([[1, 0]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([[1, 0]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_batched_with_mask_val(self):
-        target_classes = tf.constant([[1, 2, 3, 4]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2]], dtype=tf.int32)
-        masks = tf.constant(([[False, True]]))
-        masks = masks[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2]], dtype="int32")
+        masks = np.array(([[False, True]]))
+        masks = ops.expand_dims(masks, axis=-1)
         # the second element is masked
-        expected_classes = tf.constant([[1, -1]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([[1, -1]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks, -1)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_unbatched_with_mask(self):
-        target_classes = tf.constant([1, 2, 3, 4])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
-        masks = tf.constant([False, True])
-        masks = masks[..., tf.newaxis]
-        expected_classes = tf.constant([1, 0])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([1, 2, 3, 4])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
+        masks = np.array([False, True])
+        masks = ops.expand_dims(masks, axis=-1)
+        expected_classes = np.array([1, 0])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices, masks)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_with_empty_targets(self):
-        target_classes = tf.constant([])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([0, 2], dtype=tf.int32)
+        target_classes = np.array([])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([0, 2], dtype="int32")
         # return all 0s since input is empty
-        expected_classes = tf.constant([0, 0])
-        expected_classes = expected_classes[..., tf.newaxis]
+        expected_classes = np.array([0, 0])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_classes_multi_batch(self):
-        target_classes = tf.constant([[1, 2, 3, 4], [5, 6, 7, 8]])
-        target_classes = target_classes[..., tf.newaxis]
-        indices = tf.constant([[0, 2], [1, 3]], dtype=tf.int32)
-        expected_classes = tf.constant([[1, 3], [6, 8]])
-        expected_classes = expected_classes[..., tf.newaxis]
+        target_classes = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        target_classes = ops.expand_dims(target_classes, axis=-1)
+        indices = np.array([[0, 2], [1, 3]], dtype="int32")
+        expected_classes = np.array([[1, 3], [6, 8]])
+        expected_classes = ops.expand_dims(expected_classes, axis=-1)
         res = _target_gather(target_classes, indices)
         self.assertAllClose(expected_classes, res)
 
     def test_target_gather_invalid_rank(self):
-        targets = tf.random.normal([32, 2, 2, 2])
-        indices = tf.constant([0, 1], dtype=tf.int32)
+        targets = np.random.normal(size=[32, 2, 2, 2])
+        indices = np.array([0, 1], dtype="int32")
         with self.assertRaisesRegex(ValueError, "larger than 3"):
             _ = _target_gather(targets, indices)

--- a/keras_cv/utils/to_numpy.py
+++ b/keras_cv/utils/to_numpy.py
@@ -14,15 +14,14 @@
 import numpy as np
 import tensorflow as tf
 
+from keras_cv.backend import ops
+
 
 def to_numpy(x):
     if x is None:
         return None
     if isinstance(x, tf.RaggedTensor):
         x = x.to_tensor(-1)
-    if isinstance(x, tf.Tensor):
-        x = x.numpy()
-    if not isinstance(x, (np.ndarray, np.generic)):
-        x = np.array(x)
+    x = ops.convert_to_numpy(x)
     # Important for consistency when working with visualization utilities
     return np.ascontiguousarray(x)

--- a/keras_cv/utils/train.py
+++ b/keras_cv/utils/train.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import tensorflow as tf
-from tensorflow import keras
+
+from keras_cv.backend import keras
 
 
 def scale_loss_for_distribution(loss_value):

--- a/keras_cv/version_check.py
+++ b/keras_cv/version_check.py
@@ -18,7 +18,7 @@
 import tensorflow as tf
 from packaging.version import parse
 
-MIN_VERSION = "2.11.0"
+MIN_VERSION = "2.12.0"
 
 
 def check_tf_version():

--- a/keras_cv/version_check.py
+++ b/keras_cv/version_check.py
@@ -18,7 +18,7 @@
 import tensorflow as tf
 from packaging.version import parse
 
-MIN_VERSION = "2.12.0"
+MIN_VERSION = "2.13.0"
 
 
 def check_tf_version():

--- a/keras_cv/version_check_test.py
+++ b/keras_cv/version_check_test.py
@@ -29,18 +29,18 @@ def cleanup_tf_version():
 
 
 def test_check_tf_version_error():
-    tf.__version__ = "2.11.0"
+    tf.__version__ = "2.12.0"
 
     with pytest.raises(
         RuntimeError,
-        match="Tensorflow package version needs to be at least 2.12.0",
+        match="Tensorflow package version needs to be at least 2.13.0",
     ):
         version_check.check_tf_version()
 
 
 def test_check_tf_version_passes_rc2():
     # should pass
-    tf.__version__ = "2.12.1rc2"
+    tf.__version__ = "2.13.1rc2"
     version_check.check_tf_version()
 
 

--- a/keras_cv/version_check_test.py
+++ b/keras_cv/version_check_test.py
@@ -29,22 +29,22 @@ def cleanup_tf_version():
 
 
 def test_check_tf_version_error():
-    tf.__version__ = "2.8.0"
+    tf.__version__ = "2.11.0"
 
     with pytest.raises(
         RuntimeError,
-        match="Tensorflow package version needs to be at least 2.11.0",
+        match="Tensorflow package version needs to be at least 2.12.0",
     ):
         version_check.check_tf_version()
 
 
 def test_check_tf_version_passes_rc2():
     # should pass
-    tf.__version__ = "2.11.1rc2"
+    tf.__version__ = "2.12.1rc2"
     version_check.check_tf_version()
 
 
 def test_check_tf_version_passes_nightly():
     # should pass
-    tf.__version__ = "2.12.0-dev20230119"
+    tf.__version__ = "2.14.0-dev20230119"
     version_check.check_tf_version()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ isort
 black
 pytest
 pycocotools
+keras-core


### PR DESCRIPTION
# What does this PR do?

This PR adds support for [Keras Core](https://pypi.org/project/keras-core/#description), a new multi-backend implementation for Keras with support for TensorFlow, Jax, and PyTorch. Several backbones and layers have been ported to keras-core along with two object detection models, RetinaNet and YOLOV8.

Backbones ported:

- ResNetV1 (ianstenbit/keras-cv#1)
- ResNetV2 (ianstenbit/keras-cv#2)
- EfficientNetV2 (ianstenbit/keras-cv#2)
- ImageClassifier (ianstenbit/keras-cv#2)
- CSPDarkNet (ianstenbit/keras-cv#4)
- DarkNet (ianstenbit/keras-cv#4)
- MobileNet (ianstenbit/keras-cv#5, ianstenbit/keras-cv#6)
- DenseNet (ianstenbit/keras-cv#7)

Other components ported:

- Object detection layers (ianstenbit/keras-cv#12)
- Preprocessing layers (with TF-only support) (ianstenbit/keras-cv#14, ianstenbit/keras-cv#18)
- Losses (ianstenbit/keras-cv#10)
- Bounding Box utils (ianstenbit/keras-cv#11)
- PyCOCOCallback (ianstenbit/keras-cv#15)

RetinaNet PR: ianstenbit/keras-cv#13
YOLOV8 PR: ianstenbit/keras-cv#8, keras-team/keras-cv#1920

## Who can review?

@ianstenbit @jbischof @fchollet 
