### PR TITLE
Fixes GPU Tests - JAX, PyTorch and some failures for Keras2

### DIFF
--- a/keras_cv/backend/random.py
+++ b/keras_cv/backend/random.py
@@ -45,13 +45,19 @@ class SeedGenerator:
         return cls(**config)
 
 
-def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
+def _get_init_seed(seed):
     if isinstance(seed, SeedGenerator):
         seed = seed.next()
         init_seed = seed[0] + seed[1]
+        if keras_3() and keras.ops.is_tensor(init_seed):
+            init_seed = int(keras.ops.convert_to_numpy(init_seed))
     else:
         init_seed = seed
+    return init_seed
 
+
+def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
+    init_seed = _get_init_seed(seed)
     kwargs = {}
     if dtype:
         kwargs["dtype"] = dtype
@@ -76,11 +82,7 @@ def normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
 
 
 def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
-    if isinstance(seed, SeedGenerator):
-        seed = seed.next()
-        init_seed = seed[0] + seed[1]
-    else:
-        init_seed = seed
+    init_seed = _get_init_seed(seed)
     kwargs = {}
     if dtype:
         kwargs["dtype"] = dtype
@@ -105,12 +107,7 @@ def uniform(shape, minval=0.0, maxval=1.0, dtype=None, seed=None):
 
 
 def shuffle(x, axis=0, seed=None):
-    if isinstance(seed, SeedGenerator):
-        seed = seed.next()
-        init_seed = seed[0] + seed[1]
-    else:
-        init_seed = seed
-
+    init_seed = _get_init_seed(seed)
     if keras_3():
         return keras.random.shuffle(x=x, axis=axis, seed=init_seed)
     else:
@@ -120,11 +117,7 @@ def shuffle(x, axis=0, seed=None):
 
 
 def categorical(logits, num_samples, dtype=None, seed=None):
-    if isinstance(seed, SeedGenerator):
-        seed = seed.next()
-        init_seed = seed[0] + seed[1]
-    else:
-        init_seed = seed
+    init_seed = _get_init_seed(seed)
     kwargs = {}
     if dtype:
         kwargs["dtype"] = dtype

--- a/keras_cv/backend/random.py
+++ b/keras_cv/backend/random.py
@@ -27,7 +27,7 @@ class SeedGenerator:
         return super().__new__(cls)
 
     def __init__(self, seed=None):
-        self._seed = seed
+        self._initial_seed = seed
         self._current_seed = [0, seed]
 
     def next(self, ordered=True):
@@ -35,7 +35,7 @@ class SeedGenerator:
         return self._current_seed[:]
 
     def get_config(self):
-        return {"seed": self._seed}
+        return {"seed": self._initial_seed}
 
     @classmethod
     def from_config(cls, config):
@@ -48,7 +48,9 @@ def _get_init_seed(seed):
         return seed
     if isinstance(seed, SeedGenerator):
         seed = seed.next()
-        init_seed = seed[0] + seed[1]
+        init_seed = seed[0]
+        if seed[1] is not None:
+            init_seed += seed[1]
     else:
         init_seed = seed
     return init_seed

--- a/keras_cv/backend/random.py
+++ b/keras_cv/backend/random.py
@@ -24,7 +24,7 @@ class SeedGenerator:
     def __new__(cls, seed=None, **kwargs):
         if keras_3():
             return keras.random.SeedGenerator(seed=seed, **kwargs)
-        return super().__new__(cls, seed)
+        return super().__new__(cls)
 
     def __init__(self, seed=None):
         self._seed = seed

--- a/keras_cv/layers/spatial_pyramid.py
+++ b/keras_cv/layers/spatial_pyramid.py
@@ -165,7 +165,9 @@ class SpatialPyramidPooling(keras.layers.Layer):
             result.append(temp)
 
         result[-1] = keras.layers.Resizing(
-            inputs.shape[1], inputs.shape[2], interpolation="bilinear"
+            ops.cast(inputs.shape[1], dtype="int32"),
+            ops.cast(inputs.shape[2], dtype="int32"),
+            interpolation="bilinear",
         )(result[-1])
 
         result = ops.concatenate(result, axis=-1)

--- a/keras_cv/layers/spatial_pyramid.py
+++ b/keras_cv/layers/spatial_pyramid.py
@@ -164,9 +164,11 @@ class SpatialPyramidPooling(keras.layers.Layer):
             temp = ops.cast(channel(inputs, training=training), inputs.dtype)
             result.append(temp)
 
+        image_shape = ops.shape(inputs)
+        height, width = image_shape[1], image_shape[2]
         result[-1] = keras.layers.Resizing(
-            ops.cast(inputs.shape[1], dtype="int32"),
-            ops.cast(inputs.shape[2], dtype="int32"),
+            height,
+            width,
             interpolation="bilinear",
         )(result[-1])
 

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -17,6 +17,7 @@ import tensorflow as tf
 from absl.testing import parameterized
 from tensorflow import keras
 
+from keras_cv.backend import ops
 from keras_cv.losses import FocalLoss
 from keras_cv.tests.test_case import TestCase
 
@@ -70,6 +71,6 @@ class FocalLossModelGardenComparisonTest(TestCase):
             y_true = tf.cast(y_true, tf.float32)
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
-                focal_loss(y_true, tf.sigmoid(y_pred)),
+                ops.convert_to_numpy(focal_loss(y_true, tf.sigmoid(y_pred))),
                 model_garden_focal_loss(y_true, y_pred),
             )

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -72,5 +72,5 @@ class FocalLossModelGardenComparisonTest(TestCase):
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
                 ops.convert_to_numpy(focal_loss(y_true, tf.sigmoid(y_pred))),
-                model_garden_focal_loss(y_true, y_pred),
+                ops.convert_to_numpy(model_garden_focal_loss(y_true, y_pred)),
             )

--- a/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
+++ b/keras_cv/losses/numerical_tests/focal_loss_numerical_test.py
@@ -32,8 +32,8 @@ class ModelGardenFocalLoss(keras.losses.Loss):
 
     def call(self, y_true, y_pred):
         with tf.name_scope("focal_loss"):
-            y_true = tf.cast(y_true, dtype=tf.float32)
-            y_pred = tf.cast(y_pred, dtype=tf.float32)
+            y_true = tf.cast(ops.convert_to_numpy(y_true), dtype=tf.float32)
+            y_pred = tf.cast(ops.convert_to_numpy(y_pred), dtype=tf.float32)
             positive_label_mask = tf.equal(y_true, 1.0)
             cross_entropy = tf.nn.sigmoid_cross_entropy_with_logits(
                 labels=y_true, logits=y_pred
@@ -71,6 +71,6 @@ class FocalLossModelGardenComparisonTest(TestCase):
             y_true = tf.cast(y_true, tf.float32)
             y_pred = tf.random.uniform((200, 10), dtype=tf.float32)
             self.assertAllClose(
-                ops.convert_to_numpy(focal_loss(y_true, tf.sigmoid(y_pred))),
-                ops.convert_to_numpy(model_garden_focal_loss(y_true, y_pred)),
+                focal_loss(y_true, tf.sigmoid(y_pred)),
+                model_garden_focal_loss(y_true, y_pred),
             )

--- a/keras_cv/models/classification/image_classifier_test.py
+++ b/keras_cv/models/classification/image_classifier_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 
 from keras_cv.backend import keras
 from keras_cv.backend import ops
+from keras_cv.backend.config import keras_3
 from keras_cv.models.backbones.resnet_v2.resnet_v2_aliases import (
     ResNet18V2Backbone,
 )
@@ -50,6 +51,9 @@ class ImageClassifierTest(TestCase):
     @pytest.mark.large  # Fit is slow, so mark these large.
     @pytest.mark.filterwarnings("ignore::UserWarning")  # Torch + jit_compile
     def test_classifier_fit(self, jit_compile):
+        if keras_3() and jit_compile and keras.backend.backend() == "torch":
+            self.skipTest("TODO: Torch Backend `jit_compile` fails on GPU.")
+            self.supports_jit = False
         model = ImageClassifier(
             backbone=ResNet18V2Backbone(),
             num_classes=2,

--- a/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_test.py
+++ b/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_test.py
@@ -32,7 +32,7 @@ from keras_cv.tests.test_case import TestCase
 
 class DeepLabV3PlusTest(TestCase):
     def test_deeplab_v3_plus_construction(self):
-        backbone = ResNet18V2Backbone(input_shape=[512, 512, 3])
+        backbone = ResNet18V2Backbone(input_shape=[256, 256, 3])
         model = DeepLabV3Plus(backbone=backbone, num_classes=2)
         model.compile(
             optimizer="adam",
@@ -42,15 +42,15 @@ class DeepLabV3PlusTest(TestCase):
 
     @pytest.mark.large
     def test_deeplab_v3_plus_call(self):
-        backbone = ResNet18V2Backbone(input_shape=[512, 512, 3])
+        backbone = ResNet18V2Backbone(input_shape=[256, 256, 3])
         model = DeepLabV3Plus(backbone=backbone, num_classes=2)
-        images = np.random.uniform(size=(2, 512, 512, 3))
+        images = np.random.uniform(size=(2, 256, 256, 3))
         _ = model(images)
         _ = model.predict(images)
 
     @pytest.mark.large
     def test_weights_change(self):
-        target_size = [512, 512, 3]
+        target_size = [256, 256, 3]
 
         images = np.ones([1] + target_size)
         labels = np.random.uniform(size=[1] + target_size)
@@ -80,16 +80,16 @@ class DeepLabV3PlusTest(TestCase):
         model = DeepLabV3Plus.from_preset(
             "deeplab_v3_plus_resnet50_pascalvoc",
             num_classes=21,
-            input_shape=[512, 512, 3],
+            input_shape=[256, 256, 3],
         )
-        image = np.ones((1, 512, 512, 3))
+        image = np.ones((1, 256, 256, 3))
         output = ops.expand_dims(ops.argmax(model(image), axis=-1), axis=-1)
-        expected_output = np.zeros((1, 512, 512, 1))
+        expected_output = np.zeros((1, 256, 256, 1))
         self.assertAllClose(output, expected_output)
 
     @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self):
-        target_size = [512, 512, 3]
+        target_size = [256, 256, 3]
 
         backbone = ResNet18V2Backbone(input_shape=target_size)
         model = DeepLabV3Plus(backbone=backbone, num_classes=2)


### PR DESCRIPTION
* Changes SeedGenerator to be a pass-through for Keras 3. (Fixes Jax Tests)
* Copies DeepLap Test Fix from #2232 - Fixes for Keras 2
* Changes Tensors to Numpy for fixing PyTorch Tests
* Disables `jit_compile` test due to failure in PyTorch with GPU.
