### PR TITLE
Use the proper title for example

### DIFF
--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py
@@ -69,7 +69,7 @@ class EfficientNetV2Backbone(Backbone):
         input_tensor: optional Keras tensor (i.e. output of `keras.layers.Input()`)
             to use as image input for the model.
 
-    Usage:
+    Example:
     ```python
     # Construct an EfficientNetV2 from a preset:
     efficientnet = keras_cv.models.EfficientNetV2Backbone.from_preset(


### PR DESCRIPTION
Otherwise it won't be rendered correctly by the [`TFKerasDocumentationGenerator`](https://github.com/keras-team/keras-io/blob/fc340b9989cdf17fba44e66efa22758afad39b87/scripts/docstrings.py#L27-L28)

![Screenshot 2023-10-20 at 10 13 12](https://github.com/keras-team/keras-cv/assets/818310/1417ec91-8a63-4e00-88d5-8da480a19643)
