### PR TITLE
Support partial prompting in SAM

### DIFF
--- a/keras_cv/models/segmentation/segment_anything/sam.py
+++ b/keras_cv/models/segmentation/segment_anything/sam.py
@@ -126,7 +126,6 @@ class SegmentAnythingModel(Task):
     ...     "points": points,
     ...     "labels": labels,
     ...     "boxes": box,
-    ...     "masks": no_input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)

--- a/keras_cv/models/segmentation/segment_anything/sam.py
+++ b/keras_cv/models/segmentation/segment_anything/sam.py
@@ -113,8 +113,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": points,
     ...     "labels": labels,
-    ...     "box": box,
-    ...     "mask": input_mask
+    ...     "boxes": box,
+    ...     "masks": input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -132,8 +132,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": points,
     ...     "labels": labels,
-    ...     "box": box,
-    ...     "mask": no_input_mask
+    ...     "boxes": box,
+    ...     "masks": no_input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -156,8 +156,8 @@ class SegmentAnythingModel(Task):
     ...     "images": image,
     ...     "points": padded_points,
     ...     "labels": padded_labels,
-    ...     "box": no_box,
-    ...     "mask": no_input_mask
+    ...     "boxes": no_box,
+    ...     "masks": no_input_mask
     ... }
     ...
     >>> outputs = sam.predict(inputs)
@@ -175,8 +175,8 @@ class SegmentAnythingModel(Task):
         prompt_inputs = {
             "points": keras.Input(shape=[None, 2], name="points"),
             "labels": keras.Input(shape=[None], name="labels"),
-            "box": keras.Input(shape=[None, 2, 2], name="box"),
-            "mask": keras.Input(shape=[None, None, None, 1], name="mask"),
+            "boxes": keras.Input(shape=[None, 2, 2], name="boxes"),
+            "masks": keras.Input(shape=[None, None, None, 1], name="masks"),
         }
 
         # All Inputs -- Images + Prompts

--- a/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
@@ -211,8 +211,8 @@ class SAMPromptEncoder(keras.layers.Layer):
         points, labels, box, mask = (
             inputs["points"],
             inputs["labels"],
-            inputs["box"],
-            inputs["mask"],
+            inputs["boxes"],
+            inputs["masks"],
         )
 
         # Get the batch shape. Since all the inputs must have the

--- a/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_prompt_encoder.py
@@ -208,16 +208,14 @@ class SAMPromptEncoder(keras.layers.Layer):
         return mask_embedding
 
     def call(self, inputs):
-        points, labels, box, mask = (
-            inputs["points"],
-            inputs["labels"],
-            inputs["boxes"],
-            inputs["masks"],
-        )
+        # Get the batch shape based on any arbitrary input, because batch
+        # shapes must all match.
+        B = ops.shape(next(iter(inputs.values())))[0]
 
-        # Get the batch shape. Since all the inputs must have the
-        # same batch shape, choose one input arbitrarily.
-        B = ops.shape(points)[0]
+        points = inputs.get("points", ops.zeros((B, 0, 2)))
+        labels = inputs.get("labels", ops.zeros((B, 0)))
+        box = inputs.get("boxes", ops.zeros((B, 0, 2, 2)))
+        mask = inputs.get("masks", ops.zeros((B, 0, 256, 256, 1)))
 
         # Compute point embeddings
         point_embeddings = self.__embed_points(points, labels)

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -226,7 +226,8 @@ class SAMTest(TestCase):
             mask_decoder=self.mask_decoder,
         )
 
-        mask_prompts = self.get_prompts(1)
+        # We use box-only prompting for this test.
+        mask_prompts = self.get_prompts(1, "boxes")
         inputs = {
             "images": np.ones((1, 1024, 1024, 3)),
         }
@@ -277,7 +278,7 @@ class SAMTest(TestCase):
         inputs.update(mask_prompts)
 
         # Forward pass
-        outputs = model(inputs)
+        outputs = model.predict(inputs)
 
         # Save the model
         save_path = os.path.join(self.get_temp_dir(), "model.keras")
@@ -288,7 +289,7 @@ class SAMTest(TestCase):
         self.assertIsInstance(restored_model, SegmentAnythingModel)
 
         # Check that output matches.
-        restored_outputs = restored_model(inputs)
+        restored_outputs = restored_model.predict(inputs)
         self.assertAllClose(outputs, restored_outputs)
 
     @pytest.mark.large

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -91,7 +91,7 @@ class SAMTest(TestCase):
         points, labels, box, input_mask = self.get_prompts(7)
 
         outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings, dense_embeddings, dense_positional_embeddings = (
             outputs["sparse_embeddings"],
@@ -187,7 +187,7 @@ class SAMTest(TestCase):
     def test_two_way_transformer(self):
         points, labels, box, input_mask = self.get_prompts(1)
         prompt_encoder_outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings = prompt_encoder_outputs["sparse_embeddings"]
         image_embeddings = np.random.randn(1, 64, 64, 256)
@@ -208,7 +208,7 @@ class SAMTest(TestCase):
     def test_mask_decoder(self):
         points, labels, box, input_mask = self.get_prompts(1)
         prompt_encoder_outputs = self.prompt_encoder(
-            dict(points=points, labels=labels, box=box, mask=input_mask)
+            dict(points=points, labels=labels, boxes=box, masks=input_mask)
         )
         sparse_embeddings, dense_embeddings, dense_positional_embeddings = (
             prompt_encoder_outputs["sparse_embeddings"],


### PR DESCRIPTION
This lets a user specify _only_ boxes, points, or masks (or some pair thereof) without having to pass sentinel values for the other inputs.

This PR also adds a few TODOs for the last cleanup tasks I have for SAM