### PR TITLE
Fix the SAM end-to-end model predict test

### DIFF
--- a/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
+++ b/keras_cv/layers/preprocessing/base_image_augmentation_layer.py
@@ -16,11 +16,6 @@ import keras
 import tensorflow as tf
 import tree
 
-if hasattr(keras, "src"):
-    keras_backend = keras.src.backend
-else:
-    keras_backend = keras.backend
-
 from keras_cv import bounding_box
 from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import config


### PR DESCRIPTION
Fixes some of the failures seen in https://github.com/keras-team/keras-cv/actions/runs/8259807616/job/22594330565?pr=2383

One of the tests in SAM changed the global dtype policy. Until now, if the test failed, the policy was never reset due to which other unrelated tests failed. This PR should fix this issue and reduce the failure count on [this ci run](https://github.com/keras-team/keras-cv/actions/runs/8259807616/job/22594330565?pr=2383).