### PR TITLE
Align keras requirments fo torch

### DIFF
--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,5 +1,4 @@
 # Tensorflow with cuda support.
---extra-index-url https://pypi.nvidia.com
 tf-nightly[and-cuda]==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch cpu-only version.

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -2,9 +2,9 @@
 tf-nightly-cpu==2.16.0.dev20231221  # Pin a working nightly until rc0.
 
 # Torch with cuda support.
---extra-index-url https://download.pytorch.org/whl/cu118
-torch==2.1.2+cu118
-torchvision==0.16.2+cu118
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.1.2
+torchvision==0.16.2
 
 # Jax cpu-only version.
 jax[cpu]


### PR DESCRIPTION
* Use Cuda 12.1 for Torch to align with TF and Jax. Also, aligns torch install with that of Colab that uses torch+cu121 packages.
* Remove extra-url for TensorFlow as its no longer required.

Align with Keras and Keras-NLP