### PR TITLE
Fix image.shape type

### DIFF
--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -172,7 +172,7 @@ class AnchorGenerator(keras.layers.Layer):
                     "Expected `image` to be a Tensor of rank 3. Got "
                     f"image.shape.rank={len(image.shape)}"
                 )
-            image_shape = image.shape
+            image_shape = tuple(image.shape)
 
         results = {}
         for key, generator in self.anchor_generators.items():


### PR DESCRIPTION
Fixed the image.shape type when the image is passed as an argument in the AnchorGenerator class using Keras ops for Tensorflow backend.

`type(img.shape)` for tensorflow backend is `tensorflow.python.framework.tensor_shape.TensorShape` which fails in the code [here](https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box/converters.py#L478) when checking the instance with tuple or list.
For `toch` type is  `torch.size` and for `jax` type is `tuple` which will pass the above condition.
Fixes: https://github.com/keras-team/keras-cv/issues/2302