### PR TITLE
Remove pinning of keras-core, set min TF vers to 2.13

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,10 +29,10 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.13.0
+        pip install tensorflow>=2.13.0
         pip install torch>=2.0.1+cpu
         pip install "jax[cpu]"
-        pip install keras-core==0.1.0
+        pip install keras-core
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:
@@ -66,11 +66,11 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.13.0
+        pip install tensorflow>=2.13.0
         pip install "jax[cpu]"
         pip install torch>=2.0.1+cpu
         pip install torchvision>=0.15.1
-        pip install keras-core==0.1.0
+        pip install keras-core
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Test with pytest
       env:
@@ -112,7 +112,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        pip install tensorflow==2.11.0
+        pip install tensorflow>=2.13.0
         pip install -e ".[tests]" --progress-bar off --upgrade
     - name: Lint
       run: bash shell/lint.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,20 @@ jobs:
         # To switch on windows-2022/latest, please verify the bazel version:
         # https://github.com/bazelbuild/bazel/issues/14232#issuecomment-1011247429
         os: ['macos-12', 'windows-2019', 'ubuntu-18.04']
-        py-version: ['3.7', '3.8', '3.9', '3.10']
-        tf-version: ['2.11.0']
+        py-version: ['3.8', '3.9', '3.10', '3.11']
+        tf-version: ['2.13.0']
         use-macos-arm: [false]
         include:
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.13.0'
             py-version: '3.8'
             use-macos-arm: true
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.13.0'
             py-version: '3.9'
             use-macos-arm: true
           - os: 'macos-12'
-            tf-version: '2.11.0'
+            tf-version: '2.13.0'
             py-version: '3.10'
             use-macos-arm: true
       fail-fast: false
@@ -96,10 +96,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Build wheels
       run: |
-        pip install tensorflow==2.11.0
+        pip install tensorflow==2.13.0
         python -m pip install --upgrade pip setuptools wheel twine
         export BUILD_WITH_CUSTOM_OPS=false
         python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         "tensorflow-datasets",
         "keras-core",
     ],
-    python_requires=">=3.7",
     extras_require={
         "tests": [
             "flake8",
@@ -70,9 +69,16 @@ setup(
         "examples": ["tensorflow_datasets", "matplotlib"],
     },
     distclass=BinaryDistribution,
+    # Supported Python versions
+    python_requires=">=3.8",
     classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3 :: Only",
         "Operating System :: Unix",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",


### PR DESCRIPTION
- Removes pinning of `keras-core` version so it works on latest.
- Sets min-TF version as 2.13 since that's the dependency in `keras-core`
- Updates minimum python version to 3.8, which is the minimum for TF 2.13
