### PR TITLE
Standardize docstring

### DIFF
--- a/benchmarks/vectorized_channel_shuffle.py
+++ b/benchmarks/vectorized_channel_shuffle.py
@@ -50,7 +50,7 @@ class OldChannelShuffle(BaseImageAugmentationLayer):
         training: A boolean argument that determines whether the call should be
             run in inference mode or training mode, defaults to True.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     channel_shuffle = keras_cv.layers.ChannelShuffle()

--- a/benchmarks/vectorized_grayscale.py
+++ b/benchmarks/vectorized_grayscale.py
@@ -42,7 +42,7 @@ class OldGrayscale(BaseImageAugmentationLayer):
             after the `Grayscale` operation:
                  a. (..., height, width, 1) if output_channels = 1
                  b. (..., height, width, 3) if output_channels = 3.
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     to_grayscale = keras_cv.layers.preprocessing.Grayscale()

--- a/benchmarks/vectorized_jittered_resize.py
+++ b/benchmarks/vectorized_jittered_resize.py
@@ -53,7 +53,7 @@ class OldJitteredResize(BaseImageAugmentationLayer):
     are translated and scaled according to the random scaling and random
     cropping.
 
-    Usage:
+    Example:
     ```python
     train_ds = load_object_detection_dataset()
     jittered_resize = layers.JitteredResize(

--- a/benchmarks/vectorized_mosaic.py
+++ b/benchmarks/vectorized_mosaic.py
@@ -66,7 +66,7 @@ class OldMosaic(BaseImageAugmentationLayer):
         - [Yolov5 implementation](https://github.com/ultralytics/yolov5).
         - [YoloX implementation](https://github.com/Megvii-BaseDetection/YOLOX)
 
-    Sample usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     labels = tf.one_hot(labels,10)

--- a/benchmarks/vectorized_random_color_jitter.py
+++ b/benchmarks/vectorized_random_color_jitter.py
@@ -72,7 +72,7 @@ class OldRandomColorJitter(BaseImageAugmentationLayer):
             pass a tuple with two identical floats: `(0.5, 0.5)`.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     color_jitter = keras_cv.layers.RandomColorJitter(

--- a/keras_cv/bounding_box/converters.py
+++ b/keras_cv/bounding_box/converters.py
@@ -338,7 +338,7 @@ def convert_format(
     performance loss, as each image will need to be processed separately due to
     the mismatching image shapes.
 
-    Usage:
+    Example:
 
     ```python
     boxes = load_coco_dataset()

--- a/keras_cv/bounding_box/to_ragged.py
+++ b/keras_cv/bounding_box/to_ragged.py
@@ -29,7 +29,7 @@ def to_ragged(bounding_boxes, sentinel=-1, dtype=tf.float32):
     checking for padded sentinel value of the class_id axis of the
     bounding_boxes.
 
-    Usage:
+    Example:
     ```python
     bounding_boxes = {
         "boxes": tf.constant([[2, 3, 4, 5], [0, 1, 2, 3]]),

--- a/keras_cv/core/factor_sampler/constant_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/constant_factor_sampler.py
@@ -29,7 +29,7 @@ class ConstantFactorSampler(FactorSampler):
     Args:
         value: the value to return from `__call__()`.
 
-    Usage:
+    Example:
     ```python
     constant_factor = keras_cv.ConstantFactorSampler(0.5)
     random_sharpness = keras_cv.layers.RandomSharpness(factor=constant_factor)

--- a/keras_cv/core/factor_sampler/normal_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/normal_factor_sampler.py
@@ -31,7 +31,7 @@ class NormalFactorSampler(FactorSampler):
         min_value: values below min_value are clipped to min_value.
         max_value: values above max_value are clipped to max_value.
 
-    Usage:
+    Example:
     ```python
     factor = keras_cv.core.NormalFactor(
         mean=0.5,

--- a/keras_cv/core/factor_sampler/uniform_factor_sampler.py
+++ b/keras_cv/core/factor_sampler/uniform_factor_sampler.py
@@ -31,7 +31,7 @@ class UniformFactorSampler(FactorSampler):
         seed: A shape int or Tensor, the seed to the random number generator.
             Must have dtype int32 or int64. (When using XLA, only int32 is
             allowed.)
-    Usage:
+    Example:
     ```python
     uniform_factor = keras_cv.UniformFactorSampler(0, 0.5)
     random_sharpness = keras_cv.layers.RandomSharpness(factor=uniform_factor)

--- a/keras_cv/datasets/imagenet/load.py
+++ b/keras_cv/datasets/imagenet/load.py
@@ -71,7 +71,7 @@ def load(
 ):
     """Loads the ImageNet dataset from TFRecords
 
-    Usage:
+    Example:
     ```python
     dataset, ds_info = keras_cv.datasets.imagenet.load(
         split="train", tfrecord_path="gs://my-bucket/imagenet-tfrecords"

--- a/keras_cv/datasets/pascal_voc/load.py
+++ b/keras_cv/datasets/pascal_voc/load.py
@@ -52,7 +52,7 @@ def load(
 ):
     """Loads the PascalVOC 2007 dataset.
 
-    Usage:
+    Example:
     ```python
     dataset, ds_info = keras_cv.datasets.pascal_voc.load(
         split="train", bounding_box_format="xywh", batch_size=9

--- a/keras_cv/keypoint/converters.py
+++ b/keras_cv/keypoint/converters.py
@@ -82,7 +82,7 @@ def convert_format(keypoints, source, target, images=None, dtype=None):
     will need to be processed separately due to the mismatching image
     shapes.
 
-    Usage:
+    Example:
 
     ```python
     images, keypoints = load_my_dataset()

--- a/keras_cv/layers/augmenter.py
+++ b/keras_cv/layers/augmenter.py
@@ -23,7 +23,7 @@ class Augmenter(keras.layers.Layer):
     Args:
         layers: A list of `keras.layers.Layers` to apply to the example
 
-    Examples:
+    Example:
     from keras_cv import layers
     images = np.ones((16, 256, 256, 3))
     augmenter = layers.Augmenter(

--- a/keras_cv/layers/feature_pyramid.py
+++ b/keras_cv/layers/feature_pyramid.py
@@ -68,7 +68,7 @@ class FeaturePyramid(keras.layers.Layer):
             levels. Defaults to None, and a `keras.Conv2D` layer with kernel 3x3
             will be created for each pyramid level.
 
-    Sample Usage:
+    Example:
     ```python
 
     inp = keras.layers.Input((384, 384, 3))

--- a/keras_cv/layers/fusedmbconv.py
+++ b/keras_cv/layers/fusedmbconv.py
@@ -72,7 +72,7 @@ class FusedMBConvBlock(keras.layers.Layer):
         block
 
 
-    Example usage:
+    Example:
 
     ```
     inputs = tf.random.normal(shape=(1, 64, 64, 32), dtype=tf.float32)

--- a/keras_cv/layers/hierarchical_transformer_encoder.py
+++ b/keras_cv/layers/hierarchical_transformer_encoder.py
@@ -51,7 +51,7 @@ class HierarchicalTransformerEncoder(keras.layers.Layer):
             `SegFormerMultiheadAttention`. If set to > 1, a `Conv2D`
              layer is used to reduce the length of the sequence. Defaults to `1`.
 
-    Basic usage:
+    Example:
 
     ```
     project_dim = 1024

--- a/keras_cv/layers/mbconv.py
+++ b/keras_cv/layers/mbconv.py
@@ -85,7 +85,7 @@ class MBConvBlock(keras.layers.Layer):
             block
 
 
-        Example usage:
+        Example:
 
         ```
         inputs = tf.random.normal(shape=(1, 64, 64, 32), dtype=tf.float32)

--- a/keras_cv/layers/object_detection/anchor_generator.py
+++ b/keras_cv/layers/object_detection/anchor_generator.py
@@ -51,7 +51,7 @@ class AnchorGenerator(keras.layers.Layer):
       clip_boxes: whether to clip generated anchor boxes to the image
         size, defaults to `False`.
 
-    Usage:
+    Example:
     ```python
     strides = [8, 16, 32]
     scales = [1, 1.2599210498948732, 1.5874010519681994]

--- a/keras_cv/layers/object_detection/box_matcher.py
+++ b/keras_cv/layers/object_detection/box_matcher.py
@@ -67,7 +67,7 @@ class BoxMatcher(keras.layers.Layer):
         ValueError: if `thresholds` not sorted or
         len(`match_values`) != len(`thresholds`) + 1
 
-    Usage:
+    Example:
 
     ```python
     box_matcher = keras_cv.layers.BoxMatcher([0.3, 0.7], [-1, 0, 1])

--- a/keras_cv/layers/object_detection/roi_generator.py
+++ b/keras_cv/layers/object_detection/roi_generator.py
@@ -69,7 +69,7 @@ class ROIGenerator(keras.layers.Layer):
             feature maps / levels (as in FPN) this number is per
             feature map / level.
 
-    Usage:
+    Example:
     ```python
     roi_generator = ROIGenerator("xyxy")
     boxes = {2: tf.random.normal([32, 5, 4])}

--- a/keras_cv/layers/object_detection/roi_pool.py
+++ b/keras_cv/layers/object_detection/roi_pool.py
@@ -40,7 +40,7 @@ class ROIPooler(keras.layers.Layer):
         image_shape: List of Tuple of 3 integers, or `TensorShape` of the input
             image shape.
 
-    Usage:
+    Example:
     ```python
     feature_map = tf.random.normal([2, 16, 16, 512])
     roi_pooler = ROIPooler(bounding_box_format="yxyx", target_size=[7, 7],

--- a/keras_cv/layers/overlapping_patching_embedding.py
+++ b/keras_cv/layers/overlapping_patching_embedding.py
@@ -39,7 +39,7 @@ class OverlappingPatchingAndEmbedding(keras.layers.Layer):
             stride: integer, the stride to use for the patching before
                 projection. Defaults to `5`.
 
-        Basic usage:
+        Example:
 
         ```
         project_dim = 1024

--- a/keras_cv/layers/preprocessing/aug_mix.py
+++ b/keras_cv/layers/preprocessing/aug_mix.py
@@ -60,7 +60,7 @@ class AugMix(BaseImageAugmentationLayer):
         - [Official Code](https://github.com/google-research/augmix)
         - [Unofficial TF Code](https://github.com/szacho/augmix-tf)
 
-    Sample Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     augmix = keras_cv.layers.AugMix([0, 255])

--- a/keras_cv/layers/preprocessing/channel_shuffle.py
+++ b/keras_cv/layers/preprocessing/channel_shuffle.py
@@ -35,7 +35,7 @@ class ChannelShuffle(VectorizedBaseImageAugmentationLayer):
         groups: Number of groups to divide the input channels, defaults to 3.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     channel_shuffle = ChannelShuffle(groups=3)

--- a/keras_cv/layers/preprocessing/equalization.py
+++ b/keras_cv/layers/preprocessing/equalization.py
@@ -35,7 +35,7 @@ class Equalization(VectorizedBaseImageAugmentationLayer):
         bins: Integer indicating the number of bins to use in histogram
             equalization. Should be in the range [0, 256].
 
-    Usage:
+    Example:
     ```python
     equalize = Equalization()
 

--- a/keras_cv/layers/preprocessing/fourier_mix.py
+++ b/keras_cv/layers/preprocessing/fourier_mix.py
@@ -35,7 +35,7 @@ class FourierMix(BaseImageAugmentationLayer):
     References:
         - [FMix paper](https://arxiv.org/abs/2002.12047).
 
-    Sample usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     fourier_mix = keras_cv.layers.preprocessing.FourierMix(0.5)

--- a/keras_cv/layers/preprocessing/grayscale.py
+++ b/keras_cv/layers/preprocessing/grayscale.py
@@ -41,7 +41,7 @@ class Grayscale(VectorizedBaseImageAugmentationLayer):
                  a. (..., height, width, 1) if output_channels = 1
                  b. (..., height, width, 3) if output_channels = 3.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     to_grayscale = keras_cv.layers.preprocessing.Grayscale()

--- a/keras_cv/layers/preprocessing/grid_mask.py
+++ b/keras_cv/layers/preprocessing/grid_mask.py
@@ -82,7 +82,7 @@ class GridMask(BaseImageAugmentationLayer):
             [0 to 255]
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_gridmask = keras_cv.layers.preprocessing.GridMask()

--- a/keras_cv/layers/preprocessing/jittered_resize.py
+++ b/keras_cv/layers/preprocessing/jittered_resize.py
@@ -68,7 +68,7 @@ class JitteredResize(VectorizedBaseImageAugmentationLayer):
             `"mitchellcubic"`.
         seed: (Optional) integer to use as the random seed.
 
-    Usage:
+    Example:
     ```python
     train_ds = load_object_detection_dataset()
     jittered_resize = layers.JitteredResize(

--- a/keras_cv/layers/preprocessing/mix_up.py
+++ b/keras_cv/layers/preprocessing/mix_up.py
@@ -36,7 +36,7 @@ class MixUp(BaseImageAugmentationLayer):
         - [MixUp paper](https://arxiv.org/abs/1710.09412).
         - [MixUp for Object Detection paper](https://arxiv.org/pdf/1902.04103).
 
-    Sample usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     images, labels = images[:10], labels[:10]

--- a/keras_cv/layers/preprocessing/mosaic.py
+++ b/keras_cv/layers/preprocessing/mosaic.py
@@ -72,7 +72,7 @@ class Mosaic(VectorizedBaseImageAugmentationLayer):
         - [Yolov5 implementation](https://github.com/ultralytics/yolov5).
         - [YoloX implementation](https://github.com/Megvii-BaseDetection/YOLOX)
 
-    Sample usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     labels = tf.one_hot(labels,10)

--- a/keras_cv/layers/preprocessing/posterization.py
+++ b/keras_cv/layers/preprocessing/posterization.py
@@ -37,7 +37,7 @@ class Posterization(BaseImageAugmentationLayer):
         bits: integer, the number of bits to keep for each channel. Must be a
             value between 1-8.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     print(images[0, 0, 0])

--- a/keras_cv/layers/preprocessing/rand_augment.py
+++ b/keras_cv/layers/preprocessing/rand_augment.py
@@ -67,7 +67,7 @@ class RandAugment(RandomAugmentationPipeline):
         geometric: whether to include geometric augmentations. This
             should be set to False when performing object detection. Defaults to
             True.
-    Usage:
+    Example:
     ```python
     (x_test, y_test), _ = keras.datasets.cifar10.load_data()
     rand_augment = keras_cv.layers.RandAugment(

--- a/keras_cv/layers/preprocessing/random_apply.py
+++ b/keras_cv/layers/preprocessing/random_apply.py
@@ -39,7 +39,7 @@ class RandomApply(BaseImageAugmentationLayer):
             but currently doesn't work with XLA. Defaults to False.
         seed: integer, controls random behaviour.
 
-    Example usage:
+    Example:
     ```
     # Let's declare an example layer that will set all image pixels to zero.
     zero_out = keras.layers.Lambda(lambda x: {"images": 0 * x["images"]})

--- a/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
+++ b/keras_cv/layers/preprocessing/random_augmentation_pipeline.py
@@ -36,7 +36,7 @@ class RandomAugmentationPipeline(BaseImageAugmentationLayer):
     This layer can be used to create custom policies resembling `RandAugment` or
     `AutoAugment`.
 
-    Usage:
+    Example:
     ```python
     # construct a list of layers
     layers = keras_cv.layers.RandAugment.get_standard_policy(

--- a/keras_cv/layers/preprocessing/random_brightness.py
+++ b/keras_cv/layers/preprocessing/random_brightness.py
@@ -53,7 +53,7 @@ class RandomBrightness(VectorizedBaseImageAugmentationLayer):
       be clipped to the range `[0, 255]`, the valid range of RGB colors, and
       rescaled based on the `value_range` if needed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_brightness = keras_cv.layers.preprocessing.RandomBrightness()

--- a/keras_cv/layers/preprocessing/random_channel_shift.py
+++ b/keras_cv/layers/preprocessing/random_channel_shift.py
@@ -49,7 +49,7 @@ class RandomChannelShift(BaseImageAugmentationLayer):
             less channels.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     rgb_shift = keras_cv.layers.RandomChannelShift(value_range=(0, 255),

--- a/keras_cv/layers/preprocessing/random_choice.py
+++ b/keras_cv/layers/preprocessing/random_choice.py
@@ -28,7 +28,7 @@ class RandomChoice(BaseImageAugmentationLayer):
     `call`(), the policy selects a random layer from the provided list of
     `layers`. It then calls the `layer()` on the inputs.
 
-    Usage:
+    Example:
     ```python
     # construct a list of layers
     layers = keras_cv.layers.RandAugment.get_standard_policy(

--- a/keras_cv/layers/preprocessing/random_color_jitter.py
+++ b/keras_cv/layers/preprocessing/random_color_jitter.py
@@ -67,7 +67,7 @@ class RandomColorJitter(VectorizedBaseImageAugmentationLayer):
             pass a tuple with two identical floats: `(0.5, 0.5)`.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     color_jitter = keras_cv.layers.RandomColorJitter(

--- a/keras_cv/layers/preprocessing/random_contrast.py
+++ b/keras_cv/layers/preprocessing/random_contrast.py
@@ -58,7 +58,7 @@ class RandomContrast(VectorizedBaseImageAugmentationLayer):
             `mean` is the mean value of the channel.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_contrast = keras_cv.layers.preprocessing.RandomContrast()

--- a/keras_cv/layers/preprocessing/random_cutout.py
+++ b/keras_cv/layers/preprocessing/random_cutout.py
@@ -58,7 +58,7 @@ class RandomCutout(VectorizedBaseImageAugmentationLayer):
             when `fill_mode="constant"`.
         seed: Integer. Used to create a random seed.
 
-    Sample usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_cutout = keras_cv.layers.preprocessing.RandomCutout(0.5, 0.5)

--- a/keras_cv/layers/preprocessing/random_hue.py
+++ b/keras_cv/layers/preprocessing/random_hue.py
@@ -48,7 +48,7 @@ class RandomHue(VectorizedBaseImageAugmentationLayer):
             preprocessing pipeline is set up.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_hue = keras_cv.layers.preprocessing.RandomHue()

--- a/keras_cv/layers/preprocessing/random_jpeg_quality.py
+++ b/keras_cv/layers/preprocessing/random_jpeg_quality.py
@@ -35,7 +35,7 @@ class RandomJpegQuality(BaseImageAugmentationLayer):
         `tf.image.adjust_jpeg_quality()`.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     layer = keras_cv.RandomJpegQuality(factor=(75, 100)))
     (images, labels), _ = keras.datasets.cifar10.load_data()

--- a/keras_cv/layers/preprocessing/random_saturation.py
+++ b/keras_cv/layers/preprocessing/random_saturation.py
@@ -42,7 +42,7 @@ class RandomSaturation(VectorizedBaseImageAugmentationLayer):
             same, please pass a tuple with two identical floats: `(0.5, 0.5)`.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     random_saturation = keras_cv.layers.preprocessing.RandomSaturation()

--- a/keras_cv/layers/preprocessing/repeated_augmentation.py
+++ b/keras_cv/layers/preprocessing/repeated_augmentation.py
@@ -40,7 +40,7 @@ class RepeatedAugmentation(BaseImageAugmentationLayer):
         shuffle: whether to shuffle the result. Essential when using an
             asynchronous distribution strategy such as ParameterServerStrategy.
 
-    Usage:
+    Example:
 
     List of identical augmenters:
     ```python

--- a/keras_cv/layers/preprocessing/solarization.py
+++ b/keras_cv/layers/preprocessing/solarization.py
@@ -55,7 +55,7 @@ class Solarization(VectorizedBaseImageAugmentationLayer):
             values above this threshold will be solarized.
         seed: Integer. Used to create a random seed.
 
-    Usage:
+    Example:
     ```python
     (images, labels), _ = keras.datasets.cifar10.load_data()
     print(images[0, 0, 0])

--- a/keras_cv/layers/regularization/drop_path.py
+++ b/keras_cv/layers/regularization/drop_path.py
@@ -35,7 +35,7 @@ class DropPath(keras.layers.Layer):
         rate: float, the probability of the residual branch being dropped.
         seed: (Optional) integer. Used to create a random seed.
 
-    Usage:
+    Example:
     `DropPath` can be used in any network as follows:
     ```python
 

--- a/keras_cv/layers/regularization/dropblock_2d.py
+++ b/keras_cv/layers/regularization/dropblock_2d.py
@@ -48,7 +48,7 @@ class DropBlock2D(keras.layers.Layer):
         seed: integer. To use as random seed.
         name: string. The name of the layer.
 
-    Usage:
+    Examples:
     DropBlock2D can be used inside a `keras.Model`:
     ```python
     # (...)

--- a/keras_cv/layers/regularization/squeeze_excite.py
+++ b/keras_cv/layers/regularization/squeeze_excite.py
@@ -47,7 +47,7 @@ class SqueezeAndExcite2D(keras.layers.Layer):
             keras.layers.Layer) or keras.activations.Activation instance
             denoting activation to be applied after excite convolution.
             Defaults to `sigmoid`.
-    Usage:
+    Example:
 
     ```python
     # (...)

--- a/keras_cv/layers/regularization/stochastic_depth.py
+++ b/keras_cv/layers/regularization/stochastic_depth.py
@@ -32,7 +32,7 @@ class StochasticDepth(keras.layers.Layer):
     Args:
         rate: float, the probability of the residual branch being dropped.
 
-    Usage:
+    Example:
 
     `StochasticDepth` can be used in a residual network as follows:
     ```python

--- a/keras_cv/layers/segformer_multihead_attention.py
+++ b/keras_cv/layers/segformer_multihead_attention.py
@@ -45,7 +45,7 @@ class SegFormerMultiheadAttention(keras.layers.Layer):
             sr_ratio: integer, the sequence reduction ratio to perform
                 on the sequence before key and value projections.
 
-        Basic usage:
+        Example:
 
         ```
         tensor = tf.random.uniform([1, 196, 32])

--- a/keras_cv/layers/transformer_encoder.py
+++ b/keras_cv/layers/transformer_encoder.py
@@ -38,7 +38,7 @@ class TransformerEncoder(layers.Layer):
         layer_norm_epsilon: default 1e-06, the epsilon for `LayerNormalization`
             layers
 
-    Basic usage:
+    Example:
 
     ```
     project_dim = 1024

--- a/keras_cv/layers/vit_layers.py
+++ b/keras_cv/layers/vit_layers.py
@@ -44,7 +44,7 @@ class PatchingAndEmbedding(layers.Layer):
         Patchified and linearly projected input images, including a prepended
         learnable class token with shape (batch, num_patches+1, project_dim)
 
-    Basic usage:
+    Example:
 
     ```
     images = #... batch of images

--- a/keras_cv/losses/ciou_loss.py
+++ b/keras_cv/losses/ciou_loss.py
@@ -40,7 +40,7 @@ class CIoULoss(keras.losses.Loss):
     References:
         - [CIoU paper](https://arxiv.org/pdf/2005.03572.pdf)
 
-    Sample Usage:
+    Example:
     ```python
     y_true = np.random.uniform(
         size=(5, 10, 5),

--- a/keras_cv/losses/focal.py
+++ b/keras_cv/losses/focal.py
@@ -42,7 +42,7 @@ class FocalLoss(keras.losses.Loss):
     References:
         - [Focal Loss paper](https://arxiv.org/abs/1708.02002)
 
-    Standalone usage:
+    Example:
     ```python
     y_true = np.random.uniform(size=[10], low=0, high=4)
     y_pred = np.random.uniform(size=[10], low=0, high=4)

--- a/keras_cv/losses/giou_loss.py
+++ b/keras_cv/losses/giou_loss.py
@@ -42,7 +42,7 @@ class GIoULoss(keras.losses.Loss):
         - [GIoU paper](https://arxiv.org/pdf/1902.09630)
         - [TFAddons Implementation](https://www.tensorflow.org/addons/api_docs/python/tfa/losses/GIoULoss)
 
-    Sample Usage:
+    Example:
     ```python
     y_true = np.random.uniform(size=(5, 10, 5), low=0, high=10)
     y_pred = np.random.uniform(size=(5, 10, 4), low=0, high=10)

--- a/keras_cv/losses/iou_loss.py
+++ b/keras_cv/losses/iou_loss.py
@@ -47,7 +47,7 @@ class IoULoss(keras.losses.Loss):
     References:
         - [UnitBox paper](https://arxiv.org/pdf/1608.01471)
 
-    Sample Usage:
+    Example:
     ```python
     y_true = np.random.uniform(size=(5, 10, 5), low=10, high=10)
     y_pred = np.random.uniform(size=(5, 10, 5), low=10, high=10)

--- a/keras_cv/metrics/object_detection/box_coco_metrics.py
+++ b/keras_cv/metrics/object_detection/box_coco_metrics.py
@@ -93,7 +93,7 @@ class BoxCOCOMetrics(keras.metrics.Metric):
             values will allow for faster training times, while lower numbers
             allow for higher numerical precision in metric reporting.
 
-    Usage:
+    Example:
     `BoxCOCOMetrics()` can be used like any standard metric with any
     KerasCV object detection model. Inputs to `y_true` must be KerasCV bounding
     box dictionaries, `{"classes": classes, "boxes": boxes}`, and `y_pred` must

--- a/keras_cv/models/backbones/csp_darknet/csp_darknet_aliases.py
+++ b/keras_cv/models/backbones/csp_darknet/csp_darknet_aliases.py
@@ -41,7 +41,7 @@ ALIAS_DOCSTRING = """CSPDarkNetBackbone model with {stackwise_channels} channels
             to use as image input for the model.
         input_shape: optional shape tuple, defaults to (None, None, 3).
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/densenet/densenet_aliases.py
+++ b/keras_cv/models/backbones/densenet/densenet_aliases.py
@@ -39,7 +39,7 @@ ALIAS_DOCSTRING = """DenseNetBackbone model with {num_layers} layers.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_aliases.py
+++ b/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_aliases.py
@@ -31,7 +31,7 @@ ALIAS_DOCSTRING = """Instantiates the {name} architecture.
         input_shape: optional shape tuple, defaults to (None, None, 3).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-    Usage:
+    Example:
     ```python
     input_data = np.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_lite/efficientnet_lite_backbone.py
@@ -63,7 +63,7 @@ class EfficientNetLiteBackbone(Backbone):
         input_tensor: optional Keras tensor (i.e. output of `keras.layers.Input()`)
             to use as image input for the model.
 
-    Usage:
+    Example:
     ```python
     # Construct an EfficientNetLite from a preset:
     efficientnet = models.EfficientNetLiteBackbone.from_preset(

--- a/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
+++ b/keras_cv/models/backbones/efficientnet_v1/efficientnet_v1_backbone.py
@@ -63,7 +63,7 @@ class EfficientNetV1Backbone(Backbone):
         stackwise_squeeze_and_excite_ratios: list of ints, the squeeze and
             excite ratios passed to the squeeze and excitation blocks.
 
-    Usage:
+    Example:
     ```python
     # Construct an EfficientNetV1 from a preset:
     efficientnet = keras_cv.models.EfficientNetV1Backbone.from_preset(

--- a/keras_cv/models/backbones/mix_transformer/mix_transformer_aliases.py
+++ b/keras_cv/models/backbones/mix_transformer/mix_transformer_aliases.py
@@ -36,7 +36,7 @@ ALIAS_DOCSTRING = """MiT model.
         input_tensor: optional Keras tensor (i.e., output of `layers.Input()`)
             to use as image input for the model.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/mix_transformer/mix_transformer_backbone.py
+++ b/keras_cv/models/backbones/mix_transformer/mix_transformer_backbone.py
@@ -70,7 +70,7 @@ class MiTBackbone(Backbone):
             input_tensor: optional Keras tensor (i.e. output of `keras.layers.Input()`)
                 to use as image input for the model.
 
-        Examples:
+        Example:
 
         Using the class with a `backbone`:
 

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_aliases.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_aliases.py
@@ -40,7 +40,7 @@ ALIAS_DOCSTRING = """MobileNetV3Backbone model with {num_layers} layers.
         input_tensor: optional Keras tensor (i.e., output of `layers.Input()`)
             to use as image input for the model.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
+++ b/keras_cv/models/backbones/mobilenet_v3/mobilenet_v3_backbone.py
@@ -75,7 +75,7 @@ class MobileNetV3Backbone(Backbone):
             - If `alpha` = 1, default number of filters from the paper
                 are used at each layer.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/resnet_v1/resnet_v1_aliases.py
+++ b/keras_cv/models/backbones/resnet_v1/resnet_v1_aliases.py
@@ -45,7 +45,7 @@ ALIAS_DOCSTRING = """ResNetBackbone (V1) model with {num_layers} layers.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/resnet_v2/resnet_v2_aliases.py
+++ b/keras_cv/models/backbones/resnet_v2/resnet_v2_aliases.py
@@ -45,7 +45,7 @@ ALIAS_DOCSTRING = """ResNetV2Backbone model with {num_layers} layers.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/backbones/vit_det/vit_det_aliases.py
+++ b/keras_cv/models/backbones/vit_det/vit_det_aliases.py
@@ -31,7 +31,7 @@ ALIAS_DOCSTRING = """VitDet{size}Backbone model.
     For transfer learning use cases, make sure to read the
     [guide to transfer learning & fine-tuning](https://keras.io/guides/transfer_learning/).
 
-    Examples:
+    Example:
     ```python
     input_data = np.ones(shape=(1, 1024, 1024, 3))
 

--- a/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
+++ b/keras_cv/models/legacy/object_detection/faster_rcnn/faster_rcnn.py
@@ -231,7 +231,7 @@ class FasterRCNN(keras.Model):
     References:
         - [FasterRCNN](https://arxiv.org/pdf/1506.01497.pdf)
 
-    Usage:
+    Example:
     ```python
     retinanet = keras_cv.models.FasterRCNN(
         num_classes=20,

--- a/keras_cv/models/object_detection/retinanet/retinanet.py
+++ b/keras_cv/models/object_detection/retinanet/retinanet.py
@@ -51,7 +51,7 @@ class RetinaNet(Task):
     requires `num_classes`, `bounding_box_format`, and a backbone. Optionally,
     a custom label encoder, and prediction decoder may be provided.
 
-    Examples:
+    Example:
     ```python
     images = np.ones((1, 512, 512, 3))
     labels = {

--- a/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
+++ b/keras_cv/models/object_detection/yolo_v8/yolo_v8_detector.py
@@ -354,7 +354,7 @@ class YOLOV8Detector(Task):
             `keras_cv.layers.MultiClassNonMaxSuppression` layer, which uses
             a Non-Max Suppression for box pruning.
 
-    Examples:
+    Example:
     ```python
     images = tf.ones(shape=(1, 512, 512, 3))
     labels = {

--- a/keras_cv/models/object_detection/yolox/binary_crossentropy.py
+++ b/keras_cv/models/object_detection/yolox/binary_crossentropy.py
@@ -38,7 +38,7 @@ class BinaryCrossentropy(keras.losses.Loss):
         axis: the axis along which to mean the ious. Defaults to `no_reduction`
             which implies mean across no axes.
 
-    Usage:
+    Example:
     ```python
     model.compile(
       loss=BinaryCrossentropy(from_logits=True)

--- a/keras_cv/models/segmentation/basnet/basnet.py
+++ b/keras_cv/models/segmentation/basnet/basnet.py
@@ -70,7 +70,7 @@ class BASNet(Task):
             refinement module head for the model. If not provided, a default
             head is created with a Conv2D layer.
 
-    Examples:
+    Example:
     ```python
 
     import keras_cv

--- a/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus.py
+++ b/keras_cv/models/segmentation/deeplab_v3_plus/deeplab_v3_plus.py
@@ -74,7 +74,7 @@ class DeepLabV3Plus(Task):
             and feature from decoder, otherwise a default DeepLabV3
             convolutional head is used.
 
-    Examples:
+    Example:
     ```python
     import keras_cv
 

--- a/keras_cv/models/segmentation/segformer/segformer.py
+++ b/keras_cv/models/segmentation/segformer/segformer.py
@@ -54,7 +54,7 @@ class SegFormer(Task):
             convolution layer projecting the concatenated features into
             a segmentation map. Defaults to 256`.
 
-    Examples:
+    Example:
 
     Using the class with a `backbone`:
 

--- a/keras_cv/models/segmentation/segformer/segformer_aliases.py
+++ b/keras_cv/models/segmentation/segformer/segformer_aliases.py
@@ -28,7 +28,7 @@ ALIAS_DOCSTRING = """SegFormer model.
         backbone: a KerasCV backbone for feature extraction.
         num_classes: the number of classes for segmentation, including the background class.
 
-    Examples:
+    Example:
     ```python
     input_data = tf.ones(shape=(8, 224, 224, 3))
 

--- a/keras_cv/models/segmentation/segment_anything/sam.py
+++ b/keras_cv/models/segmentation/segment_anything/sam.py
@@ -54,7 +54,7 @@ class SegmentAnythingModel(Task):
         - [Segment Anything paper](https://arxiv.org/abs/2304.02643)
         - [Segment Anything GitHub](https://github.com/facebookresearch/segment-anything)
 
-    Examples:
+    Example:
 
     >>> import numpy as np
     >>> from keras_cv.models import ViTDetBBackbone

--- a/keras_cv/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/models/stable_diffusion/stable_diffusion.py
@@ -285,7 +285,7 @@ class StableDiffusionBase:
     def image_encoder(self):
         """image_encoder returns the VAE Encoder with pretrained weights.
 
-        Usage:
+        Example:
         ```python
         sd = keras_cv.models.StableDiffusion()
         my_image = np.ones((512, 512, 3))

--- a/keras_cv/models/task.py
+++ b/keras_cv/models/task.py
@@ -115,7 +115,7 @@ class Task(keras.Model):
                 initialization, Defaults to `None`.If `None`, the preset
                 value will be used.
 
-        Examples:
+        Example:
         ```python
         # Load architecture and weights from preset
         model = keras_cv.models.{{model_name}}.from_preset(

--- a/keras_cv/ops/iou_3d.py
+++ b/keras_cv/ops/iou_3d.py
@@ -29,7 +29,7 @@ def iou_3d(y_true, y_pred):
     https://github.com/keras-team/keras-cv/blob/master/keras_cv/bounding_box_3d/formats.py
     for more details on supported bounding box formats.
 
-    Sample Usage:
+    Example:
     ```python
     y_true = [[0, 0, 0, 2, 2, 2, 0], [1, 1, 1, 2, 2, 2, 3 * math.pi / 4]]
     y_pred = [[1, 1, 1, 2, 2, 2, math.pi / 4], [1, 1, 1, 2, 2, 2, 0]]

--- a/keras_cv/training/contrastive/contrastive_trainer.py
+++ b/keras_cv/training/contrastive/contrastive_trainer.py
@@ -42,7 +42,7 @@ class ContrastiveTrainer(keras.Model):
       A `keras.Model` instance.
 
 
-    Usage:
+    Example:
     ```python
     encoder = keras.Sequential(
         [

--- a/keras_cv/utils/preprocessing.py
+++ b/keras_cv/utils/preprocessing.py
@@ -68,7 +68,7 @@ def transform_value_range(
     Returns:
         a new Tensor with values in the target range.
 
-    Usage:
+    Example:
     ```python
     original_range = [0, 1]
     target_range = [0, 255]

--- a/keras_cv/visualization/plot_bounding_box_gallery.py
+++ b/keras_cv/visualization/plot_bounding_box_gallery.py
@@ -54,7 +54,7 @@ def plot_bounding_box_gallery(
 ):
     """Plots a gallery of images with corresponding bounding box annotations.
 
-    Usage:
+    Example:
     ```python
     train_ds = tfds.load(
         "voc/2007", split="train", with_info=False, shuffle_files=True

--- a/keras_cv/visualization/plot_image_gallery.py
+++ b/keras_cv/visualization/plot_image_gallery.py
@@ -74,7 +74,7 @@ def plot_image_gallery(
 ):
     """Displays a gallery of images.
 
-    Usage:
+    Example:
     ```python
     train_ds = tfds.load(
         "cats_vs_dogs",

--- a/keras_cv/visualization/plot_segmentation_mask_gallery.py
+++ b/keras_cv/visualization/plot_segmentation_mask_gallery.py
@@ -79,7 +79,7 @@ def plot_segmentation_mask_gallery(
         kwargs: keyword arguments to propagate to
             `keras_cv.visualization.plot_image_gallery()`.
 
-    Usage:
+    Example:
     ```python
     train_ds = tfds.load(
         "oxford_iiit_pet", split="train", with_info=False, shuffle_files=True


### PR DESCRIPTION
Standardize the docstring format to use `Example:` or `Examples:` which are the only tags allowed to render the docstrings example https://github.com/keras-team/keras-io/blob/3edab1fc38c450e78cd7a48b6e7e332c92aad199/scripts/docstrings.py#L28-L29 

