### PR TITLE
Set read-only tokens for all GitHub workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   release:
     types: [created]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test the code with tf.keras

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,6 +11,8 @@ on: # rebuild any PRs and main branch changes
       - '.devcontainer/**'
       - 'workflows/**'
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+
 jobs:
   deploy-with-custom-ops:
     # This job is currently skipped until we cut a release with custom ops.


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/keras-team/keras-cv/issues/2074.

This PR ensures all workflows run with read-only permissions, protecting the project from potential supply-chain attacks.

## Who can review?
@ianstenbit, @jbischof