### PR TITLE
Set a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to ???@???; and/or
+- send a [private vulnerability report](https://github.com/keras-team/keras-cv/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+please give us 90 days to work on a fix before public exposure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,6 @@ used before a patch is released.
 
 You may submit the report in the following ways:
 
-- send an email to ???@???; and/or
 - send a [private vulnerability report](https://github.com/keras-team/keras-cv/security/advisories/new)
 
 Please provide the following information in your report:


### PR DESCRIPTION
# What does this PR do?

Fixes #2141

This PR sets a simple security policy for Keras CV. It is almost identical to the one used by keras-team/keras.

It currently offers two avenues to report vulnerabilities:

- an email (currently just a placeholder!)
- GitHub's private reporting feature

If you'd rather just use one of these, let me know and I'll modify the policy. Or, if you think [/tf-keras's Tensorflow-based policy](https://github.com/keras-team/tf-keras/blob/master/CONTRIBUTING.md#security-vulnerability-reports) is a better fit, I can use it here as well. (I admit I'm not 100% sure which repos are still tied to TF and which aren't...)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

@divyashreepathihalli, @sampathweb (from the template)