### PR TITLE
remove tests from pypi build

### DIFF
--- a/keras_cv/utils/__init__.py
+++ b/keras_cv/utils/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from keras_cv.utils import test_utils
 from keras_cv.utils.conditional_imports import assert_cv2_installed
 from keras_cv.utils.conditional_imports import assert_matplotlib_installed
 from keras_cv.utils.conditional_imports import (

--- a/pip_build.py
+++ b/pip_build.py
@@ -45,6 +45,10 @@ to_copy = [
 ]
 
 
+def ignore_files(_, filenames):
+    return [f for f in filenames if "test" in f]
+
+
 def build():
     if os.path.exists(build_directory):
         raise ValueError(f"Directory already exists: {build_directory}")
@@ -55,7 +59,9 @@ def build():
         root_path = pathlib.Path(__file__).parent.resolve()
         os.chdir(root_path)
         os.mkdir(build_directory)
-        shutil.copytree(package, os.path.join(build_directory, package))
+        shutil.copytree(
+            package, os.path.join(build_directory, package), ignore=ignore_files
+        )
         for fname in to_copy:
             shutil.copy(fname, os.path.join(f"{build_directory}", fname))
         os.chdir(build_directory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-license_file = LICENSE
-description-file = README.md
+license_files = LICENSE
+description_file = README.md
 version = attr: keras_cv.__version__
 
 [tool:pytest]


### PR DESCRIPTION
Removed test files from the PyPI upload.

Some other minor changes:
* Changed metadata in setup.cfg to avoid deprecation warning during build.
* Removed importing test_utils

I also took a brief look. All files containing `test` in the file name are only test related. No need to include in the production code.