### PR TITLE
Modify layer checkpoint dependencies to empty list

### DIFF
--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -216,6 +216,6 @@ def legacy_load_weights(layer, weights_path):
         if cls.__name__ == "Functional":
             functional_cls = cls
     property = functional_cls._layer_checkpoint_dependencies
-    functional_cls._layer_checkpoint_dependencies = None
+    functional_cls._layer_checkpoint_dependencies = []
     layer.load_weights(weights_path)
     functional_cls._layer_checkpoint_dependencies = property


### PR DESCRIPTION
This duplicates the fix done in KerasNLP for layer_checkpoint_dependencies: https://github.com/keras-team/keras-nlp/pull/1368