### PR TITLE
ImageNet Dataset Research Paper And Website Added In The Docstring of…

### DIFF
--- a/keras_cv/datasets/imagenet/load.py
+++ b/keras_cv/datasets/imagenet/load.py
@@ -64,7 +64,7 @@ def load(
     img_size=None,
     crop_to_aspect_ratio=True,
 ):
-    """Loads the ImageNet dataset from TFRecords
+      """Loads the ImageNet dataset from TFRecords
 
     Usage:
     ```python
@@ -72,6 +72,10 @@ def load(
         split="train", tfrecord_path="gs://my-bucket/imagenet-tfrecords"
     )
     ```
+    
+    References:
+    - [ImageNet Dataset Research Paper](https://arxiv.org/abs/1409.0575)
+    - [ImageNet Dataset Website](https://www.image-net.org/)
 
     Args:
         split: the split to load. Should be one of "train" or "validation."


### PR DESCRIPTION
… load.py of ImageNet Dataset

# What does this PR do?
Adds Research Paper And Website of ImageNet Dataset in the docstring of load.py of ImageNet Dataset.


<!-- Remove if not applicable -->

Fixes # (issue)
https://github.com/keras-team/keras-cv/issues/1981


## Before submitting
- [ ] This PR updates docstring of ImageNet Dataset

## Who can review?
@ianstenbit 
@jbischof 

Previous Work in this issue:
--- Updated Docstring of Waymo Dataset---
https://github.com/keras-team/keras-cv/pull/1975

Current Work In This Issue:
---Updating Docstring of ImageNet Dataset---

---Future Work In This Issue---
Will update the docstring of the Pascal Voc Dataset
