### PR TITLE
Vectorized implementation of RandomColorDegeneration and Equalization preprocessing layers

### DIFF
--- a/keras_cv/layers/preprocessing/random_color_degeneration.py
+++ b/keras_cv/layers/preprocessing/random_color_degeneration.py
@@ -58,10 +58,14 @@ class RandomColorDegeneration(VectorizedBaseImageAugmentationLayer):
         self.seed = seed
 
     def get_random_transformation_batch(self, batch_size, **kwargs):
-        return self.factor(shape=(batch_size, 1, 1, 1), dtype=self.compute_dtype)
+        return self.factor(
+            shape=(batch_size, 1, 1, 1), dtype=self.compute_dtype
+        )
 
     def augment_images(self, images, transformations=None, **kwargs):
-        degenerates = tf.image.grayscale_to_rgb(tf.image.rgb_to_grayscale(images))
+        degenerates = tf.image.grayscale_to_rgb(
+            tf.image.rgb_to_grayscale(images)
+        )
         result = preprocessing.blend(images, degenerates, transformations)
         return result
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons --sometimes notifications get lost.
-->

Fixes #2120 (issue)

As Keras_CV==0.7.1, [RandomColorDegeneration](https://github.com/keras-team/keras-cv/blob/v0.7.1/keras_cv/layers/preprocessing/random_color_degeneration.py) and [Equalization](https://github.com/keras-team/keras-cv/blob/v0.7.1/keras_cv/layers/preprocessing/equalization.py) preprocessing layers are not subclasses of `VectorizedBaseImageAugmentationLayer`, thus resulting in a slow forward pass.

The vectorized implementation of `RandomColorDegeneration` is quite straightforward, while `RandomColorDegeneration` has a potential bottleneck represented by [tf.histogram_fixed_width](https://www.tensorflow.org/api_docs/python/tf/histogram_fixed_width).
In this pull request I propose an implementation for both layers.

As requested in #2120, these are the demo outputs:

**RandomColorDegeneration:**
![image](https://github.com/keras-team/keras-cv/assets/7725068/444db184-5e94-4ede-867d-c98aad850752)
![image](https://github.com/keras-team/keras-cv/assets/7725068/ab04b22a-0370-4f75-a41b-df5a6e130e11)

**Equalization:**
![image](https://github.com/keras-team/keras-cv/assets/7725068/4f1fa6e6-c7c0-47a9-91e7-80897df0e2bb)
![image](https://github.com/keras-team/keras-cv/assets/7725068/a5d4aa10-6b7d-4dc1-8974-256da7507486)

The output of the `Equalization` layer is deterministic, so the two implementations (original vs vectorized) can be compared with `np.allclose(output_original, output_vectorized)`, which returns `True`.

Source: https://colab.research.google.com/drive/1t5b4a11ae3HWxUoyL-R50E2z8dkNSQYP

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!--
Feel free to tag @divyashreepathihalli and @sampathweb in your reviews.
-->

<!--
This PR template is copied and modified from here:
https://github.com/huggingface/transformers/blob/main/.github/PULL_REQUEST_TEMPLATE.md
-->
