### PR TITLE
Revert back to JAX 0.4.23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
       python:
         patterns:
           - "*"
+    ignore:
+        # TODO: ignore all updates for JAX GPU due to cuda version issue
+      - dependency-name: "jax[cuda12_pip]"

--- a/keras_cv/conftest.py
+++ b/keras_cv/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import keras_core
 import pytest
 import tensorflow as tf
 from packaging import version
@@ -101,7 +100,7 @@ def pytest_collection_modifyitems(config, items):
         reason="This test is only supported on Keras 2",
     )
     skip_tf_only = pytest.mark.skipif(
-        keras_3() and keras_core.backend.backend() != "tensorflow",
+        keras_3() and backend_config.backend() != "tensorflow",
         reason="This test is only supported on TensorFlow",
     )
     for item in items:

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -9,6 +9,6 @@ torchvision>=0.16.0
 # Jax with cuda support.
 # TODO: 0.4.24 has an updated Cuda version breaks Jax CI.
 --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]==0.4.24
+jax[cuda12_pip]==0.4.23
 
 -r requirements-common.txt


### PR DESCRIPTION
* Dependabot updated JAX, but we have to keep it pinned to 0.4.23 due to Cuda compatibility.
* Remove `keras_core` from conftest.py and use `config.backend` to check for TensorFlow.