### PR TITLE
Use "masks" and "boxes" as prompt keys for SAM

### DIFF
--- a/keras_cv/models/segmentation/segment_anything/sam.py
+++ b/keras_cv/models/segmentation/segment_anything/sam.py
@@ -113,8 +113,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": points,
     ...     "labels": labels,
-    ...     "box": box,
-    ...     "mask": input_mask
+    ...     "boxes": box,
+    ...     "masks": input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -132,8 +132,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": points,
     ...     "labels": labels,
-    ...     "box": box,
-    ...     "mask": no_input_mask
+    ...     "boxes": box,
+    ...     "masks": no_input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -156,8 +156,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": padded_points,
     ...     "labels": padded_labels,
-    ...     "box": no_box,
-    ...     "mask": no_input_mask
+    ...     "boxes": no_box,
+    ...     "masks": no_input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -175,8 +175,8 @@ class SegmentAnythingModel(Task):
         prompt_inputs = {
             "points": keras.Input(shape=[None, 2], name="points"),
             "labels": keras.Input(shape=[None], name="labels"),
-            "box": keras.Input(shape=[None, 2, 2], name="box"),
-            "mask": keras.Input(shape=[None, None, None, 1], name="mask"),
+            "boxes": keras.Input(shape=[None, 2, 2], name="boxes"),
+            "masks": keras.Input(shape=[None, None, None, 1], name="masks"),
         }
 
         # All Inputs -- Images + Prompts

--- a/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
@@ -211,8 +211,8 @@ class SAMPromptEncoder(keras.layers.Layer):
         points, labels, box, mask = (
             inputs["points"],
             inputs["labels"],
-            inputs["box"],
-            inputs["mask"],
+            inputs["boxes"],
+            inputs["masks"],
         )
 
         # Get the batch shape. Since all the inputs must have the

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -91,7 +91,7 @@ class SAMTest(TestCase):
         points, labels, box, input_mask = self.get_prompts(7)
 
         outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings, dense_embeddings, dense_positional_embeddings = (
             outputs["sparse_embeddings"],
@@ -187,7 +187,7 @@ class SAMTest(TestCase):
     def test_two_way_transformer(self):
         points, labels, box, input_mask = self.get_prompts(1)
         prompt_encoder_outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings = prompt_encoder_outputs["sparse_embeddings"]
         image_embeddings = np.random.randn(1, 64, 64, 256)
@@ -208,7 +208,7 @@ class SAMTest(TestCase):
     def test_mask_decoder(self):
         points, labels, box, input_mask = self.get_prompts(1)
         prompt_encoder_outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings, dense_embeddings, dense_positional_embeddings = (
             prompt_encoder_outputs["sparse_embeddings"],


### PR DESCRIPTION
Even though these inputs only accept 1 input per image, we use plurals as our standard for input keys in KerasCV (take, for example, "images", which is plural even though there is only 1 input image per batch)

cc @tirthasheshpatel 