### PR TITLE
[WiP] Switch Keras2 to tf_keras

### DIFF
--- a/keras_cv/backend/__init__.py
+++ b/keras_cv/backend/__init__.py
@@ -52,7 +52,13 @@ if multi_backend():
 
     keras.backend.name_scope = keras.name_scope
 else:
-    from tensorflow import keras
+    try:
+        import tf_keras as keras
+    except ImportError:
+            raise ImportError(
+                "Keras 2 requires the `tf_keras` package."
+                "Please install it with `pip install tf_keras`."
+            )
 
     if not hasattr(keras, "saving"):
         keras.saving = types.SimpleNamespace()


### PR DESCRIPTION
Switches `from tensorflow import keras` to `import tf_keras as keras` when using `keras 2` workflow.

We currently use TensorFlow 2.13 in release (for Waymo?).  If we can bump it to 2.14, we can switch to `tf_keras`.
https://github.com/keras-team/keras-cv/blob/master/.github/workflows/actions.yml#L36