### PR TITLE
bug fix for num_steps=1

### DIFF
--- a/keras_cv/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion.py
@@ -210,7 +210,11 @@ class StableDiffusionBase:
 
         # Iterative reverse diffusion stage
         num_timesteps = 1000
-        ratio = (num_timesteps - 1) / (num_steps - 1)
+        ratio = (
+            (num_timesteps - 1) / (num_steps - 1)
+            if num_steps > 1
+            else num_timesteps
+        )
         timesteps = (np.arange(0, num_steps) * ratio).round().astype(np.int64)
 
         alphas, alphas_prev = self._get_initial_alphas(timesteps)

--- a/keras_cv/models/stable_diffusion/stable_diffusion_test.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion_test.py
@@ -73,6 +73,14 @@ class StableDiffusionTest(TestCase):
         )
 
     @pytest.mark.extra_large
+    def test_num_steps_equal_to_one_no_error(self):
+        stablediff = StableDiffusion(128, 128)
+        _ = stablediff.generate_image(
+            stablediff.encode_text("thou shall not render"),
+            num_steps=1,
+        )
+
+    @pytest.mark.extra_large
     def test_mixed_precision(self):
         try:
             mixed_precision.set_global_policy("mixed_float16")


### PR DESCRIPTION
StableDiffusion would raise an error because divided by zero when `num_steps=1`.
This PR fixes the bug.