### PR TITLE
Use correct convention for static shape in point_cloud grouping

### DIFF
--- a/keras_cv/point_cloud/point_cloud.py
+++ b/keras_cv/point_cloud/point_cloud.py
@@ -72,10 +72,10 @@ def group_points_by_boxes(points, boxes):
       box, all the point indices that belong to the box.
 
     """
-    num_boxes = boxes.get_shape().as_list()[-2] or tf.shape(boxes)[-2]
+    num_boxes = boxes.shape[-2] or tf.shape(boxes)[-2]
     # [..., num_points]
     box_indices = within_box3d_index(points, boxes)
-    num_points = points.get_shape().as_list()[-2] or tf.shape(points)[-2]
+    num_points = points.shape[-2] or tf.shape(points)[-2]
     point_indices = tf.range(num_points, dtype=tf.int32)
 
     def group_per_sample(box_index):

--- a/keras_cv/point_cloud/point_cloud.py
+++ b/keras_cv/point_cloud/point_cloud.py
@@ -87,7 +87,7 @@ def group_points_by_boxes(points, boxes):
         )
         return res
 
-    boxes_rank = boxes.shape.rank
+    boxes_rank = len(boxes.shape)
     if boxes_rank == 2:
         return group_per_sample(box_indices)
     elif boxes_rank == 3:


### PR DESCRIPTION
This also has the side effect of allowing for Numpy inputs instead of just TF tensor inputs to point_cloud `group_points_by_boxes`, which is more pleasant for tinkering.