### PR TITLE
Fix Keras 3 version check

### DIFF
--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -29,8 +29,6 @@ else:
 
 def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
-    import os
-
     import keras
 
     # Return False if env variable is set and `tf_keras` is installed.

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -29,22 +29,19 @@ else:
 
 def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
-    import keras
+    try:
+        from tensorflow import keras
 
-    # Return False if env variable is set and `tf_keras` is installed.
-    use_legacy_keras = os.environ.get("TF_USE_LEGACY_KERAS", "")
-    if use_legacy_keras == "1" or use_legacy_keras.lower() == "true":
-        try:
-            import tf_keras  # noqa: F401
-
-            return False
-        except ImportError:
-            # `tf_keras` is not installed
-            pass
-
-    # Note that only recent versions of keras have a `version()` function.
-    if hasattr(keras, "version") and keras.version().startswith("3."):
-        return True
+        # Note that only recent versions of keras have a `version()` function.
+        if hasattr(keras, "version") and keras.version().startswith("3."):
+            return True
+    except:
+        raise ValueError(
+            "Unable to import `keras` with `tensorflow`.  Please check your "
+            "Keras and Tensorflow version are compatible; Keras 3 requires "
+            "TensorFlow 2.15 or later. See keras.io/getting_started for more "
+            "information on installing Keras."
+        )
 
     # No `keras.version()` means we are on an old version of keras.
     return False

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -27,9 +27,22 @@ else:
     _keras_dir = os.path.join(_keras_base_dir, ".keras")
 
 
-def detect_if_keras_3_installed():
+def detect_if_tensorflow_uses_keras_3():
     # We follow the version of keras that tensorflow is configured to use.
+    import os
+
     import keras
+
+    # Return False if env variable is set and `tf_keras` is installed.
+    use_legacy_keras = os.environ.get("TF_USE_LEGACY_KERAS", "")
+    if use_legacy_keras == "1" or use_legacy_keras.lower() == "true":
+        try:
+            import tf_keras  # noqa: F401
+
+            return False
+        except ImportError:
+            # `tf_keras` is not installed
+            pass
 
     # Note that only recent versions of keras have a `version()` function.
     if hasattr(keras, "version") and keras.version().startswith("3."):
@@ -39,7 +52,7 @@ def detect_if_keras_3_installed():
     return False
 
 
-_USE_KERAS_3 = detect_if_keras_3_installed()
+_USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
 if _USE_KERAS_3:
     _MULTI_BACKEND = True
 

--- a/keras_cv/backend/config.py
+++ b/keras_cv/backend/config.py
@@ -27,9 +27,9 @@ else:
     _keras_dir = os.path.join(_keras_base_dir, ".keras")
 
 
-def detect_if_tensorflow_uses_keras_3():
+def detect_if_keras_3_installed():
     # We follow the version of keras that tensorflow is configured to use.
-    from tensorflow import keras
+    import keras
 
     # Note that only recent versions of keras have a `version()` function.
     if hasattr(keras, "version") and keras.version().startswith("3."):
@@ -39,7 +39,7 @@ def detect_if_tensorflow_uses_keras_3():
     return False
 
 
-_USE_KERAS_3 = detect_if_tensorflow_uses_keras_3()
+_USE_KERAS_3 = detect_if_keras_3_installed()
 if _USE_KERAS_3:
     _MULTI_BACKEND = True
 


### PR DESCRIPTION
`from tensorflow import keras` doesn't work for `TF 2.14` and Keras 3.

`keras-nlp` has a function to check if TensorFlow uses Keras 3 via - 
https://github.com/keras-team/keras-nlp/blob/master/keras_nlp/backend/config.py#L66

This works when using `tf-nightly` or `TensorFlow 2.15`, but breaks on `TensorFlow 2.14` which is the default in Colab.  To fix it, use `import keras` instead of `from tensorflow import keras` when doing this check.

Colab to repro the issue:
https://colab.research.google.com/drive/17AwBX5S29d-hjUDPLN8roHSNzrjXricG?usp=sharing