### PR TITLE
Use non-ragged outputs in MultiClassNMS

### DIFF
--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression.py
@@ -123,7 +123,7 @@ class MultiClassNonMaxSuppression(keras.layers.Layer):
         }
         # this is required to comply with KerasCV bounding box format.
         return bounding_box.mask_invalid_detections(
-            bounding_boxes, output_ragged=True
+            bounding_boxes, output_ragged=False
         )
 
     def get_config(self):

--- a/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
+++ b/keras_cv/layers/object_detection/multi_class_non_max_suppression_test.py
@@ -47,6 +47,6 @@ def decode_predictions_output_shapes():
 class NmsPredictionDecoderTest(TestCase):
     def test_decode_predictions_output_shapes(self):
         result = decode_predictions_output_shapes()
-        self.assertEqual(result["boxes"].shape, [8, None, 4])
-        self.assertEqual(result["classes"].shape, [8, None])
-        self.assertEqual(result["confidence"].shape, [8, None])
+        self.assertEqual(result["boxes"].shape, [8, 100, 4])
+        self.assertEqual(result["classes"].shape, [8, 100])
+        self.assertEqual(result["confidence"].shape, [8, 100])


### PR DESCRIPTION
Using Ragged outputs that weren't subsequently padded was causing issues in the PyCOCOCallback, and we shouldn't silently default to Ragged anywhere.