### PR TITLE
Update visualization/plot_image_gallery.py to solve an error in the object_detection_keras_cv.py in the keras-team/keras-io Project

### DIFF
--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -133,7 +133,7 @@ def plot_image_gallery(
         )  # batch_size from within passed `tf.data.Dataset`
     else:
         batch_size = (
-            images.shape[0] if len(images.shape) == 4 else 1
+            np.asarray(images).shape[0] if len(images.shape) == 4 else 1
         )  # batch_size from np.array or single image
 
     rows = rows or int(math.ceil(math.sqrt(batch_size)))


### PR DESCRIPTION
Update visualization/plot_image_gallery.py 
The guide has an issue when calling the visualization.plot_image_gallery function with its input being a list, it has to be of type array because it will be calling for the shape of it later in the function. The error occurred in the second code cell in the Beginner section, Ligne 155 in the object_detection_keras_cv.py file. This update should solve it.