### PR TITLE
U-Net Research Paper Attached, Linter Issue Solved

### DIFF
--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -178,7 +178,7 @@ def UNet(
     function that acts on tensors as inputs.
 
     Reference:
-        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://bit.ly/3rG7Fda)       
+        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597) #noqa:E501  
     Args:
         input_shape: the rank 3 shape of the input to the UNet
         down_block_configs: a list of (filter_count, num_blocks) tuples

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -178,7 +178,8 @@ def UNet(
     function that acts on tensors as inputs.
 
     Reference:
-        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
+        - [U-Net: Convolutional Networks for Biomedical Image Segmentation]
+          (https://arxiv.org/abs/1505.04597)
         
     Args:
         input_shape: the rank 3 shape of the input to the UNet

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -181,7 +181,7 @@ def UNet(
         - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
 
             U-Net relies on strong use of Data Augmentation and architecture consists of a contracting path to capture 
-            context and a symmetric expanding path that enables precise localization.
+            
     
     Args:
         input_shape: the rank 3 shape of the input to the UNet

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -179,10 +179,7 @@ def UNet(
 
     Reference:
         - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
-
-       
-            
-    
+        
     Args:
         input_shape: the rank 3 shape of the input to the UNet
         down_block_configs: a list of (filter_count, num_blocks) tuples

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -178,7 +178,7 @@ def UNet(
     function that acts on tensors as inputs.
 
     Reference:
-        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597) #noqa:E501  
+        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
     Args:
         input_shape: the rank 3 shape of the input to the UNet
         down_block_configs: a list of (filter_count, num_blocks) tuples
@@ -186,7 +186,7 @@ def UNet(
         up_block_configs: a list of filter counts, one for each up block
         down_block: a downsampling block
         up_block: an upsampling block
-    """
+    """ # noqa: E501
 
     input = layers.Input(shape=input_shape)
     x = input

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -178,9 +178,7 @@ def UNet(
     function that acts on tensors as inputs.
 
     Reference:
-        - [U-Net: Convolutional Networks for Biomedical Image Segmentation]
-          (https://arxiv.org/abs/1505.04597)
-        
+        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://bit.ly/3rG7Fda)       
     Args:
         input_shape: the rank 3 shape of the input to the UNet
         down_block_configs: a list of (filter_count, num_blocks) tuples

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -180,7 +180,7 @@ def UNet(
     Reference:
         - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
 
-            U-Net relies on strong use of Data Augmentation and architecture consists of a contracting path to capture 
+       
             
     
     Args:

--- a/keras_cv/models/__internal__/unet.py
+++ b/keras_cv/models/__internal__/unet.py
@@ -177,6 +177,12 @@ def UNet(
     All function parameters require curried functions as inputs which return a
     function that acts on tensors as inputs.
 
+    Reference:
+        - [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597)
+
+            U-Net relies on strong use of Data Augmentation and architecture consists of a contracting path to capture 
+            context and a symmetric expanding path that enables precise localization.
+    
     Args:
         input_shape: the rank 3 shape of the input to the UNet
         down_block_configs: a list of (filter_count, num_blocks) tuples


### PR DESCRIPTION
# What does this PR do?
The original Research Paper of U-Net Is Attached, Along With That Linter Issue, Has Been Resolved. 

Fixes # (issue)
Linter Issue Has Been Resolved. The Linter Showed Error Because The Docstring Was too long, so I kept the name of the research paper in one line, and research paper link in other line.


## Before submitting
- [ ] This PR fixes a typo or improves the docs
Updates In Docstring of U-Net Research Paper
## Who can review?
@ianstenbit 

This Pull Request Is Successor of the PR #1954 
