### PR TITLE
Pin Jax Version in GPU CI

### DIFF
--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -7,7 +7,8 @@ torch>=2.1.0
 torchvision>=0.16.0
 
 # Jax with cuda support.
+# TODO: 0.4.24 has an updated Cuda version breaks Jax CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]
+jax[cuda12_pip]==0.4.23
 
 -r requirements-common.txt


### PR DESCRIPTION
JAX 0.4.24 updated the Cuda version and broke the GPU CI.  So we are pinning the JAX Version for GPU tests similar to what's done in Keras and Keras-NLP Repos.