### PR TITLE
Fixes Focal loss test for Torch

### DIFF
--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -72,5 +72,5 @@ class FocalLossModelGardenComparisonTest(TestCase):
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
                 ops.convert_to_numpy(focal_loss(y_true, tf.sigmoid(y_pred))),
-                model_garden_focal_loss(y_true, y_pred).numpy(),
+                ops.convert_to_numpy(model_garden_focal_loss(y_true, y_pred)),
             )

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
 
+from keras_cv.backend import ops
 from keras_cv.losses import FocalLoss
 from keras_cv.tests.test_case import TestCase
 
@@ -70,6 +71,6 @@ class FocalLossModelGardenComparisonTest(TestCase):
             y_true = tf.cast(y_true, tf.float32)
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
-                focal_loss(y_true, tf.sigmoid(y_pred)),
-                model_garden_focal_loss(y_true, y_pred),
+                ops.convert_to_numpy(focal_loss(y_true, tf.sigmoid(y_pred))),
+                model_garden_focal_loss(y_true, y_pred).numpy(),
             )


### PR DESCRIPTION
Fixes one of failing test for Torch on GPU - 
```
FAILED keras_cv/losses/numerical_tests/focal_loss_numerical_test.py::FocalLossModelGardenComparisonTest::test_model_garden_implementation_has_same_outputs_sum
```