### PR TITLE
DeepLabV3Plus Type Fix

### DIFF
--- a/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus.py
+++ b/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus.py
@@ -16,6 +16,7 @@ import copy
 
 from keras_cv.backend import keras
 from keras_cv.layers.spatial_pyramid import SpatialPyramidPooling
+from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.models.backbones.backbone_presets import backbone_presets
 from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
@@ -97,12 +98,14 @@ class DeepLabV3Plus(Task):
         segmentation_head=None,
         **kwargs,
     ):
-        if not isinstance(backbone, keras.layers.Layer) or not isinstance(
-            backbone, keras.Model
+        if (
+            not isinstance(backbone, keras.layers.Layer)
+            or not isinstance(backbone, keras.Model)
+            or not issubclass(backbone.__class__, Backbone)
         ):
             raise ValueError(
                 "Argument `backbone` must be a `keras.layers.Layer` instance "
-                f" or `keras.Model`. Received instead "
+                f" or `keras.Model` or `keras_cv.models.backbones.backbone.Backbone`. Received instead "
                 f"backbone={backbone} (of type {type(backbone)})."
             )
 


### PR DESCRIPTION
# What does this PR do?

The code showcasing the basic usage of DeepLabV3Plus:

```
import tensorflow as tf
import keras_cv

images = np.ones(shape=(1, 96, 96, 3))
labels = np.zeros(shape=(1, 96, 96, 1))
backbone = keras_cv.models.ResNet50V2Backbone(input_shape=[96, 96, 3])
model = keras_cv.models.segmentation.DeepLabV3Plus(
    num_classes=1, backbone=backbone,
)

# Evaluate model
model(images)

# Train model
model.compile(
    optimizer="adam",
    loss=keras.losses.BinaryCrossentropy(from_logits=False),
    metrics=["accuracy"],
)
model.fit(images, labels, epochs=3)
```

Throws an error:

```
ValueError: Argument `backbone` must be a `keras.layers.Layer` instance  or `keras.Model`. Received instead backbone=<ResNetV2Backbone name=res_net_v2_backbone, built=True> (of type <class 'keras_cv.models.backbones.resnet_v2.resnet_v2_backbone.ResNetV2Backbone'>).
```

Because the model is of type `keras_cv.models.backbones.backbone.Backbone`. The PR just adds an additional check as to whether the provided backbone is a subclass of `keras_cv.models.backbones.backbone.Backbone` or not and updates the error appropriately.

## Unit Tests

Surprisingly enough, this unit test fails for me locally:

```
from keras_cv.models import DeepLabV3Plus
from keras_cv.models import ResNet18V2Backbone

backbone = ResNet18V2Backbone(input_shape=[512, 512, 3])
model = DeepLabV3Plus(backbone=backbone, num_classes=1)
model.compile(
    optimizer="adam",
    loss=keras.losses.BinaryCrossentropy(),
    metrics=["accuracy"],
)
```

Does it seem to pass on build on GitHub actions?

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?

## Who can review?

@ianstenbit @jbischof 