### PR TITLE
Remove unneeded environment variable

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,7 +75,6 @@ jobs:
     - name: Test with pytest
       env:
         TEST_CUSTOM_OPS: false # TODO(ianstenbit): test custom ops, or figure out what our story is here
-        KERAS_CV_MULTI_BACKEND: true
         KERAS_BACKEND: ${{ matrix.backend }}
         JAX_ENABLE_X64: true
       run: |

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -56,11 +56,6 @@ if not os.path.exists(_config_path):
         # Except permission denied.
         pass
 
-# Set Keras backend based on KERAS_CV_MULTI_BACKEND flag, if applicable.
-if "KERAS_CV_MULTI_BACKEND" in os.environ:
-    if os.environ["KERAS_CV_MULTI_BACKEND"]:
-        _MULTI_BACKEND = True
-
 if "KERAS_BACKEND" in os.environ and os.environ["KERAS_BACKEND"]:
     _MULTI_BACKEND = True
 


### PR DESCRIPTION
Setting `KERAS_BACKEND` should be enough to trigger Keras Core usage