### PR TITLE
Export Model APIs

### DIFF
--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_aliases.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_aliases.py
@@ -52,7 +52,7 @@ ALIAS_DOCSTRING = """CSPDarkNetBackbone model with {stackwise_channels} channels
 """  # noqa: E501
 
 
-@keras_cv_export("keras_cv.losses.CSPDarkNetTinyBackbone")
+@keras_cv_export("keras_cv.models.CSPDarkNetTinyBackbone")
 class CSPDarkNetTinyBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,
@@ -87,7 +87,7 @@ class CSPDarkNetTinyBackbone(CSPDarkNetBackbone):
         return cls.presets
 
 
-@keras_cv_export("keras_cv.losses.CSPDarkNetSBackbone")
+@keras_cv_export("keras_cv.models.CSPDarkNetSBackbone")
 class CSPDarkNetSBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,
@@ -118,7 +118,7 @@ class CSPDarkNetSBackbone(CSPDarkNetBackbone):
         return {}
 
 
-@keras_cv_export("keras_cv.losses.CSPDarkNetMBackbone")
+@keras_cv_export("keras_cv.models.CSPDarkNetMBackbone")
 class CSPDarkNetMBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,
@@ -149,7 +149,7 @@ class CSPDarkNetMBackbone(CSPDarkNetBackbone):
         return {}
 
 
-@keras_cv_export("keras_cv.losses.CSPDarkNetLBackbone")
+@keras_cv_export("keras_cv.models.CSPDarkNetLBackbone")
 class CSPDarkNetLBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,
@@ -184,7 +184,7 @@ class CSPDarkNetLBackbone(CSPDarkNetBackbone):
         return cls.presets
 
 
-@keras_cv_export("keras_cv.losses.CSPDarkNetXLBackbone")
+@keras_cv_export("keras_cv.models.CSPDarkNetXLBackbone")
 class CSPDarkNetXLBackbone(CSPDarkNetBackbone):
     def __new__(
         cls,

--- a/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_aliases.py
+++ b/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_aliases.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models.backbones.efficientnet_lite.efficientnet_lite_backbone import (  # noqa: E501
     EfficientNetLiteBackbone,
 )
@@ -41,6 +42,7 @@ ALIAS_DOCSTRING = """Instantiates the {name} architecture.
 """  # noqa: E501
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB0Backbone")
 class EfficientNetLiteB0Backbone(EfficientNetLiteBackbone):
     def __new__(
         cls,
@@ -73,6 +75,7 @@ class EfficientNetLiteB0Backbone(EfficientNetLiteBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB1Backbone")
 class EfficientNetLiteB1Backbone(EfficientNetLiteBackbone):
     def __new__(
         cls,
@@ -105,6 +108,7 @@ class EfficientNetLiteB1Backbone(EfficientNetLiteBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB2Backbone")
 class EfficientNetLiteB2Backbone(EfficientNetLiteBackbone):
     def __new__(
         cls,
@@ -137,6 +141,7 @@ class EfficientNetLiteB2Backbone(EfficientNetLiteBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB3Backbone")
 class EfficientNetLiteB3Backbone(EfficientNetLiteBackbone):
     def __new__(
         cls,
@@ -169,6 +174,7 @@ class EfficientNetLiteB3Backbone(EfficientNetLiteBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB4Backbone")
 class EfficientNetLiteB4Backbone(EfficientNetLiteBackbone):
     def __new__(
         cls,

--- a/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_backbone.py
@@ -24,6 +24,7 @@ Reference:
 import copy
 import math
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
@@ -35,6 +36,7 @@ from keras_cv.utils.python_utils import classproperty
 BN_AXIS = 3
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteBackbone")
 @keras.saving.register_keras_serializable(package="keras_cv.models")
 class EfficientNetLiteBackbone(Backbone):
     """Instantiates the EfficientNetLite architecture using given scaling

--- a/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_aliases.py
+++ b/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_aliases.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models.backbones.efficientnet_v1.efficientnet_v1_backbone import (
     EfficientNetV1Backbone,
 )
@@ -33,6 +34,7 @@ ALIAS_DOCSTRING = """Instantiates the {name} architecture.
 """  # noqa: E501
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B0Backbone")
 class EfficientNetV1B0Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -63,6 +65,7 @@ class EfficientNetV1B0Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B1Backbone")
 class EfficientNetV1B1Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -93,6 +96,7 @@ class EfficientNetV1B1Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B2Backbone")
 class EfficientNetV1B2Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -123,6 +127,7 @@ class EfficientNetV1B2Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B3Backbone")
 class EfficientNetV1B3Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -153,6 +158,7 @@ class EfficientNetV1B3Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B4Backbone")
 class EfficientNetV1B4Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -183,6 +189,7 @@ class EfficientNetV1B4Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B5Backbone")
 class EfficientNetV1B5Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -213,6 +220,7 @@ class EfficientNetV1B5Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B6Backbone")
 class EfficientNetV1B6Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,
@@ -243,6 +251,7 @@ class EfficientNetV1B6Backbone(EfficientNetV1Backbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.EfficientNetV1B7Backbone")
 class EfficientNetV1B7Backbone(EfficientNetV1Backbone):
     def __new__(
         cls,

--- a/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
@@ -24,7 +24,7 @@ from keras_cv.models.backbones.efficientnet_v1.efficientnet_v1_backbone_presets 
 from keras_cv.utils.python_utils import classproperty
 
 
-@keras_cv_export("keras_cv.models.EfficientNetLiteB4Backbone")
+@keras_cv_export("keras_cv.models.EfficientNetV1Backbone")
 @keras.saving.register_keras_serializable(package="keras_cv.models")
 class EfficientNetV1Backbone(Backbone):
     """Instantiates the EfficientNetV1 architecture.

--- a/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
@@ -14,6 +14,7 @@
 import copy
 import math
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
@@ -23,6 +24,7 @@ from keras_cv.models.backbones.efficientnet_v1.efficientnet_v1_backbone_presets 
 from keras_cv.utils.python_utils import classproperty
 
 
+@keras_cv_export("keras_cv.models.EfficientNetLiteB4Backbone")
 @keras.saving.register_keras_serializable(package="keras_cv.models")
 class EfficientNetV1Backbone(Backbone):
     """Instantiates the EfficientNetV1 architecture.

--- a/keras_cv/models/backbones/mix_transformer/mix_transformer_aliases.py
+++ b/keras_cv/models/backbones/mix_transformer/mix_transformer_aliases.py
@@ -14,6 +14,7 @@
 
 import copy
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models.backbones.mix_transformer.mix_transformer_backbone import (
     MiTBackbone,
 )
@@ -46,6 +47,7 @@ ALIAS_DOCSTRING = """MiT model.
 """  # noqa: E501
 
 
+@keras_cv_export("keras_cv.models.MiTB0Backbone")
 class MiTB0Backbone(MiTBackbone):
     def __new__(
         cls,
@@ -80,6 +82,7 @@ class MiTB0Backbone(MiTBackbone):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.MiTB1Backbone")
 class MiTB1Backbone(MiTBackbone):
     def __new__(
         cls,
@@ -109,6 +112,7 @@ class MiTB1Backbone(MiTBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.MiTB2Backbone")
 class MiTB2Backbone(MiTBackbone):
     def __new__(
         cls,
@@ -138,6 +142,7 @@ class MiTB2Backbone(MiTBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.MiTB3Backbone")
 class MiTB3Backbone(MiTBackbone):
     def __new__(
         cls,
@@ -167,6 +172,7 @@ class MiTB3Backbone(MiTBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.MiTB4Backbone")
 class MiTB4Backbone(MiTBackbone):
     def __new__(
         cls,
@@ -196,6 +202,7 @@ class MiTB4Backbone(MiTBackbone):
         return {}
 
 
+@keras_cv_export("keras_cv.models.MiTB5Backbone")
 class MiTB5Backbone(MiTBackbone):
     def __new__(
         cls,

--- a/keras_cv/models/backbones/vgg16/vgg16_backbone.py
+++ b/keras_cv/models/backbones/vgg16/vgg16_backbone.py
@@ -14,10 +14,12 @@
 
 from keras import layers
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models import utils
 from keras_cv.models.backbones.backbone import Backbone
 
 
+@keras_cv_export("keras_cv.models.VGG16Backbone")
 class VGG16Backbone(Backbone):
     """
     Reference:

--- a/keras_cv/models/backbones/vit_det/vit_det_aliases.py
+++ b/keras_cv/models/backbones/vit_det/vit_det_aliases.py
@@ -14,6 +14,7 @@
 
 import copy
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models.backbones.vit_det.vit_det_backbone import ViTDetBackbone
 from keras_cv.models.backbones.vit_det.vit_det_backbone_presets import (
     backbone_presets,
@@ -41,6 +42,7 @@ ALIAS_DOCSTRING = """VitDet{size}Backbone model.
 """  # noqa: E501
 
 
+@keras_cv_export("keras_cv.models.ViTDetBBackbone")
 class ViTDetBBackbone(ViTDetBackbone):
     def __new__(
         cls,
@@ -64,6 +66,7 @@ class ViTDetBBackbone(ViTDetBackbone):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.ViTDetLBackbone")
 class ViTDetLBackbone(ViTDetBackbone):
     def __new__(
         cls,
@@ -87,6 +90,7 @@ class ViTDetLBackbone(ViTDetBackbone):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.ViTDetHBackbone")
 class ViTDetHBackbone(ViTDetBackbone):
     def __new__(
         cls,

--- a/keras_cv/models/feature_extractor/clip/clip_encoder.py
+++ b/keras_cv/models/feature_extractor/clip/clip_encoder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import numpy as np
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.backend import ops
 
@@ -31,6 +32,7 @@ def get_initializer(initializer_range=0.02):
     return keras.initializers.TruncatedNormal(stddev=initializer_range)
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.QuickGELU")
 class QuickGELU(keras.layers.Layer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -39,6 +41,7 @@ class QuickGELU(keras.layers.Layer):
         return x * ops.sigmoid(1.702 * x)
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.ResidualAttention")
 class ResidualAttention(keras.layers.Layer):
     def __init__(
         self,
@@ -136,6 +139,7 @@ class ResidualAttention(keras.layers.Layer):
         return config
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPEncoder")
 class CLIPEncoder(keras.layers.Layer):
     def __init__(self, width, num_layers, heads, **kwargs):
         super().__init__(**kwargs)
@@ -185,6 +189,7 @@ class CLIPEncoder(keras.layers.Layer):
         return config
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPAttention")
 class CLIPAttention(keras.layers.Layer):
     """
     Adapted from https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/modeling_clip.py # noqa: E501

--- a/keras_cv/models/feature_extractor/clip/clip_image_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_image_model.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.backend import ops
 from keras_cv.models.feature_extractor.clip.clip_encoder import CLIPEncoder
 from keras_cv.models.feature_extractor.clip.clip_encoder import get_initializer
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPPatchingAndEmbedding")
 class CLIPPatchingAndEmbedding(keras.layers.Layer):
     def __init__(
         self, width, patch_size, input_resolution, output_dim, **kwargs
@@ -95,6 +97,7 @@ class CLIPPatchingAndEmbedding(keras.layers.Layer):
         return config
 
 
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPImageEncoder")
 class CLIPImageEncoder(keras.Model):
     def __init__(
         self,

--- a/keras_cv/models/feature_extractor/clip/clip_processor.py
+++ b/keras_cv/models/feature_extractor/clip/clip_processor.py
@@ -19,7 +19,7 @@ from keras_cv.backend import ops
 from keras_cv.models.feature_extractor.clip.clip_tokenizer import CLIPTokenizer
 
 
-@keras_cv_export("keras_cv.models.feature_extractors.CLIPProcessor")
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPProcessor")
 class CLIPProcessor:
     """
     CLIPProcessor is a utility class that provides functionality for processing

--- a/keras_cv/models/feature_extractor/clip/clip_text_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_text_model.py
@@ -11,11 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from keras_cv.api_export import keras_cv_export
 from keras_cv.backend import keras
 from keras_cv.backend import ops
 from keras_cv.models.feature_extractor.clip.clip_encoder import CLIPEncoder
 
 
+@keras_cv_export("keras_cv.models.feature_extractors.CLIPTextEncoder")
 class CLIPTextEncoder(keras.Model):
     def __init__(
         self,

--- a/keras_cv/models/feature_extractor/clip/clip_text_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_text_model.py
@@ -17,7 +17,7 @@ from keras_cv.backend import ops
 from keras_cv.models.feature_extractor.clip.clip_encoder import CLIPEncoder
 
 
-@keras_cv_export("keras_cv.models.feature_extractors.CLIPTextEncoder")
+@keras_cv_export("keras_cv.models.feature_extractor.CLIPTextEncoder")
 class CLIPTextEncoder(keras.Model):
     def __init__(
         self,

--- a/keras_cv/models/segmentation/segformer/segformer_aliases.py
+++ b/keras_cv/models/segmentation/segformer/segformer_aliases.py
@@ -14,6 +14,7 @@
 
 import copy
 
+from keras_cv.api_export import keras_cv_export
 from keras_cv.models.segmentation.segformer.segformer import SegFormer
 from keras_cv.models.segmentation.segformer.segformer_presets import presets
 from keras_cv.utils.python_utils import classproperty
@@ -39,6 +40,7 @@ ALIAS_DOCSTRING = """SegFormer model.
 """  # noqa: E501
 
 
+@keras_cv_export("keras_cv.models.SegFormerB0")
 class SegFormerB0(SegFormer):
     def __new__(
         cls,
@@ -67,6 +69,7 @@ class SegFormerB0(SegFormer):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.SegFormerB1")
 class SegFormerB1(SegFormer):
     def __new__(
         cls,
@@ -95,6 +98,7 @@ class SegFormerB1(SegFormer):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.SegFormerB2")
 class SegFormerB2(SegFormer):
     def __new__(
         cls,
@@ -123,6 +127,7 @@ class SegFormerB2(SegFormer):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.SegFormerB3")
 class SegFormerB3(SegFormer):
     def __new__(
         cls,
@@ -151,6 +156,7 @@ class SegFormerB3(SegFormer):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.SegFormerB4")
 class SegFormerB4(SegFormer):
     def __new__(
         cls,
@@ -179,6 +185,7 @@ class SegFormerB4(SegFormer):
         return cls.presets
 
 
+@keras_cv_export("keras_cv.models.SegFormerB5")
 class SegFormerB5(SegFormer):
     def __new__(
         cls,


### PR DESCRIPTION
* Exported all the missing APIs.
* Fixed few typos.
* CSPDarkNetBackbone export should be corrected under `.models` instead of `.losses`

Once this is merged, the APIs will be available to list in the https://keras.io/api/keras_cv/models/ Related:https://github.com/keras-team/keras-cv/issues/2386
