### PR TITLE
Fix base image aug layer for non-TF backend in `tf.data` pipeline.

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer_test.py
@@ -265,3 +265,11 @@ class BaseImageAugmentationLayerTest(TestCase):
         self.assertNotAllClose(
             segmentation_mask_diff[0], segmentation_mask_diff[1]
         )
+
+    def test_augment_tf_data_pipeline(self):
+        image = np.random.random(size=(1, 8, 8, 3)).astype("float32")
+        tf_dataset = tf.data.Dataset.from_tensor_slices(image).map(
+            RandomAddLayer(fixed_value=2.0)
+        )
+        output = iter(tf_dataset).get_next()
+        self.assertAllClose(image[0] + 2.0, output)


### PR DESCRIPTION
When we have Image Aug Layers in JAX or Torch backend used in `tf.data` pipeline, the `ops.convert_to_tensor` breaks since it cannot convert a TF Symbolic tensor in the graph.  This fix only does the conversion when its not part of a TF graph.  Also, the conversion steps are skipped for TF backend since its not necessary.

Added unit test to verfy the failing under `tf.data` pipeline.