### PR TITLE
Added support of segmentation mask in RandomShear Layer

### DIFF
--- a/examples/layers/preprocessing/segmentation/random_shear_demo.py
+++ b/examples/layers/preprocessing/segmentation/random_shear_demo.py
@@ -1,0 +1,34 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""random_shear_demo.py shows how to use the RandomShear preprocessing layer.
+
+Uses the oxford iiit pet_dataset.  In this script the pets
+are loaded, then are passed through the preprocessing layers.
+Finally, they are shown using matplotlib.
+"""
+import demo_utils
+import tensorflow as tf
+
+from keras_cv.layers import preprocessing
+
+
+def main():
+    ds = demo_utils.load_oxford_iiit_pet_dataset()
+    randomshear = preprocessing.RandomShear(0.5, 0.5)
+    ds = ds.map(randomshear, num_parallel_calls=tf.data.AUTOTUNE)
+    demo_utils.visualize_dataset(ds)
+
+
+if __name__ == "__main__":
+    main()

--- a/keras_cv/layers/preprocessing/README.md
+++ b/keras_cv/layers/preprocessing/README.md
@@ -37,7 +37,7 @@ The provided table gives an overview of the different augmentation layers availa
 | RandomRotation | ✅ | ✅ | ✅ | ✅ |
 | RandomSaturation | ✅ | ✅ | ✅ | ✅ |
 | RandomSharpness | ✅ | ✅ | ✅ | ✅ |
-| RandomShear | ✅ | ❌ | ✅ | ✅ |
+| RandomShear | ✅ | ✅ | ✅ | ✅ |
 | RandomTranslation | ✅ | ❌ | ✅ | ✅ |
 | RandomZoom | ✅ | ❌ | ❌ | ✅ |
 | RepeatedAugmentation <sup>+</sup> | - | - | - | - |

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -218,6 +218,31 @@ class RandomShear(VectorizedBaseImageAugmentationLayer):
 
     def augment_labels(self, labels, transformations, **kwargs):
         return labels
+    
+    def augment_segmentation_masks(self, segmentation_masks, transformations, **kwargs):
+        x, y = transformations["shear_x"], transformations["shear_y"]
+
+        if x is not None:
+            transforms_x = self._build_shear_x_transform_matrix(x)
+            segmentation_masks = preprocessing.transform(
+                images=segmentation_masks,
+                transforms=transforms_x,
+                interpolation=self.interpolation,
+                fill_mode=self.fill_mode,
+                fill_value=self.fill_value,
+            )
+
+        if y is not None:
+            transforms_y = self._build_shear_y_transform_matrix(y)
+            segmentation_masks = preprocessing.transform(
+                images=segmentation_masks,
+                transforms=transforms_y,
+                interpolation=self.interpolation,
+                fill_mode=self.fill_mode,
+                fill_value=self.fill_value,
+            )
+
+        return segmentation_masks
 
     def augment_bounding_boxes(
         self, bounding_boxes, transformations, images=None, **kwargs

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -229,7 +229,7 @@ class RandomShear(VectorizedBaseImageAugmentationLayer):
             segmentation_masks = preprocessing.transform(
                 images=segmentation_masks,
                 transforms=transforms_x,
-                interpolation=self.interpolation,
+                interpolation="nearest",
                 fill_mode=self.fill_mode,
                 fill_value=self.fill_value,
             )

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -239,7 +239,7 @@ class RandomShear(VectorizedBaseImageAugmentationLayer):
             segmentation_masks = preprocessing.transform(
                 images=segmentation_masks,
                 transforms=transforms_y,
-                interpolation=self.interpolation,
+                interpolation="nearest",
                 fill_mode=self.fill_mode,
                 fill_value=self.fill_value,
             )

--- a/keras_cv/layers/preprocessing/random_shear.py
+++ b/keras_cv/layers/preprocessing/random_shear.py
@@ -218,8 +218,10 @@ class RandomShear(VectorizedBaseImageAugmentationLayer):
 
     def augment_labels(self, labels, transformations, **kwargs):
         return labels
-    
-    def augment_segmentation_masks(self, segmentation_masks, transformations, **kwargs):
+
+    def augment_segmentation_masks(
+        self, segmentation_masks, transformations, **kwargs
+    ):
         x, y = transformations["shear_x"], transformations["shear_y"]
 
         if x is not None:

--- a/keras_cv/layers/preprocessing/random_shear_test.py
+++ b/keras_cv/layers/preprocessing/random_shear_test.py
@@ -47,13 +47,13 @@ class RandomShearTest(TestCase):
         self.assertTrue(tf.math.reduce_any(xs[1] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
         self.assertTrue(
-            tf.match.reduce_any(ys_segmentation_masks[0] == fill_value)
+            tf.math.reduce_any(ys_segmentation_masks[0] == fill_value)
         )
-        self.assertTrue(tf.match.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[0] == 2.0))
         self.assertTrue(
-            tf.match.reduce_any(ys_segmentation_masks[1] == fill_value)
+            tf.math.reduce_any(ys_segmentation_masks[1] == fill_value)
         )
-        self.assertTrue(tf.match.reduce_any(ys_segmentation_masks[1] == 1.0))
+        self.assertTrue(tf.math.reduce_any(ys_segmentation_masks[1] == 1.0))
 
     def test_return_shapes(self):
         """test return dict keys and value pairs"""
@@ -85,7 +85,7 @@ class RandomShearTest(TestCase):
                 "images": xs,
                 "targets": ys_labels,
                 "bounding_boxes": ys_bounding_boxes,
-                "ys_segmentation_masks": ys_segmentation_masks,
+                "segmentation_masks": ys_segmentation_masks,
             }
         )
         xs, ys_labels, ys_bounding_boxes, ys_segmentation_masks = (

--- a/keras_cv/layers/preprocessing/random_shear_test.py
+++ b/keras_cv/layers/preprocessing/random_shear_test.py
@@ -27,19 +27,33 @@ class RandomShearTest(TestCase):
             [2 * tf.ones(img_shape), tf.ones(img_shape)],
             axis=0,
         )
+        ys_segmentation_masks = tf.stack(
+            [2 * tf.ones(img_shape), tf.ones(img_shape)],
+            axis=0,
+        )
         xs = tf.cast(xs, tf.float32)
+        ys_segmentation_masks = tf.cast(ys_segmentation_masks, tf.float32)
 
         fill_value = 0.0
         layer = preprocessing.RandomShear(
             x_factor=(3, 3), seed=0, fill_mode="constant", fill_value=fill_value
         )
         xs = layer(xs)
+        ys_segmentation_masks = layer(ys_segmentation_masks)
 
         # Some pixels should be replaced with fill value
         self.assertTrue(tf.math.reduce_any(xs[0] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[0] == 2.0))
         self.assertTrue(tf.math.reduce_any(xs[1] == fill_value))
         self.assertTrue(tf.math.reduce_any(xs[1] == 1.0))
+        self.assertTrue(
+            tf.match.reduce_any(ys_segmentation_masks[0] == fill_value)
+        )
+        self.assertTrue(tf.match.reduce_any(ys_segmentation_masks[0] == 2.0))
+        self.assertTrue(
+            tf.match.reduce_any(ys_segmentation_masks[1] == fill_value)
+        )
+        self.assertTrue(tf.match.reduce_any(ys_segmentation_masks[1] == 1.0))
 
     def test_return_shapes(self):
         """test return dict keys and value pairs"""
@@ -55,6 +69,9 @@ class RandomShearTest(TestCase):
             "classes": tf.random.uniform((2, 3), 0, 1),
         }
 
+        # randomly sample segmentation masks
+        ys_segmentation_masks = tf.ones((2, 512, 512, 3))
+
         layer = preprocessing.RandomShear(
             x_factor=(0.1, 0.3),
             y_factor=(0.1, 0.3),
@@ -68,18 +85,21 @@ class RandomShearTest(TestCase):
                 "images": xs,
                 "targets": ys_labels,
                 "bounding_boxes": ys_bounding_boxes,
+                "ys_segmentation_masks": ys_segmentation_masks,
             }
         )
-        xs, ys_labels, ys_bounding_boxes = (
+        xs, ys_labels, ys_bounding_boxes, ys_segmentation_masks = (
             outputs["images"],
             outputs["targets"],
             outputs["bounding_boxes"],
+            outputs["segmentation_masks"],
         )
         ys_bounding_boxes = bounding_box.to_dense(ys_bounding_boxes)
         self.assertEqual(xs.shape, [2, 512, 512, 3])
         self.assertEqual(ys_labels.shape, [2, 10])
         self.assertEqual(ys_bounding_boxes["boxes"].shape, [2, 3, 4])
         self.assertEqual(ys_bounding_boxes["classes"].shape, [2, 3])
+        self.assertEqual(ys_segmentation_masks.shape, [2, 512, 512, 3])
 
     def test_single_image_input(self):
         """test for single image input"""


### PR DESCRIPTION
# What does this PR do?

Related #1992 

Add support of segmentation mask in Augmix layer. Here is the [colab link](https://colab.research.google.com/drive/1lBOl5ruK7AhZf9YOh4v3c9F1oYq2kob-?usp=sharing) for demo.

Output generated by demo:

<img width="484" alt="Screenshot 2023-08-11 at 8 23 29 PM" src="https://github.com/keras-team/keras-cv/assets/53268607/85ece6a4-0ec2-41df-95de-2c9b7c2795f6">

## Who can review?

@ianstenbit 
