### PR TITLE
Fix Segment Anything Model saving bug

### DIFF
--- a/keras_cv/models/segmentation/segment_anything/sam_layers.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_layers.py
@@ -275,7 +275,7 @@ class RandomFrequencyPositionalEmbeddings(keras.layers.Layer):
         super().__init__(**kwargs)
         self.num_positional_features = num_positional_features
         self.scale = scale
-        init_func = lambda *a, **kw: self.scale * ops.random.normal(
+        init_func = lambda *a, **kw: self.scale * keras.random.normal(
             shape=(2, self.num_positional_features), dtype=self.dtype
         )
         self.positional_encoding_gaussian_matrix = self.add_weight(

--- a/keras_cv/models/segmentation/segment_anything/sam_layers.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_layers.py
@@ -275,15 +275,12 @@ class RandomFrequencyPositionalEmbeddings(keras.layers.Layer):
         super().__init__(**kwargs)
         self.num_positional_features = num_positional_features
         self.scale = scale
-        init_func = lambda *a, **kw: self.scale * keras.random.normal(
-            shape=(2, self.num_positional_features), dtype=self.dtype
-        )
         self.positional_encoding_gaussian_matrix = self.add_weight(
             name="positional_encoding_gaussian_matrix",
             shape=(2, self.num_positional_features),
             dtype=self.dtype,
             trainable=False,
-            initializer=init_func,
+            initializer=keras.initializers.get("normal"),
         )
 
     def build(self, input_shape=None):


### PR DESCRIPTION
# What does this PR do?

Loading `keras_cv.models.SegmentAnythingModel` presets fail when using Keras 3. This is because Keras 3 moves the `random` module outside of the `ops` namespace and one of the layers in the SAM model uses the `ops.random.normal` function. This PR fixes the error by accessing the function from the top-level keras module (`keras.random.normal`).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@divyashreepathihalli @sampathweb