### PR TITLE
Add bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,38 @@
+---
+name: Bug
+about: File a bug/issue
+title: '[BUG] <title>'
+labels: bug
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for the bug you encountered.
+-->
+
+### Current Behavior:
+<!-- A concise description of what you're experiencing. -->
+
+### Expected Behavior:
+<!-- A concise description of what you expected to happen. -->
+
+### Steps To Reproduce:
+<!--
+Please include a minimal colab gist replicating the issue you encountered. THIS IS
+CRITICAL FOR US TO HELP YOU. It is very difficult to fix an issue from a stack trace alone.
+
+To save a gist, choose "File > Save a copy as Github Gist" in colab
+-->
+
+### Version:
+<!--
+Example:
+- HEAD
+- 0.6.1
+-->
+
+### Anything else:
+<!--
+Links? References? Anything that will give us more context about the issue that you are encountering!
+-->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug
 about: File a bug/issue
-title: '[BUG] <title>'
+title: ''
 labels: bug
 assignees: ''
 
@@ -19,10 +19,15 @@ Note: Please search to see if an issue already exists for the bug you encountere
 
 ### Steps To Reproduce:
 <!--
-Please include a minimal colab gist replicating the issue you encountered. THIS IS
-CRITICAL FOR US TO HELP YOU. It is very difficult to fix an issue from a stack trace alone.
+Please include a minimal colab gist replicating the issue you encountered. 
+THIS IS CRITICAL FOR US TO HELP YOU. It is very difficult to fix an issue from a 
+stack trace alone.
 
-To save a gist, choose "File > Save a copy as Github Gist" in colab
+To save a gist, choose "File > Save a copy as Github Gist" in colab. This 
+ensures that your colab is accessible to all users.
+
+Exception: Any issues related to installation outside of colab or where 
+replication is not important to addressing your concern.
 -->
 
 ### Version:
@@ -34,5 +39,6 @@ Example:
 
 ### Anything else:
 <!--
-Links? References? Anything that will give us more context about the issue that you are encountering!
+Links? References? Anything that will give us more context about the issue that 
+you are encountering!
 -->


### PR DESCRIPTION
We currently only offer a "feature request" type. Users are generally creating bugs from the "other" category and only leaving a stack trace, which is very difficult to replicate.

Ideally almost all bugs would include a colab gist to speed replication time.