### PR TITLE
Fix import paths for various internal imports to play nice with Namex.

### DIFF
--- a/keras_cv/layers/preprocessing/resizing.py
+++ b/keras_cv/layers/preprocessing/resizing.py
@@ -14,13 +14,13 @@
 
 import tensorflow as tf
 
-import keras_cv.utils
 from keras_cv import bounding_box
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import ops
 from keras_cv.layers.preprocessing.base_image_augmentation_layer import (
     BaseImageAugmentationLayer,
 )
+from keras_cv.utils import get_interpolation
 
 H_AXIS = -3
 W_AXIS = -2
@@ -91,9 +91,7 @@ class Resizing(BaseImageAugmentationLayer):
         self.interpolation = interpolation
         self.crop_to_aspect_ratio = crop_to_aspect_ratio
         self.pad_to_aspect_ratio = pad_to_aspect_ratio
-        self._interpolation_method = keras_cv.utils.get_interpolation(
-            interpolation
-        )
+        self._interpolation_method = get_interpolation(interpolation)
         self.bounding_box_format = bounding_box_format
         self.force_output_dense_images = True
 


### PR DESCRIPTION
This is causing not-so-nice behavior with Namex, because for a pip-installed version of KerasCV this import path doesn't exist, but Namex can't add the `src` prefix to it because of how it's imported.