### PR TITLE
Fixed ROI Pooling Output Shape to Consider Multiple ROIs (#2350)

### DIFF
--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -112,11 +112,12 @@ class ROIPooler(keras.layers.Layer):
           feature_map: [H, W, C] float Tensor
           rois: [N, 4] float Tensor
         Returns:
-          pooled_feature_map: [target_size, C] float Tensor
+          pooled_feature_map: [N, target_height, target_width, C] float Tensor
         """
         feature_map, rois = args
         num_rois = rois.get_shape().as_list()[0]
         height, width, channel = feature_map.get_shape().as_list()
+        regions = []
         # TODO (consider vectorize it for better performance)
         for n in range(num_rois):
             # [4]
@@ -127,7 +128,7 @@ class ROIPooler(keras.layers.Layer):
             region_width = width * (roi[3] - roi[1])
             h_step = region_height / self.target_height
             w_step = region_width / self.target_width
-            regions = []
+            region_steps = []
             for i in range(self.target_height):
                 for j in range(self.target_width):
                     height_start = y_start + i * h_step
@@ -147,16 +148,16 @@ class ROIPooler(keras.layers.Layer):
                         1, width_end - width_start
                     )
                     # [h_step, w_step, C]
-                    region = feature_map[
+                    region_step = feature_map[
                         height_start:height_end, width_start:width_end, :
                     ]
                     # target_height * target_width * [C]
-                    regions.append(tf.reduce_max(region, axis=[0, 1]))
-            regions = tf.reshape(
-                tf.stack(regions),
+                    region_steps.append(tf.reduce_max(region_step, axis=[0, 1]))
+            regions.append(tf.reshape(
+                tf.stack(region_steps),
                 [self.target_height, self.target_width, channel],
-            )
-            return regions
+            ))
+        return tf.stack(regions)
 
     def get_config(self):
         config = {

--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -153,10 +153,12 @@ class ROIPooler(keras.layers.Layer):
                     ]
                     # target_height * target_width * [C]
                     region_steps.append(tf.reduce_max(region_step, axis=[0, 1]))
-            regions.append(tf.reshape(
-                tf.stack(region_steps),
-                [self.target_height, self.target_width, channel],
-            ))
+            regions.append(
+                tf.reshape(
+                    tf.stack(region_steps),
+                    [self.target_height, self.target_width, channel],
+                )
+            )
         return tf.stack(regions)
 
     def get_config(self):

--- a/keras_cv/layers/object_detection/roi_pool_test.py
+++ b/keras_cv/layers/object_detection/roi_pool_test.py
@@ -168,7 +168,8 @@ class ROIPoolTest(TestCase):
         # ------------------repeated----------------------
         # | 12, 13(max) | 14, 15(max)   |
         expected_feature_map = tf.reshape(
-            tf.constant([1, 3, 1, 3, 5, 7, 9, 11, 9, 11, 13, 15]), [1, 1, 6, 2, 1]
+            tf.constant([1, 3, 1, 3, 5, 7, 9, 11, 9, 11, 13, 15]),
+            [1, 1, 6, 2, 1],
         )
         self.assertAllClose(expected_feature_map, pooled_feature_map)
 
@@ -212,15 +213,17 @@ class ROIPoolTest(TestCase):
             )
 
     def test_multiple_rois(self):
-        feature_map = tf.expand_dims(tf.reshape(tf.range(0, 64), [8, 8, 1]), axis=0)
+        feature_map = tf.expand_dims(
+            tf.reshape(tf.range(0, 64), [8, 8, 1]), axis=0
+        )
 
         roi_pooler = ROIPooler(
-            bounding_box_format="yxyx", target_size=[2, 2], image_shape=[224, 224, 3]
+            bounding_box_format="yxyx",
+            target_size=[2, 2],
+            image_shape=[224, 224, 3],
         )
         rois = tf.constant(
-            [
-                [[0.0, 0.0, 112.0, 112.0], [0.0, 112.0, 224.0, 224.0]]
-            ],
+            [[[0.0, 0.0, 112.0, 112.0], [0.0, 112.0, 224.0, 224.0]]],
         )
 
         pooled_feature_map = roi_pooler(feature_map, rois)


### PR DESCRIPTION
# What does this PR do?
Keras ROI Pooling was not including multiple ROIs in the output. Instead, only the first ROI was included. Documentation for underlying function that created per-feature-map ROI Pools was similarly incorrect. Thus, I also corrected the documentation for `_pool_single_sample` to match the expectations provided in `ROIPooler.call`.

Corresponding test cases were updated to reflect the update and a new test was added to test this specific situation.

Fixes #2350.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case. (#2350)
- [x] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.