### PR TITLE
Change CenterPillar name

### DIFF
--- a/keras_cv/models/object_detection_3d/center_pillar_backbone_presets.py
+++ b/keras_cv/models/object_detection_3d/center_pillar_backbone_presets.py
@@ -19,7 +19,7 @@ backbone_presets = {
         "metadata": {
             "description": "An example CenterPillar backbone for WOD.",
             "params": 1277680,
-            "official_name": "WaymoOpenDataset",
+            "official_name": "CenterPillar",
         },
         "kaggle_handle": "gs://keras-cv-kaggle/center_pillar_waymo_open_dataset",  # noqa: E501
     },


### PR DESCRIPTION
The official name used to be "WaymoOpenDataset", but this isn't accurate.