### PR TITLE
Backwards compatibility fixes for Keras <=2.15

### DIFF
--- a/keras_cv/models/backbones/backbone.py
+++ b/keras_cv/models/backbones/backbone.py
@@ -32,6 +32,20 @@ class Backbone(keras.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._pyramid_level_inputs = {}
+        self._functional_layer_ids = set(
+            id(layer) for layer in self._flatten_layers()
+        )
+
+    def __dir__(self):
+        # Temporary fixes for weight saving. This mimics the following PR for
+        # older version of Keras: https://github.com/keras-team/keras/pull/18982
+        def filter_fn(attr):
+            try:
+                return id(getattr(self, attr)) not in self._functional_layer_ids
+            except:
+                return True
+
+        return filter(filter_fn, super().__dir__())
 
     def get_config(self):
         # Don't chain to super here. The default `get_config()` for functional

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_presets.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_backbone_presets.py
@@ -26,7 +26,7 @@ backbone_presets_no_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_tiny/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_tiny/2",
     },
     "csp_darknet_s": {
         "metadata": {
@@ -39,7 +39,7 @@ backbone_presets_no_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_s/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_s/2",
     },
     "csp_darknet_m": {
         "metadata": {
@@ -52,7 +52,7 @@ backbone_presets_no_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_m/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_m/2",
     },
     "csp_darknet_l": {
         "metadata": {
@@ -65,7 +65,7 @@ backbone_presets_no_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_l/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_l/2",
     },
     "csp_darknet_xl": {
         "metadata": {
@@ -78,7 +78,7 @@ backbone_presets_no_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_xl/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_xl/2",
     },
 }
 
@@ -95,7 +95,7 @@ backbone_presets_with_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_tiny_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_tiny_imagenet/2",  # noqa: E501
     },
     "csp_darknet_l_imagenet": {
         "metadata": {
@@ -109,7 +109,7 @@ backbone_presets_with_weights = {
             "official_name": "CSPDarkNet",
             "path": "csp_darknet",
         },
-        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_l_imagenet/1",
+        "kaggle_handle": "kaggle://keras/cspdarknet/csp_darknet_l_imagenet/2",
     },
 }
 

--- a/keras_cv/models/backbones/densenet/densenet_backbone_presets.py
+++ b/keras_cv/models/backbones/densenet/densenet_backbone_presets.py
@@ -18,19 +18,19 @@ backbone_presets_no_weights = {
         "metadata": {
             "description": "DenseNet model with 121 layers.",
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet121/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet121/2",
     },
     "densenet169": {
         "metadata": {
             "description": "DenseNet model with 169 layers.",
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet169/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet169/2",
     },
     "densenet201": {
         "metadata": {
             "description": "DenseNet model with 201 layers.",
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet201/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet201/2",
     },
 }
 
@@ -42,7 +42,7 @@ backbone_presets_with_weights = {
                 "classification task."
             ),
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet121_imagenet/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet121_imagenet/2",
     },
     "densenet169_imagenet": {
         "metadata": {
@@ -51,7 +51,7 @@ backbone_presets_with_weights = {
                 "classification task."
             ),
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet169_imagenet/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet169_imagenet/2",
     },
     "densenet201_imagenet": {
         "metadata": {
@@ -60,7 +60,7 @@ backbone_presets_with_weights = {
                 "classification task."
             ),
         },
-        "kaggle_handle": "kaggle://keras/densenet/densenet201_imagenet/1",
+        "kaggle_handle": "kaggle://keras/densenet/densenet201_imagenet/2",
     },
 }
 

--- a/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets.py
+++ b/keras_cv/models/backbones/efficientnet_v2/efficientnet_v2_backbone_presets.py
@@ -24,7 +24,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s/2",
     },
     "efficientnetv2_m": {
         "metadata": {
@@ -35,7 +35,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_m/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_m/2",
     },
     "efficientnetv2_l": {
         "metadata": {
@@ -47,7 +47,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_l/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_l/2",
     },
     "efficientnetv2_b0": {
         "metadata": {
@@ -60,7 +60,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0/2",
     },
     "efficientnetv2_b1": {
         "metadata": {
@@ -73,7 +73,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1/2",
     },
     "efficientnetv2_b2": {
         "metadata": {
@@ -86,7 +86,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2/2",
     },
     "efficientnetv2_b3": {
         "metadata": {
@@ -99,7 +99,7 @@ backbone_presets_no_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b3/1",
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b3/2",
     },
 }
 
@@ -117,7 +117,7 @@ backbone_presets_with_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s_imagenet/2",  # noqa: E501
     },
     "efficientnetv2_b0_imagenet": {
         "metadata": {
@@ -134,7 +134,7 @@ backbone_presets_with_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0_imagenet/2",  # noqa: E501
     },
     "efficientnetv2_b1_imagenet": {
         "metadata": {
@@ -151,7 +151,7 @@ backbone_presets_with_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1_imagenet/2",  # noqa: E501
     },
     "efficientnetv2_b2_imagenet": {
         "metadata": {
@@ -168,7 +168,7 @@ backbone_presets_with_weights = {
             "official_name": "EfficientNetV2",
             "path": "efficientnetv2",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2_imagenet/2",  # noqa: E501
     },
 }
 

--- a/keras_cv/models/backbones/mix_transformer/mix_transformer_backbone_presets.py
+++ b/keras_cv/models/backbones/mix_transformer/mix_transformer_backbone_presets.py
@@ -23,7 +23,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b0/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b0/2",
     },
     "mit_b1": {
         "metadata": {
@@ -34,7 +34,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b1/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b1/2",
     },
     "mit_b2": {
         "metadata": {
@@ -45,7 +45,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b2/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b2/2",
     },
     "mit_b3": {
         "metadata": {
@@ -56,7 +56,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b3/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b3/2",
     },
     "mit_b4": {
         "metadata": {
@@ -67,7 +67,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b4/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b4/2",
     },
     "mit_b5": {
         "metadata": {
@@ -78,7 +78,7 @@ backbone_presets_no_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b5/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b5/2",
     },
 }
 
@@ -92,7 +92,7 @@ backbone_presets_with_weights = {
             "official_name": "MiT",
             "path": "mit",
         },
-        "kaggle_handle": "kaggle://keras/mit/mit_b0_imagenet/1",
+        "kaggle_handle": "kaggle://keras/mit/mit_b0_imagenet/2",
     },
 }
 

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_presets.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone_presets.py
@@ -25,7 +25,7 @@ backbone_presets_no_weights = {
             "official_name": "MobileNetV3",
             "path": "mobilenetv3",
         },
-        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_small/1",
+        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_small/2",
     },
     "mobilenet_v3_large": {
         "metadata": {
@@ -38,7 +38,7 @@ backbone_presets_no_weights = {
             "official_name": "MobileNetV3",
             "path": "mobilenetv3",
         },
-        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large/1",
+        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large/2",
     },
 }
 
@@ -55,7 +55,7 @@ backbone_presets_with_weights = {
             "official_name": "MobileNetV3",
             "path": "mobilenetv3",
         },
-        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large_imagenet/2",  # noqa: E501
     },
     "mobilenet_v3_small_imagenet": {
         "metadata": {
@@ -69,7 +69,7 @@ backbone_presets_with_weights = {
             "official_name": "MobileNetV3",
             "path": "mobilenetv3",
         },
-        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_small_imagenet/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_small_imagenet/2",  # noqa: E501
     },
 }
 

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_backbone_presets.py
@@ -25,7 +25,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet18/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet18/2",
     },
     "resnet34": {
         "metadata": {
@@ -38,7 +38,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet34/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet34/2",
     },
     "resnet50": {
         "metadata": {
@@ -51,7 +51,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet50/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet50/2",
     },
     "resnet101": {
         "metadata": {
@@ -64,7 +64,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet101/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet101/2",
     },
     "resnet152": {
         "metadata": {
@@ -77,7 +77,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet152/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet152/2",
     },
 }
 
@@ -94,7 +94,7 @@ backbone_presets_with_weights = {
             "official_name": "ResNetV1",
             "path": "resnet_v1",
         },
-        "kaggle_handle": "kaggle://keras/resnetv1/resnet50_imagenet/1",
+        "kaggle_handle": "kaggle://keras/resnetv1/resnet50_imagenet/2",
     },
 }
 

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_backbone_presets.py
@@ -24,7 +24,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet18_v2/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet18_v2/2",
     },
     "resnet34_v2": {
         "metadata": {
@@ -36,7 +36,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet34_v2/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet34_v2/2",
     },
     "resnet50_v2": {
         "metadata": {
@@ -48,7 +48,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2/2",
     },
     "resnet101_v2": {
         "metadata": {
@@ -60,7 +60,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet101_v2/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet101_v2/2",
     },
     "resnet152_v2": {
         "metadata": {
@@ -72,7 +72,7 @@ backbone_presets_no_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet152_v2/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet152_v2/2",
     },
 }
 
@@ -88,7 +88,7 @@ backbone_presets_with_weights = {
             "official_name": "ResNetV2",
             "path": "resnet_v2",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2_imagenet/1",
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2_imagenet/2",
     },
 }
 

--- a/keras_cv/models/backbones/vit_det/vit_det_backbone_presets.py
+++ b/keras_cv/models/backbones/vit_det/vit_det_backbone_presets.py
@@ -26,7 +26,7 @@ backbone_presets_no_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_base/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_base/2",
     },
     "vitdet_large": {
         "metadata": {
@@ -40,7 +40,7 @@ backbone_presets_no_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_large/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_large/2",
     },
     "vitdet_huge": {
         "metadata": {
@@ -54,7 +54,7 @@ backbone_presets_no_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_huge/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_huge/2",
     },
 }
 
@@ -69,7 +69,7 @@ backbone_presets_with_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_base_sa1b/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_base_sa1b/2",
     },
     "vitdet_large_sa1b": {
         "metadata": {
@@ -80,7 +80,7 @@ backbone_presets_with_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_large_sa1b/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_large_sa1b/2",
     },
     "vitdet_huge_sa1b": {
         "metadata": {
@@ -91,7 +91,7 @@ backbone_presets_with_weights = {
             "official_name": "VitDet",
             "path": "vit_det",
         },
-        "kaggle_handle": "kaggle://keras/vitdet/vitdet_huge_sa1b/1",
+        "kaggle_handle": "kaggle://keras/vitdet/vitdet_huge_sa1b/2",
     },
 }
 

--- a/keras_cv/models/classification/image_classifier_presets.py
+++ b/keras_cv/models/classification/image_classifier_presets.py
@@ -27,7 +27,7 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/resnetv2/resnet50_v2_imagenet_classifier/2",  # noqa: E501
     },
     "efficientnetv2_s_imagenet_classifier": {
         "metadata": {
@@ -44,7 +44,7 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_s_imagenet_classifier/2",  # noqa: E501
     },
     "efficientnetv2_b0_imagenet_classifier": {
         "metadata": {
@@ -64,7 +64,7 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b0_imagenet_classifier/2",  # noqa: E501
     },
     "efficientnetv2_b1_imagenet_classifier": {
         "metadata": {
@@ -84,7 +84,7 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b1_imagenet_classifier/2",  # noqa: E501
     },
     "efficientnetv2_b2_imagenet_classifier": {
         "metadata": {
@@ -104,7 +104,7 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/efficientnetv2/efficientnetv2_b2_imagenet_classifier/2",  # noqa: E501
     },
     "mobilenet_v3_large_imagenet_classifier": {
         "metadata": {
@@ -121,6 +121,6 @@ classifier_presets = {
             "official_name": "ImageClassifier",
             "path": "image_classifier",
         },
-        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large_imagenet_classifier/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/mobilenetv3/mobilenet_v3_large_imagenet_classifier/2",  # noqa: E501
     },
 }

--- a/keras_cv/models/object_detection/retinanet/retinanet_label_encoder.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_label_encoder.py
@@ -68,7 +68,7 @@ class RetinaNetLabelEncoder(keras.layers.Layer):
         self.box_variance = ops.array(box_variance, "float32")
         self.background_class = background_class
         self.ignore_class = ignore_class
-        self.matched_boxes_metric = keras.metrics.BinaryAccuracy(
+        self.matched_boxes_metric = MatchedBoxesMetric(
             name="percent_boxes_matched_with_anchor"
         )
         self.positive_threshold = positive_threshold
@@ -244,3 +244,9 @@ class RetinaNetLabelEncoder(keras.layers.Layer):
             )
 
         return super().from_config(config)
+
+
+class MatchedBoxesMetric(keras.metrics.BinaryAccuracy):
+    # Prevent `load_weights` from accessing metric
+    def load_own_variables(self, store):
+        return

--- a/keras_cv/models/object_detection/retinanet/retinanet_presets.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet_presets.py
@@ -26,6 +26,6 @@ retinanet_presets = {
             "official_name": "RetinaNet",
             "path": "retinanet",
         },
-        "kaggle_handle": "kaggle://keras/retinanet/retinanet_resnet50_pascalvoc/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/retinanet/retinanet_resnet50_pascalvoc/2",  # noqa: E501
     },
 }

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone_presets.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_backbone_presets.py
@@ -22,7 +22,7 @@ backbone_presets_no_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xs_backbone/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xs_backbone/2",
     },
     "yolo_v8_s_backbone": {
         "metadata": {
@@ -31,7 +31,7 @@ backbone_presets_no_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_s_backbone/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_s_backbone/2",
     },
     "yolo_v8_m_backbone": {
         "metadata": {
@@ -40,7 +40,7 @@ backbone_presets_no_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_backbone/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_backbone/2",
     },
     "yolo_v8_l_backbone": {
         "metadata": {
@@ -49,7 +49,7 @@ backbone_presets_no_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_l_backbone/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_l_backbone/2",
     },
     "yolo_v8_xl_backbone": {
         "metadata": {
@@ -58,7 +58,7 @@ backbone_presets_no_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xl_backbone/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xl_backbone/2",
     },
 }
 
@@ -72,7 +72,7 @@ backbone_presets_with_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xs_backbone_coco/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xs_backbone_coco/2",
     },
     "yolo_v8_s_backbone_coco": {
         "metadata": {
@@ -81,7 +81,7 @@ backbone_presets_with_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_s_backbone_coco/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_s_backbone_coco/2",
     },
     "yolo_v8_m_backbone_coco": {
         "metadata": {
@@ -90,7 +90,7 @@ backbone_presets_with_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_backbone_coco/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_backbone_coco/2",
     },
     "yolo_v8_l_backbone_coco": {
         "metadata": {
@@ -99,7 +99,7 @@ backbone_presets_with_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_l_backbone_coco/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_l_backbone_coco/2",
     },
     "yolo_v8_xl_backbone_coco": {
         "metadata": {
@@ -110,7 +110,7 @@ backbone_presets_with_weights = {
             "official_name": "YOLOV8",
             "path": "yolo_v8",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xl_backbone_coco/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_xl_backbone_coco/2",
     },
 }
 

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector_presets.py
@@ -25,6 +25,6 @@ yolo_v8_detector_presets = {
             "official_name": "YOLOV8Detector",
             "path": "yolo_v8_detector",
         },
-        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_pascalvoc/1",
+        "kaggle_handle": "kaggle://keras/yolov8/yolo_v8_m_pascalvoc/2",
     },
 }

--- a/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_presets.py
+++ b/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_presets.py
@@ -29,6 +29,6 @@ deeplab_v3_plus_presets = {
             "official_name": "DeepLabV3Plus",
             "path": "deeplab_v3_plus",
         },
-        "kaggle_handle": "kaggle://keras/deeplabv3plus/deeplab_v3_plus_resnet50_pascalvoc/1",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/deeplabv3plus/deeplab_v3_plus_resnet50_pascalvoc/2",  # noqa: E501
     },
 }

--- a/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_presets.py
+++ b/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus_presets.py
@@ -29,6 +29,6 @@ deeplab_v3_plus_presets = {
             "official_name": "DeepLabV3Plus",
             "path": "deeplab_v3_plus",
         },
-        "kaggle_handle": "kaggle://keras/deeplabv3plus/deeplab_v3_plus_resnet50_pascalvoc/2",  # noqa: E501
+        "kaggle_handle": "kaggle://keras/deeplabv3plus/deeplab_v3_plus_resnet50_pascalvoc/1",  # noqa: E501
     },
 }

--- a/keras_cv/models/segmentation/segformer/segformer_presets.py
+++ b/keras_cv/models/segmentation/segformer/segformer_presets.py
@@ -25,7 +25,7 @@ presets_no_weights = {
             "official_name": "SegFormerB0",
             "path": "segformer_b0",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b0/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b0/2",
     },
     "segformer_b1": {
         "metadata": {
@@ -34,7 +34,7 @@ presets_no_weights = {
             "official_name": "SegFormerB1",
             "path": "segformer_b1",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b1/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b1/2",
     },
     "segformer_b2": {
         "metadata": {
@@ -43,7 +43,7 @@ presets_no_weights = {
             "official_name": "SegFormerB2",
             "path": "segformer_b2",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b2/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b2/2",
     },
     "segformer_b3": {
         "metadata": {
@@ -52,7 +52,7 @@ presets_no_weights = {
             "official_name": "SegFormerB3",
             "path": "segformer_b3",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b3/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b3/2",
     },
     "segformer_b4": {
         "metadata": {
@@ -61,7 +61,7 @@ presets_no_weights = {
             "official_name": "SegFormerB4",
             "path": "segformer_b4",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b4/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b4/2",
     },
     "segformer_b5": {
         "metadata": {
@@ -70,7 +70,7 @@ presets_no_weights = {
             "official_name": "SegFormerB5",
             "path": "segformer_b5",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b5/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b5/2",
     },
 }
 
@@ -84,7 +84,7 @@ presets_with_weights = {
             "official_name": "SegFormerB0",
             "path": "segformer_b0",
         },
-        "kaggle_handle": "kaggle://keras/segformer/segformer_b0_imagenet/1",
+        "kaggle_handle": "kaggle://keras/segformer/segformer_b0_imagenet/2",
     },
 }
 

--- a/keras_cv/models/segmentation/segment_anything/sam_presets.py
+++ b/keras_cv/models/segmentation/segment_anything/sam_presets.py
@@ -22,7 +22,7 @@ sam_presets = {
             "official_name": "SAM",
             "path": "segment_anything",
         },
-        "kaggle_handle": "kaggle://keras/sam/sam_base_sa1b/1",
+        "kaggle_handle": "kaggle://keras/sam/sam_base_sa1b/2",
     },
     "sam_large_sa1b": {
         "metadata": {
@@ -31,7 +31,7 @@ sam_presets = {
             "official_name": "SAM",
             "path": "segment_anything",
         },
-        "kaggle_handle": "kaggle://keras/sam/sam_large_sa1b/1",
+        "kaggle_handle": "kaggle://keras/sam/sam_large_sa1b/2",
     },
     "sam_huge_sa1b": {
         "metadata": {
@@ -40,6 +40,6 @@ sam_presets = {
             "official_name": "SAM",
             "path": "segment_anything",
         },
-        "kaggle_handle": "kaggle://keras/sam/sam_huge_sa1b/1",
+        "kaggle_handle": "kaggle://keras/sam/sam_huge_sa1b/2",
     },
 }

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -29,6 +29,22 @@ class Task(keras.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._backbone = None
+        self._functional_layer_ids = set(
+            id(layer) for layer in self._flatten_layers()
+        )
+
+    def __dir__(self):
+        # Temporary fixes for weight saving. This mimics the following PR for
+        # older version of Keras: https://github.com/keras-team/keras/pull/18982
+        def filter_fn(attr):
+            if attr in ["backbone", "_backbone"]:
+                return False
+            try:
+                return id(getattr(self, attr)) not in self._functional_layer_ids
+            except:
+                return True
+
+        return filter(filter_fn, super().__dir__())
 
     @property
     def backbone(self):

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -44,7 +44,7 @@ def get_file(preset, path):
         # Insert the kaggle framework into the handle.
         if len(segments) == 3:
             org, model, variant = segments
-            kaggle_handle = f"{org}/{model}/keras/{variant}/1"
+            kaggle_handle = f"{org}/{model}/keras/{variant}/2"
         elif len(segments) == 4:
             org, model, variant, version = segments
             kaggle_handle = f"{org}/{model}/keras/{variant}/{version}"

--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -165,6 +165,11 @@ def load_from_preset(
     # Default to loading weights if available.
     if load_weights is not False and config["weights"] is not None:
         weights_path = get_file(preset, config["weights"])
+        import h5py
+
+        f = h5py.File(weights_path)
+        f.visititems(lambda name, _: print(name))
+
         if hasattr(layer, "_layer_checkpoint_dependencies"):
             legacy_load_weights(layer, weights_path)
         else:


### PR DESCRIPTION
This PR adds backwards compatibility fixes for issues with weights reloading in Keras 2.15 and bumps version numbers of presets to pull from the new compatible weights (after Keras saving fixes).
