### PR TITLE
Fix dtype support for SegmentAnythingModel

### DIFF
--- a/keras_cv/layers/vit_det_layers.py
+++ b/keras_cv/layers/vit_det_layers.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.backend import ops

--- a/keras_cv/layers/vit_det_layers.py
+++ b/keras_cv/layers/vit_det_layers.py
@@ -123,16 +123,16 @@ class AddRelativePositionalEmbedding(keras.layers.Layer):
             return rel_pos_resized
         else:
             rel_pos_resized = rel_pos
-        query_coordinates = np.arange(query_size, dtype="float32")[:, None] * (
-            max(key_size / query_size, 1.0)
-        )
-        key_coordinates = np.arange(key_size, dtype="float32")[None, :] * (
-            max(query_size / key_size, 1.0)
-        )
+        query_coordinates = ops.cast(
+            ops.arange(query_size), dtype=self.compute_dtype
+        )[:, None] * (max(key_size / query_size, 1.0))
+        key_coordinates = ops.cast(
+            ops.arange(key_size), dtype=self.compute_dtype
+        )[None, :] * (max(query_size / key_size, 1.0))
         relative_coordinates = (query_coordinates - key_coordinates) + (
             key_size - 1
         ) * max(query_size / key_size, 1.0)
-        relative_coordinates = relative_coordinates.astype("int32")
+        relative_coordinates = ops.cast(relative_coordinates, dtype="int32")
         return ops.take(rel_pos_resized, relative_coordinates, 0)
 
     def call(self, attention_map, queries, query_size, key_size):

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -281,7 +281,7 @@ class SAMTest(TestCase):
             self.assertAllClose(iou_pred, iou_pred_ex, atol=1e-4)
 
             # Reset the global policy
-            keras.mixed_precision.set_dtype_policy(old_policy)
+            keras.mixed_precision.set_global_policy(old_policy)
 
     @pytest.mark.extra_large
     def test_end_to_end_model_save(self):

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -234,7 +234,9 @@ class SAMTest(TestCase):
             # We are changing the global dtype policy here but don't want any
             # other tests to use that policy, so compute under a lock until
             # we reset the global policy.
-            old_policy = keras.mixed_precision.dtype_policy()
+            old_policy = getattr(
+                keras.mixed_precision, "dtype_policy", lambda: "float32"
+            )()
             keras.mixed_precision.set_global_policy(dtype_policy)
             model = SegmentAnythingModel(
                 backbone=self.image_encoder,

--- a/keras_cv/models/segmentation/segment_anything/sam_test.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_test.py
@@ -220,48 +220,66 @@ class SAMTest(TestCase):
         self.assertEqual(num_parameters, 4_058_340)
 
     @pytest.mark.large
-    def test_end_to_end_model_predict(self):
-        model = SegmentAnythingModel(
-            backbone=self.image_encoder,
-            prompt_encoder=self.prompt_encoder,
-            mask_decoder=self.mask_decoder,
-        )
+    @parameterized.named_parameters(
+        [
+            ("float32", "float32"),
+            ("mixed_float16", "mixed_float16"),
+            ("bfloat16", "bfloat16"),
+        ]
+    )
+    def test_end_to_end_model_predict(self, dtype_policy):
+        import threading
 
-        # We use box-only prompting for this test.
-        mask_prompts = self.get_prompts(1, "boxes")
-        inputs = {
-            "images": np.ones((1, 1024, 1024, 3)),
-        }
-        inputs.update(mask_prompts)
+        with threading.Lock():
+            # We are changing the global dtype policy here but don't want any
+            # other tests to use that policy, so compute under a lock until
+            # we reset the global policy.
+            old_policy = keras.mixed_precision.dtype_policy()
+            keras.mixed_precision.set_global_policy(dtype_policy)
+            model = SegmentAnythingModel(
+                backbone=self.image_encoder,
+                prompt_encoder=self.prompt_encoder,
+                mask_decoder=self.mask_decoder,
+            )
 
-        # Check the number of parameters
-        num_parameters = np.sum([np.prod(x.shape) for x in model.weights])
-        self.assertEqual(num_parameters, 89_670_912 + 6_476 + 4_058_340)
+            # We use box-only prompting for this test.
+            mask_prompts = self.get_prompts(1, "boxes")
+            inputs = {
+                "images": np.ones((1, 1024, 1024, 3)),
+            }
+            inputs.update(mask_prompts)
 
-        # Forward pass through the model
-        outputs = model.predict(inputs)
-        masks, iou_pred = outputs["masks"], outputs["iou_pred"]
+            # Check the number of parameters
+            num_parameters = np.sum([np.prod(x.shape) for x in model.weights])
+            self.assertEqual(num_parameters, 89_670_912 + 6_476 + 4_058_340)
 
-        # Check the output is equal to the one we expect if we
-        # run each component separately. This is to confirm that
-        # the graph is getting compiled correctly i.e. the jitted
-        # execution is equivalent to the eager execution.
-        features = self.image_encoder(inputs["images"])
-        outputs_ex = self.prompt_encoder(
-            {k: v for k, v in inputs.items() if k != "images"}
-        )
-        outputs_ex = self.mask_decoder(
-            {
-                "image_embeddings": features,
-                "image_pe": outputs_ex["dense_positional_embeddings"],
-                "sparse_prompt_embeddings": outputs_ex["sparse_embeddings"],
-                "dense_prompt_embeddings": outputs_ex["dense_embeddings"],
-            },
-        )
-        masks_ex, iou_pred_ex = outputs_ex["masks"], outputs_ex["iou_pred"]
+            # Forward pass through the model
+            outputs = model.predict(inputs)
+            masks, iou_pred = outputs["masks"], outputs["iou_pred"]
 
-        self.assertAllClose(masks, masks_ex, atol=1e-4)
-        self.assertAllClose(iou_pred, iou_pred_ex, atol=1e-4)
+            # Check the output is equal to the one we expect if we
+            # run each component separately. This is to confirm that
+            # the graph is getting compiled correctly i.e. the jitted
+            # execution is equivalent to the eager execution.
+            features = self.image_encoder(inputs["images"])
+            outputs_ex = self.prompt_encoder(
+                {k: v for k, v in inputs.items() if k != "images"}
+            )
+            outputs_ex = self.mask_decoder(
+                {
+                    "image_embeddings": features,
+                    "image_pe": outputs_ex["dense_positional_embeddings"],
+                    "sparse_prompt_embeddings": outputs_ex["sparse_embeddings"],
+                    "dense_prompt_embeddings": outputs_ex["dense_embeddings"],
+                },
+            )
+            masks_ex, iou_pred_ex = outputs_ex["masks"], outputs_ex["iou_pred"]
+
+            self.assertAllClose(masks, masks_ex, atol=1e-4)
+            self.assertAllClose(iou_pred, iou_pred_ex, atol=1e-4)
+
+            # Reset the global policy
+            keras.mixed_precision.set_dtype_policy(old_policy)
 
     @pytest.mark.extra_large
     def test_end_to_end_model_save(self):


### PR DESCRIPTION
# What does this PR do?

Segment Anything model can use `keras.mixed_precision.set_dype_policy` for quick optimizations. This PR fixed the model so that it can be run with any dtype policy set. Also added a test for `float32` (default in keras), `mixed_float16`, and `bfloat16`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
