### PR TITLE
Adapt KerasCV for Kaggle integration with new preset format

### DIFF
--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -17,6 +17,8 @@ import os
 
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
+from keras_cv.utils.preset_utils import check_preset_class
+from keras_cv.utils.preset_utils import load_from_preset
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 
@@ -66,6 +68,30 @@ class Backbone(keras.Model):
         }
 
     @classmethod
+    def _legacy_from_preset(
+        cls,
+        preset,
+        load_weights=None,
+        **kwargs,
+    ):
+        metadata = cls.presets[preset]
+        config = metadata["config"]
+        model = cls.from_config({**config, **kwargs})
+
+        if preset not in cls.presets_with_weights or load_weights is False:
+            return model
+
+        weights = keras.utils.get_file(
+            "model.h5",
+            metadata["weights_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["weights_hash"],
+        )
+
+        model.load_weights(weights)
+        return model
+
+    @classmethod
     def from_preset(
         cls,
         preset,
@@ -95,42 +121,17 @@ class Backbone(keras.Model):
             load_weights=False,
         ```
         """
+        # TODO: delete me!
+        if preset in cls.presets:
+            return cls._legacy_from_preset(preset, **kwargs)
 
-        if not cls.presets:
-            raise NotImplementedError(
-                "No presets have been created for this class."
-            )
-
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
-
-        if load_weights and preset not in cls.presets_with_weights:
-            raise ValueError(
-                f"""Pretrained weights not available for preset "{preset}". """
-                "Set `load_weights=False` to use this preset or choose one of "
-                "the following presets with weights:"
-                f""" "{'", "'.join(cls.presets_with_weights)}"."""
-            )
-
-        metadata = cls.presets[preset]
-        config = metadata["config"]
-        model = cls.from_config({**config, **kwargs})
-
-        if preset not in cls.presets_with_weights or load_weights is False:
-            return model
-
-        weights = keras.utils.get_file(
-            "model.h5",
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
+        check_preset_class(preset, cls)
+        return load_from_preset(
+            preset,
+            load_weights=load_weights,
+            config_overrides=kwargs,
         )
 
-        model.load_weights(weights)
-        return model
 
     def __init_subclass__(cls, **kwargs):
         # Use __init_subclass__ to set up a correct docstring for from_preset.

--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -132,7 +132,6 @@ class Backbone(keras.Model):
             config_overrides=kwargs,
         )
 
-
     def __init_subclass__(cls, **kwargs):
         # Use __init_subclass__ to set up a correct docstring for from_preset.
         super().__init_subclass__(**kwargs)

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -25,6 +25,9 @@ from keras_cv.models.backbones.backbone_presets import (
     backbone_presets_with_weights,
 )
 from keras_cv.models.object_detection.__internal__ import unpack_input
+from keras_cv.models.object_detection.yolo_v8.yolo_v8_backbone import (
+    YOLOV8Backbone,
+)
 from keras_cv.models.object_detection.yolo_v8.yolo_v8_detector_presets import (
     yolo_v8_detector_presets,
 )
@@ -657,6 +660,10 @@ class YOLOV8Detector(Task):
         return copy.deepcopy(
             {**backbone_presets_with_weights, **yolo_v8_detector_presets}
         )
+
+    @classproperty
+    def backbone_cls(cls):
+        return YOLOV8Backbone
 
     @classproperty
     def backbone_presets(cls):

--- a/keras_cv/models/object_detection_3d/center_pillar.py
+++ b/keras_cv/models/object_detection_3d/center_pillar.py
@@ -18,6 +18,9 @@ from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.backend import ops
 from keras_cv.layers.object_detection_3d.heatmap_decoder import HeatmapDecoder
+from keras_cv.models.object_detection_3d.center_pillar_backbone import (
+    CenterPillarBackbone,
+)
 from keras_cv.models.object_detection_3d.center_pillar_backbone_presets import (
     backbone_presets,
 )
@@ -201,6 +204,10 @@ class MultiHeadCenterPillar(Task):
     def presets(cls):
         """Dictionary of preset names and configurations."""
         return copy.deepcopy(backbone_presets)
+
+    @classproperty
+    def backbone_cls(cls):
+        return CenterPillarBackbone
 
     @classproperty
     def backbone_presets(cls):

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -17,6 +17,7 @@ import os
 
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
+from keras_cv.models.backbones.backbone import Backbone
 from keras_cv.utils.preset_utils import check_preset_class
 from keras_cv.utils.preset_utils import load_from_preset
 from keras_cv.utils.python_utils import classproperty
@@ -167,7 +168,7 @@ class Task(keras.Model):
         preset_cls = check_preset_class(preset, (cls, cls.backbone_cls))
 
         # Backbone case.
-        if preset_cls == cls.backbone_cls:
+        if issubclass(preset_cls, Backbone):
             backbone = load_from_preset(
                 preset,
                 load_weights=load_weights,

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -75,6 +75,10 @@ class Task(keras.Model):
         }
 
     @classproperty
+    def backbone_cls(cls):
+        return None
+
+    @classproperty
     def backbone_presets(cls):
         """Dictionary of preset names and configs for compatible backbones."""
         return {}
@@ -160,10 +164,10 @@ class Task(keras.Model):
                 preset, load_weights, input_shape, **kwargs
             )
 
-        check_preset_class(preset, cls)
+        preset_cls = check_preset_class(preset, (cls, cls.backbone_cls))
 
         # Backbone case.
-        if preset in cls.backbone_presets:
+        if preset_cls == cls.backbone_cls:
             backbone = load_from_preset(
                 preset,
                 load_weights=load_weights,

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -160,7 +160,7 @@ class Task(keras.Model):
                 preset, load_weights, input_shape, **kwargs
             )
 
-        preset_cls = check_preset_class(preset, cls)
+        check_preset_class(preset, cls)
 
         # Backbone case.
         if preset in cls.backbone_presets:

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -17,6 +17,8 @@ import os
 
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
+from keras_cv.utils.preset_utils import check_preset_class
+from keras_cv.utils.preset_utils import load_from_preset
 from keras_cv.utils.python_utils import classproperty
 from keras_cv.utils.python_utils import format_docstring
 
@@ -78,6 +80,46 @@ class Task(keras.Model):
         return {}
 
     @classmethod
+    def _legacy_from_preset(
+        cls,
+        preset,
+        load_weights=True,
+        input_shape=None,
+        **kwargs,
+    ):
+        metadata = cls.presets[preset]
+        # Check if preset is backbone-only model
+        if preset in cls.backbone_presets:
+            backbone_cls = keras.saving.get_registered_object(
+                metadata["class_name"]
+            )
+            backbone = backbone_cls.from_preset(preset, load_weights)
+            return cls(backbone, **kwargs)
+
+        # Otherwise must be one of class presets
+        config = metadata["config"]
+        if input_shape is not None:
+            config["backbone"]["config"]["input_shape"] = input_shape
+        model = cls.from_config({**config, **kwargs})
+
+        if preset not in cls.presets_with_weights or load_weights is False:
+            return model
+
+        local_weights_path = "model.h5"
+        if metadata["weights_url"].endswith(".weights.h5"):
+            local_weights_path = "model.weights.h5"
+
+        weights = keras.utils.get_file(
+            local_weights_path,
+            metadata["weights_url"],
+            cache_subdir=os.path.join("models", preset),
+            file_hash=metadata["weights_hash"],
+        )
+
+        model.load_weights(weights)
+        return model
+
+    @classmethod
     def from_preset(
         cls,
         preset,
@@ -112,56 +154,28 @@ class Task(keras.Model):
         ```
         """
 
-        if not cls.presets:
-            raise NotImplementedError(
-                "No presets have been created for this class."
+        # TODO: delete me!
+        if preset in cls.presets:
+            return cls._legacy_from_preset(
+                preset, load_weights, input_shape, **kwargs
             )
 
-        if preset not in cls.presets:
-            raise ValueError(
-                "`preset` must be one of "
-                f"""{", ".join(cls.presets)}. Received: {preset}."""
-            )
+        preset_cls = check_preset_class(preset, cls)
 
-        if load_weights and preset not in cls.presets_with_weights:
-            raise ValueError(
-                f"""Pretrained weights not available for preset "{preset}". """
-                "Set `load_weights=False` to use this preset or choose one of "
-                "the following presets with weights:"
-                f""" "{'", "'.join(cls.presets_with_weights)}"."""
-            )
-
-        metadata = cls.presets[preset]
-        # Check if preset is backbone-only model
+        # Backbone case.
         if preset in cls.backbone_presets:
-            backbone_cls = keras.saving.get_registered_object(
-                metadata["class_name"]
+            backbone = load_from_preset(
+                preset,
+                load_weights=load_weights,
             )
-            backbone = backbone_cls.from_preset(preset, load_weights)
-            return cls(backbone, **kwargs)
+            return cls(backbone=backbone, **kwargs)
 
-        # Otherwise must be one of class presets
-        config = metadata["config"]
-        if input_shape is not None:
-            config["backbone"]["config"]["input_shape"] = input_shape
-        model = cls.from_config({**config, **kwargs})
-
-        if preset not in cls.presets_with_weights or load_weights is False:
-            return model
-
-        local_weights_path = "model.h5"
-        if metadata["weights_url"].endswith(".weights.h5"):
-            local_weights_path = "model.weights.h5"
-
-        weights = keras.utils.get_file(
-            local_weights_path,
-            metadata["weights_url"],
-            cache_subdir=os.path.join("models", preset),
-            file_hash=metadata["weights_hash"],
+        # Task case.
+        return load_from_preset(
+            preset,
+            load_weights=load_weights,
+            config_overrides=kwargs,
         )
-
-        model.load_weights(weights)
-        return model
 
     @property
     def layers(self):

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -51,6 +51,10 @@ def recursive_pop(config, key):
     for value in config.values():
         if isinstance(value, dict):
             recursive_pop(value, key)
+        if isinstance(value, list):
+            for v in value:
+                if isinstance(v, dict):
+                    recursive_pop(v, key)
 
 
 def save_to_preset(

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -1,0 +1,141 @@
+# Copyright 2023 The KerasCV Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import os
+
+from keras_cv.backend import keras
+
+try:
+    import kagglehub
+except ImportError:
+    kagglehub = None
+
+KAGGLE_PREFIX = "kaggle://"
+
+
+def get_file(preset, path):
+    """Download a preset file in necessary and return the local path."""
+    if preset.startswith(KAGGLE_PREFIX):
+        kaggle_handle = preset.removeprefix(KAGGLE_PREFIX)
+        if kagglehub is None:
+            raise ImportError(
+                "`from_preset()` requires the `kagglehub` package. "
+                "Please install with `pip install kagglehub`."
+            )
+        if len(kaggle_handle.split("/")) not in (4, 5):
+            raise ValueError(
+                "Unexpected kaggle preset handle. Kaggle model handles should have "
+                "the form kaggle://{org}/{model}/keras/{variant}[/{version}]. For "
+                "example, kaggle://keras-nlp/albert/keras/bert_base_en_uncased."
+            )
+        return kagglehub.model_download(kaggle_handle, path)
+    return os.path.join(preset, path)
+
+
+def recursive_pop(config, key):
+    """Remove a key from a nested config object"""
+    config.pop(key, None)
+    for value in config.values():
+        if isinstance(value, dict):
+            recursive_pop(value, key)
+
+
+def save_to_preset(
+    layer,
+    preset,
+    save_weights=True,
+    config_filename="config.json",
+    weights_filename="model.weights.h5",
+):
+    """Save a KerasCV layer to a preset directory."""
+    os.makedirs(preset, exist_ok=True)
+
+    # Optionally save weights.
+    save_weights = save_weights and hasattr(layer, "save_weights")
+    if save_weights:
+        weights_path = os.path.join(preset, weights_filename)
+        layer.save_weights(weights_path)
+
+    # Save a serialized Keras object.
+    config_path = os.path.join(preset, config_filename)
+    config = keras.saving.serialize_keras_object(layer)
+    # Include references to weights.
+    config["weights"] = weights_filename if save_weights else None
+    recursive_pop(config, "compile_config")
+    recursive_pop(config, "build_config")
+    with open(config_path, "w") as config_file:
+        config_file.write(json.dumps(config, indent=4))
+
+    from keras_cv import __version__ as keras_cv_version
+
+    keras_version = keras.version() if hasattr(keras, "version") else None
+
+    # Save any associated metadata.
+    if config_filename == "config.json":
+        metadata = {
+            "keras_version": keras_version,
+            "keras_cv_version": keras_cv_version,
+            "parameter_count": layer.count_params(),
+            "date_saved": datetime.datetime.now().strftime("%Y-%m-%d@%H:%M:%S"),
+        }
+        metadata_path = os.path.join(preset, "metadata.json")
+        with open(metadata_path, "w") as metadata_file:
+            metadata_file.write(json.dumps(metadata, indent=4))
+
+
+def load_from_preset(
+    preset,
+    load_weights=True,
+    config_file="config.json",
+    config_overrides={},
+):
+    """Load a KerasCV layer to a preset directory."""
+    # Load a serialized Keras object.
+    config_path = get_file(preset, config_file)
+    with open(config_path) as config_file:
+        config = json.load(config_file)
+    config["config"] = {**config["config"], **config_overrides}
+    layer = keras.saving.deserialize_keras_object(config)
+
+    # Optionally load weights.
+    load_weights = load_weights and config["weights"]
+    if load_weights:
+        weights_path = get_file(preset, config["weights"])
+        layer.load_weights(weights_path)
+
+    return layer
+
+
+def check_preset_class(
+    preset,
+    classes,
+    config_file="config.json",
+):
+    """Validate a preset is being loaded on the correct class."""
+    config_path = get_file(preset, config_file)
+    with open(config_path) as config_file:
+        config = json.load(config_file)
+    cls = keras.saving.get_registered_object(config["registered_name"])
+    if not isinstance(classes, (tuple, list)):
+        classes = (classes,)
+    if cls not in classes:
+        raise ValueError(
+            f"Unexpected class in preset `'{preset}'`. "
+            "When calling `from_preset()` on a class object, the preset class "
+            f"much match allowed classes. Allowed classes are `{classes}`. "
+            f"Received: `{cls}`."
+        )
+    return cls

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -29,17 +29,25 @@ KAGGLE_PREFIX = "kaggle://"
 def get_file(preset, path):
     """Download a preset file in necessary and return the local path."""
     if preset.startswith(KAGGLE_PREFIX):
-        kaggle_handle = preset.removeprefix(KAGGLE_PREFIX)
         if kagglehub is None:
             raise ImportError(
                 "`from_preset()` requires the `kagglehub` package. "
                 "Please install with `pip install kagglehub`."
             )
-        if len(kaggle_handle.split("/")) not in (4, 5):
+        segments = preset.removeprefix(KAGGLE_PREFIX).split("/")
+        # Insert the kaggle framework into the handle.
+        if len(segments) == 3:
+            org, model, variant = segments
+            kaggle_handle = f"{org}/{model}/keras/{variant}/1"
+        elif len(segments) == 4:
+            org, model, variant, version = segments
+            kaggle_handle = f"{org}/{model}/keras/{variant}/{version}"
+        else:
             raise ValueError(
-                "Unexpected kaggle preset handle. Kaggle model handles should have "
-                "the form kaggle://{org}/{model}/keras/{variant}[/{version}]. For "
-                "example, kaggle://keras-nlp/albert/keras/bert_base_en_uncased."
+                "Unexpected kaggle preset handle. Kaggle model handles should "
+                "have the form kaggle://{org}/{model}/{variant}[/{version}]. "
+                "For example, 'kaggle://keras/bert/bert_base_en'. "
+                f"Received: preset={preset}"
             )
         return kagglehub.model_download(kaggle_handle, path)
     return os.path.join(preset, path)

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -46,7 +46,7 @@ def get_file(preset, path):
             raise ValueError(
                 "Unexpected kaggle preset handle. Kaggle model handles should "
                 "have the form kaggle://{org}/{model}/{variant}[/{version}]. "
-                "For example, 'kaggle://keras/bert/bert_base_en'. "
+                "For example, 'kaggle://keras/retinanet/retinanet_base_en'. "
                 f"Received: preset={preset}"
             )
         return kagglehub.model_download(kaggle_handle, path)

--- a/keras_cv/utils/preset_utils_test.py
+++ b/keras_cv/utils/preset_utils_test.py
@@ -14,24 +14,43 @@
 
 import json
 import os
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
+
+from keras_cv.models import DeepLabV3Plus
 from keras_cv.models import ImageClassifier
+from keras_cv.models import RetinaNet
+from keras_cv.models import YOLOV8Detector
 from keras_cv.tests.test_case import TestCase
 from keras_cv.utils import preset_utils
 
 
 class PresetUtilsTest(TestCase):
     @parameterized.parameters(
-        (ImageClassifier, "resnet50_v2_imagenet_classifier"),
-        (ImageClassifier, "efficientnetv2_s_imagenet_classifier"),
-        (ImageClassifier, "mobilenet_v3_large_imagenet_classifier"),
+        (ImageClassifier, "resnet50_v2_imagenet_classifier", "classification"),
+        (
+            ImageClassifier,
+            "efficientnetv2_s_imagenet_classifier",
+            "classification",
+        ),
+        (
+            ImageClassifier,
+            "mobilenet_v3_large_imagenet_classifier",
+            "classification",
+        ),
+        (YOLOV8Detector, "yolo_v8_m_pascalvoc", "detection"),
+        (RetinaNet, "retinanet_resnet50_pascalvoc", "detection"),
+        (DeepLabV3Plus, "deeplab_v3_plus_resnet50_pascalvoc", "segmentation"),
     )
     @pytest.mark.large
-    def test_classifier_preset_saving(self, cls, preset_name):
+    def test_preset_saving(self, cls, preset_name, task_type):
         save_dir = self.get_temp_dir()
-        model = cls.from_preset(preset_name)
+        if task_type == "detection":
+            model = cls.from_preset(preset_name, bounding_box_format="xywh")
+        else:
+            model = cls.from_preset(preset_name)
         preset_utils.save_to_preset(model, save_dir)
 
         # Check existence of files

--- a/keras_cv/utils/preset_utils_test.py
+++ b/keras_cv/utils/preset_utils_test.py
@@ -1,0 +1,62 @@
+# Copyright 2023 The KerasNLP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import numpy as np
+import pytest
+from absl.testing import parameterized
+from keras_cv.models import ImageClassifier
+from keras_cv.tests.test_case import TestCase
+from keras_cv.utils import preset_utils
+
+
+class PresetUtilsTest(TestCase):
+    @parameterized.parameters(
+        (ImageClassifier, "resnet50_v2_imagenet_classifier"),
+        (ImageClassifier, "efficientnetv2_s_imagenet_classifier"),
+        (ImageClassifier, "mobilenet_v3_large_imagenet_classifier"),
+    )
+    @pytest.mark.large
+    def test_classifier_preset_saving(self, cls, preset_name):
+        save_dir = self.get_temp_dir()
+        model = cls.from_preset(preset_name)
+        preset_utils.save_to_preset(model, save_dir)
+
+        # Check existence of files
+        self.assertTrue(os.path.exists(os.path.join(save_dir, "config.json")))
+        self.assertTrue(
+            os.path.exists(os.path.join(save_dir, "model.weights.h5"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(save_dir, "metadata.json")))
+
+        # Check the model config (`config.json`)
+        with open(os.path.join(save_dir, "config.json"), "r") as f:
+            config_json = f.read()
+        self.assertTrue(
+            "build_config" not in config_json
+        )  # Test on raw json to include nested keys
+        self.assertTrue(
+            "compile_config" not in config_json
+        )  # Test on raw json to include nested keys
+        config = json.loads(config_json)
+        self.assertEqual(config["weights"], "model.weights.h5")
+
+        # Try loading the model from preset directory
+        restored_model = preset_utils.load_from_preset(save_dir)
+
+        input_batch = np.ones(shape=(2, 224, 224, 3))
+        expected_output = model(input_batch)
+        restored_output = restored_model(input_batch)
+        self.assertAllClose(expected_output, restored_output)


### PR DESCRIPTION
This PR changes the preset logic to a new format based on Keras V3 Saving, along with preset utilities to easily integrate with Kaggle.