### PR TITLE
Bump python version requirement to 3.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.9
 COPY setup.sh /setup.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -99,10 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,10 @@ jobs:
         # To switch on windows-2022/latest, please verify the bazel version:
         # https://github.com/bazelbuild/bazel/issues/14232#issuecomment-1011247429
         os: ['macos-12', 'windows-2019', 'ubuntu-18.04']
-        py-version: ['3.8', '3.9', '3.10', '3.11']
+        py-version: ['3.9', '3.10', '3.11']
         tf-version: ['2.13.0']
         use-macos-arm: [false]
         include:
-          - os: 'macos-12'
-            tf-version: '2.13.0'
-            py-version: '3.8'
-            use-macos-arm: true
           - os: 'macos-12'
             tf-version: '2.13.0'
             py-version: '3.9'
@@ -100,7 +96,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Build wheels
       run: |
         pip install tensorflow==2.13.0

--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -135,6 +135,7 @@ class BaseImageAugmentationLayer(base_class):
             seed=seed, force_generator=force_generator
         )
         super().__init__(**kwargs)
+        self.built = True
         self._convert_input_args = False
 
     @property

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_utils.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_utils.py
@@ -310,7 +310,8 @@ class CrossStagePartial(keras.layers.Layer):
                 )
             )
 
-        self.add = keras.layers.Add()
+        if self.residual:
+            self.add = keras.layers.Add()
         self.concatenate = keras.layers.Concatenate()
 
         self.darknet_conv3 = DarknetConvBlock(

--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,10 @@ setup(
     },
     distclass=BinaryDistribution,
     # Supported Python versions
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Keras-core now requires at least 3.9, and tf 2.14 (out imminently) will require 3.9 as well.

We should follow suit for cv/nlp.