### PR TITLE
Fix MBConv Layer for Quickstart

### DIFF
--- a/keras_cv/layers/fusedmbconv.py
+++ b/keras_cv/layers/fusedmbconv.py
@@ -168,6 +168,13 @@ class FusedMBConvBlock(keras.layers.Layer):
             name=self.name + "project_bn",
         )
 
+        if self.survival_probability:
+            self.dropout = keras.layers.Dropout(
+                self.survival_probability,
+                noise_shape=(None, 1, 1, 1),
+                name=self.name + "drop",
+            )
+
     def build(self, input_shape):
         if self.name is None:
             self.name = keras.backend.get_uid("block0")
@@ -209,11 +216,7 @@ class FusedMBConvBlock(keras.layers.Layer):
         # Residual:
         if self.strides == 1 and self.input_filters == self.output_filters:
             if self.survival_probability:
-                x = keras.layers.Dropout(
-                    self.survival_probability,
-                    noise_shape=(None, 1, 1, 1),
-                    name=self.name + "drop",
-                )(x)
+                x = self.dropout(x)
             x = keras.layers.add([x, inputs], name=self.name + "add")
         return x
 

--- a/keras_cv/layers/mbconv.py
+++ b/keras_cv/layers/mbconv.py
@@ -224,11 +224,7 @@ class MBConvBlock(keras.layers.Layer):
 
         if self.strides == 1 and self.input_filters == self.output_filters:
             if self.survival_probability:
-                x = keras.layers.Dropout(
-                    self.survival_probability,
-                    noise_shape=(None, 1, 1, 1),
-                    name=self.name + "drop",
-                )(x)
+                x = self.dropout(x)
             x = keras.layers.add([x, inputs], name=self.name + "add")
         return x
 

--- a/keras_cv/layers/mbconv.py
+++ b/keras_cv/layers/mbconv.py
@@ -175,6 +175,13 @@ class MBConvBlock(keras.layers.Layer):
             name=self.name + "project_bn",
         )
 
+        if self.survival_probability:
+            self.dropout = keras.layers.Dropout(
+                self.survival_probability,
+                noise_shape=(None, 1, 1, 1),
+                name=self.name + "drop",
+            )
+
     def build(self, input_shape):
         if self.name is None:
             self.name = keras.backend.get_uid("block0")


### PR DESCRIPTION
With TF backend, noise_shape + Dropout has to be created during init, not in the model `call`

Fixes #1940.