### PR TITLE
Remove keras-nightly pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Tensorflow.
 tf-nightly-cpu==2.16.0.dev20231109  # Pin a working nightly until rc0.
-keras-nightly==3.0.0.dev2023111903  # TODO recent nightly fails keras_cv/models/object_detection/retinanet/retinanet_test.py
 
 # Torch.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
With the fix to `keras` Reshape, this PR removes the pin on keras-nightly.  Will have to wait for keras-nightly wheel before it can be merged.