### PR TITLE
Update centernet_label_encoder.py

### DIFF
--- a/keras_cv/layers/object_detection_3d/centernet_label_encoder.py
+++ b/keras_cv/layers/object_detection_3d/centernet_label_encoder.py
@@ -422,10 +422,8 @@ class CenterNetLabelEncoder(keras.layers.Layer):
             )
             global_xyz = tf.zeros([b, 3], dtype=point_xyz.dtype)
             # [B, H, W, Z, 3]
-            feature_map_ref_xyz = tf.constant(
-                voxel_utils.compute_feature_map_ref_xyz(
-                    self._voxel_size, self._spatial_size, global_xyz
-                ),
+            feature_map_ref_xyz = voxel_utils.compute_feature_map_ref_xyz(
+                self._voxel_size, self._spatial_size, global_xyz
             )
             # convert from global box point xyz to offset w.r.t center of
             # feature map.


### PR DESCRIPTION
# What does this PR do?
Remove the unnecessary tf.constant from the encorder.

This was identified and verified internally with a centerpillar model running with multibackend keras.

The tf.constant was raising an error when the input is already a tensor instance and without dtype casting.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

