### PR TITLE
Add support of segmentation mask in RandomCutout

### DIFF
--- a/examples/layers/preprocessing/segmentation/random_cutout_demo.py
+++ b/examples/layers/preprocessing/segmentation/random_cutout_demo.py
@@ -1,0 +1,34 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""random_cutout_demo.py shows how to use the RandomCutout preprocessing layer.
+
+Uses the oxford iiit pet_dataset.  In this script the pets
+are loaded, then are passed through the preprocessing layers.
+Finally, they are shown using matplotlib.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+
+def main():
+    ds = demo_utils.load_oxford_iiit_pet_dataset()
+    randomcutout = preprocessing.RandomCutout(0.5, 0.5)
+    ds = ds.map(randomcutout, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_dataset(ds)
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -120,6 +120,24 @@ class RandomCutout(BaseImageAugmentationLayer):
     def augment_label(self, label, transformation=None, **kwargs):
         return label
 
+    def augment_segmentation_mask(
+        self, segmentation_masks, transformation=None, **kwargs
+    ):
+        """Apply random cutout."""
+        inputs = tf.expand_dims(segmentation_masks, 0)
+        center_x, center_y, rectangle_height, rectangle_width = transformation
+
+        rectangle_fill = self._compute_rectangle_fill(inputs)
+        inputs = fill_utils.fill_rectangle(
+            inputs,
+            center_x,
+            center_y,
+            rectangle_width,
+            rectangle_height,
+            rectangle_fill,
+        )
+        return inputs[0]
+
     def _compute_rectangle_position(self, inputs):
         input_shape = tf.shape(inputs)
         image_height, image_width = (

--- a/keras_cv/layers/preprocessing/random_cutout_test.py
+++ b/keras_cv/layers/preprocessing/random_cutout_test.py
@@ -21,11 +21,18 @@ from keras_cv.tests.test_case import TestCase
 class RandomCutoutTest(TestCase):
     def _run_test(self, height_factor, width_factor):
         img_shape = (40, 40, 3)
+        mask_shape = (40, 40, 3)
         xs = tf.stack(
             [2 * np.ones(img_shape), np.ones(img_shape)],
             axis=0,
         )
         xs = tf.cast(xs, tf.float32)
+
+        ys_segmentation_masks = tf.stack(
+            [2 * np.ones(mask_shape), np.ones(mask_shape)],
+            axis=0,
+        )
+        ys_segmentation_masks = tf.cast(ys_segmentation_masks, tf.float32)
 
         fill_value = 0.0
         layer = preprocessing.RandomCutout(
@@ -36,32 +43,47 @@ class RandomCutoutTest(TestCase):
             seed=1,
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         # Some pixels should be replaced with fill value
         self.assertTrue(tf.math.reduce_any(xs[0] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
         self.assertTrue(tf.math.reduce_any(xs[1] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[0] == fill_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[1] == fill_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[1] == 1.0))
 
     def test_return_shapes(self):
         xs = np.ones((2, 512, 512, 3))
+        ys_segmentation_masks = np.ones((2, 512, 512, 3))
 
         layer = preprocessing.RandomCutout(
             height_factor=0.5, width_factor=0.5, seed=1
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         self.assertEqual(xs.shape, [2, 512, 512, 3])
+        self.assertEqual(ys_segmentation_masks.shape, [2, 512, 512, 3])
 
     def test_return_shapes_single_element(self):
         xs = np.ones((512, 512, 3))
+        ys_segmentation_masks = np.ones((512, 512, 3))
 
         layer = preprocessing.RandomCutout(
             height_factor=0.5, width_factor=0.5, seed=1
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         self.assertEqual(xs.shape, [512, 512, 3])
+        self.assertEqual(ys_segmentation_masks.shape, [512, 512, 3])
 
     def test_random_cutout_single_float(self):
         self._run_test(0.5, 0.5)
@@ -85,6 +107,13 @@ class RandomCutoutTest(TestCase):
             ),
             tf.float32,
         )
+        ys_segmentation_masks = tf.cast(
+            tf.stack(
+                [2 * np.ones((40, 40, 1)), np.ones((40, 40, 1))],
+                axis=0,
+            ),
+            tf.float32,
+        )
 
         patch_value = 0.0
         layer = preprocessing.RandomCutout(
@@ -95,20 +124,36 @@ class RandomCutoutTest(TestCase):
             seed=1,
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         # Some pixels should be replaced with fill value
         self.assertTrue(tf.math.reduce_any(xs[0] == patch_value))
         self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
         self.assertTrue(tf.math.reduce_any(xs[1] == patch_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[0] == patch_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[1] == patch_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[1] == 1.0))
 
     def test_random_cutout_call_tiny_image(self):
         img_shape = (4, 4, 3)
+        mask_shape = (4, 4, 3)
         xs = tf.stack(
             [2 * np.ones(img_shape), np.ones(img_shape)],
             axis=0,
         )
         xs = tf.cast(xs, tf.float32)
+
+        ys_segmentation_masks = tf.stack(
+            [2 * np.ones(mask_shape), np.ones(mask_shape)],
+            axis=0,
+        )
+        ys_segmentation_masks = tf.cast(ys_segmentation_masks, tf.float32)
 
         fill_value = 0.0
         layer = preprocessing.RandomCutout(
@@ -119,15 +164,30 @@ class RandomCutoutTest(TestCase):
             seed=1,
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         # Some pixels should be replaced with fill value
         self.assertTrue(tf.math.reduce_any(xs[0] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
         self.assertTrue(tf.math.reduce_any(xs[1] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[0] == fill_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[1] == fill_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[1] == 1.0))
 
     def test_in_tf_function(self):
         xs = tf.cast(
+            tf.stack(
+                [2 * np.ones((100, 100, 1)), np.ones((100, 100, 1))], axis=0
+            ),
+            tf.float32,
+        )
+        ys_segmentation_masks = tf.cast(
             tf.stack(
                 [2 * np.ones((100, 100, 1)), np.ones((100, 100, 1))], axis=0
             ),
@@ -148,9 +208,18 @@ class RandomCutoutTest(TestCase):
             return layer(x)
 
         xs = augment(xs)
+        ys_segmentation_masks = augment(ys_segmentation_masks)
 
         # Some pixels should be replaced with fill value
         self.assertTrue(tf.math.reduce_any(xs[0] == patch_value))
         self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
         self.assertTrue(tf.math.reduce_any(xs[1] == patch_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[0] == patch_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(
+            tf.math.reduce_any(ys_segmentation_masks[1] == patch_value)
+        )
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[1] == 1.0))


### PR DESCRIPTION
# What does this PR do?

Related: #1992 

Add support of segmentation mask in Augmix layer. Here is the [colab link](https://colab.research.google.com/drive/169KKaG4yLUT842Vzj9YDBYFb8rKYt0_b?usp=sharing) for demo.

Output generated by demo:

<img width="484" alt="Screenshot 2023-08-02 at 7 22 48 AM" src="https://github.com/keras-team/keras-cv/assets/53268607/fc0c703d-f4e2-4d62-b1d2-dc40615c6a8b">

## Who can review?

@ianstenbit @jbischof 
