### PR TITLE
[Yolov8 detector] Fix example in docstring

### DIFF
--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -353,24 +353,14 @@ class YOLOV8Detector(Task):
     ```python
     images = tf.ones(shape=(1, 512, 512, 3))
     labels = {
-        "boxes": [
+        "boxes": tf.constant([
             [
                 [0, 0, 100, 100],
                 [100, 100, 200, 200],
                 [300, 300, 100, 100],
             ]
-        ],
-        "classes": [[1, 1, 1]],
-    }
-
-    # Convert labels to tensors
-    boxes_tensor = tf.constant(labels["boxes"], dtype=tf.float32)
-    classes_tensor = tf.constant(labels["classes"], dtype=tf.int32)
-
-    # Create a new list that includes the TensorFlow tensors
-    labels_tensor = {
-        "boxes": boxes_tensor,
-        "classes": classes_tensor,
+        ], dtype=tf.float32),
+        "classes": tf.constant([[1, 1, 1]], dtype=tf.int64),
     }
 
     model = keras_cv.models.YOLOV8Detector(
@@ -395,7 +385,7 @@ class YOLOV8Detector(Task):
         optimizer=tf.optimizers.SGD(global_clipnorm=10.0),
         jit_compile=False,
     )
-    model.fit(images, labels_tensor)
+    model.fit(images, labels)
     ```
     """  # noqa: E501
 

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -362,13 +362,24 @@ class YOLOV8Detector(Task):
         ],
         "classes": [[1, 1, 1]],
     }
+
+    # Convert labels to tensors
+    boxes_tensor = tf.constant(labels["boxes"], dtype=tf.float32)
+    classes_tensor = tf.constant(labels["classes"], dtype=tf.int32)
+
+    # Create a new list that includes the TensorFlow tensors
+    labels_tensor = {
+        "boxes": boxes_tensor,
+        "classes": classes_tensor,
+    }
+
     model = keras_cv.models.YOLOV8Detector(
         num_classes=20,
         bounding_box_format="xywh",
         backbone=keras_cv.models.YOLOV8Backbone.from_preset(
-            "yolo_v8_m_coco"
+            "yolo_v8_m_backbone_coco"
         ),
-        fpn_depth=2.
+        fpn_depth=2
     )
 
     # Evaluate model without box decoding and NMS
@@ -384,7 +395,7 @@ class YOLOV8Detector(Task):
         optimizer=tf.optimizers.SGD(global_clipnorm=10.0),
         jit_compile=False,
     )
-    model.fit(images, labels)
+    model.fit(images, labels_tensor)
     ```
     """  # noqa: E501
 


### PR DESCRIPTION
# What does this PR do?

* Fixed typo: 
-- `yolo_v8_m_coco` to `yolo_v8_m_backbone_coco`
-- `fpn_depth=2.` to `fpn_depth=2`
* Fixed `model.fit`
-- Converted `labels` to `labels_tensor`.
-- `model.fit(images, labels)` to `model.fit(images, labels_tensor)`

## Who can review?

@ianstenbit @jbischof 
