### PR TITLE
Explicitly specify full package for more modules, as shown in #2001

### DIFF
--- a/keras_cv/datasets/imagenet/load.py
+++ b/keras_cv/datasets/imagenet/load.py
@@ -56,7 +56,9 @@ def parse_imagenet_example(img_size, crop_to_aspect_ratio):
     return apply
 
 
-@keras_cv_export("keras_cv.datasets.imagenet.load")
+@keras_cv_export(
+    "keras_cv.datasets.imagenet.load", package="keras_cv.datasets.imagenet"
+)
 def load(
     split,
     tfrecord_path,

--- a/keras_cv/datasets/load_test.py
+++ b/keras_cv/datasets/load_test.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests ability to load keras_cv.datasets."""
+
+from keras_cv.tests.test_case import TestCase
+
+
+class LoadTest(TestCase):
+    def test_datasets_load(self):
+        import keras_cv.datasets  # noqa: F401
+
+    def test_imagenet_load(self):
+        import keras_cv.datasets.imagenet  # noqa: F401

--- a/keras_cv/datasets/pascal_voc/segmentation.py
+++ b/keras_cv/datasets/pascal_voc/segmentation.py
@@ -465,7 +465,10 @@ def _build_sbd_dataset_from_metadata(metadata):
     return dataset
 
 
-@keras_cv_export("keras_cv.datasets.pascal_voc.segmentation.load")
+@keras_cv_export(
+    "keras_cv.datasets.pascal_voc.segmentation.load",
+    package="keras_cv.datasets.pascal_voc_segmentation",
+)
 def load(
     split="sbd_train",
     data_dir=None,

--- a/keras_cv/keypoint/converters.py
+++ b/keras_cv/keypoint/converters.py
@@ -60,7 +60,9 @@ FROM_XY_CONVERTERS = {
 }
 
 
-@keras_cv_export("keras_cv.keypoint.convert_format")
+@keras_cv_export(
+    "keras_cv.keypoint.convert_format", package="keras_cv.keypoint"
+)
 def convert_format(keypoints, source, target, images=None, dtype=None):
     """Converts keypoints from one format to another.
 


### PR DESCRIPTION
Explicitly specify full package-name for several methods upon registering as serialisable. 

Fixes #2070

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

