### PR TITLE
Add support of segmentation mask to fourier mix

### DIFF
--- a/examples/layers/preprocessing/segmentation/fourier_mix_demo.py
+++ b/examples/layers/preprocessing/segmentation/fourier_mix_demo.py
@@ -1,0 +1,34 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""fourier_mix_demo.py shows how to use the FourierMix preprocessing layer.
+
+Uses the oxford iiit pet_dataset.  In this script the pets
+are loaded, then are passed through the preprocessing layers.
+Finally, they are shown using matplotlib.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+
+def main():
+    ds = demo_utils.load_oxford_iiit_pet_dataset()
+    fouriermix = preprocessing.FourierMix(alpha=0.8)
+    ds = ds.map(fouriermix, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_dataset(ds)
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/preprocessing/README.md
+++ b/keras_cv/layers/preprocessing/README.md
@@ -11,7 +11,7 @@ The provided table gives an overview of the different augmentation layers availa
 | ChannelShuffle | ✅ | ✅ | ✅ | ✅ |
 | CutMix | ❌ | ✅ | ❌ | ✅ |
 | Equalization | ❌ | ✅ | ✅ | ✅ |
-| FourierMix | ❌ | ❌ | ❌ | ✅ |
+| FourierMix | ❌ | ✅ | ❌ | ✅ |
 | Grayscale | ✅ | ✅ | ✅ | ✅ |
 | GridMask | ❌ | ✅ | ✅ | ✅ |
 | JitteredResize | ✅ | ✅ | ✅ | ✅ |

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -235,6 +235,7 @@ class FourierMix(BaseImageAugmentationLayer):
         segmentation_masks = (
             masks * segmentation_masks + (1.0 - masks) * fmix_segmentation_masks
         )
+        return segmentation_masks
 
     def get_config(self):
         config = {


### PR DESCRIPTION
# What does this PR do?

Fixes #1992 

Add support of segmentation mask to Fourier Mix preprocessing layers. Here is the working [colab link](https://colab.research.google.com/drive/1Qc6wCE2cPUMHxo8q-XzbmYMpocqKdDHT?usp=sharing).

Demo output:

<img width="484" alt="Screenshot 2023-07-31 at 3 46 03 AM" src="https://github.com/keras-team/keras-cv/assets/53268607/ea93054d-b58b-4fd7-8b46-28c18d55d02e">

## Who can review?

@ianstenbit @jbischof 
