### PR TITLE
fix shapes error  if images was a list.

### DIFF
--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -18,8 +18,8 @@ import numpy as np
 import tensorflow as tf
 
 from keras_cv import utils
-from keras_cv.backend import ops
 from keras_cv.api_export import keras_cv_export
+from keras_cv.backend import ops
 from keras_cv.utils import assert_matplotlib_installed
 
 try:
@@ -52,9 +52,11 @@ def _extract_image_batch(images, num_images, batch_size):
                 "batch your `np.array` samples together."
             )
         else:
-            num_samples = (
-                num_images if num_images <= batch_size else num_batches_required
-            )
+            if num_images <= batch_size:
+                num_samples = num_images
+            else:
+                num_samples = num_batches_required
+
             sample = images[:num_samples, ...]
     return sample
 

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -52,11 +52,9 @@ def _extract_image_batch(images, num_images, batch_size):
                 "batch your `np.array` samples together."
             )
         else:
-            if num_images <= batch_size:
-                num_samples = num_images
-            else:
-                num_samples = num_batches_required
-
+            num_samples = (
+                num_images if num_images <= batch_size else num_batches_required
+            )
             sample = images[:num_samples, ...]
     return sample
 

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -18,6 +18,7 @@ import numpy as np
 import tensorflow as tf
 
 from keras_cv import utils
+from keras_cv.backend import ops
 from keras_cv.api_export import keras_cv_export
 from keras_cv.utils import assert_matplotlib_installed
 
@@ -45,7 +46,7 @@ def _extract_image_batch(images, num_images, batch_size):
         return sample
 
     else:
-        if len(images.shape) != 4:
+        if len(ops.shape(images)) != 4:
             raise ValueError(
                 "`plot_images_gallery()` requires you to "
                 "batch your `np.array` samples together."
@@ -129,7 +130,7 @@ def plot_image_gallery(
         )  # batch_size from within passed `tf.data.Dataset`
     else:
         batch_size = (
-            images.shape[0] if len(images.shape) == 4 else 1
+            ops.shape(images)[0] if len(ops.shape(images)) == 4 else 1
         )  # batch_size from np.array or single image
 
     rows = rows or int(math.ceil(math.sqrt(batch_size)))


### PR DESCRIPTION
Fixing error in this guide - classification_with_keras_cv
```
AttributeError                            Traceback (most recent call last)
[<ipython-input-3-79c475acdf18>](https://localhost:8080/#) in <cell line: 4>()
      2 image = keras.utils.load_img(filepath)
      3 image = np.array(image)
----> 4 keras_cv.visualization.plot_image_gallery(
      5     [image], rows=1, cols=1, value_range=(0, 255), show=True, scale=4
      6 )

[/usr/local/lib/python3.10/dist-packages/keras_cv/src/visualization/plot_image_gallery.py](https://localhost:8080/#) in plot_image_gallery(images, value_range, scale, rows, cols, path, show, transparent, dpi, legend_handles)
    130     else:
    131         batch_size = (
--> 132             images.shape[0] if len(images.shape) == 4 else 1
    133         )  # batch_size from np.array or single image
    134 

AttributeError: 'list' object has no attribute 'shape'
```