### PR TITLE
Remove weight traversal output

### DIFF
--- a/keras_cv/utils/preset_utils.py
+++ b/keras_cv/utils/preset_utils.py
@@ -165,11 +165,6 @@ def load_from_preset(
     # Default to loading weights if available.
     if load_weights is not False and config["weights"] is not None:
         weights_path = get_file(preset, config["weights"])
-        import h5py
-
-        f = h5py.File(weights_path)
-        f.visititems(lambda name, _: print(name))
-
         if hasattr(layer, "_layer_checkpoint_dependencies"):
             legacy_load_weights(layer, weights_path)
         else:


### PR DESCRIPTION
Accidentally left in a weight traversal output while debugging.