### PR TITLE
Added new dependency on keras_nlp

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -6,7 +6,6 @@ kagglehub
 keras-core>=0.1.6
 keras_nlp
 tensorflow-datasets
-tensorflow-text
 pycocotools
 # Tooling deps.
 packaging

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -4,7 +4,9 @@ regex
 pandas
 kagglehub
 keras-core>=0.1.6
+keras_nlp
 tensorflow-datasets
+tensorflow-text
 pycocotools
 # Tooling deps.
 packaging

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "tensorflow-datasets",
         "keras-core",
         "kagglehub",
-        "keras_nlp"
+        "keras_nlp",
     ],
     extras_require={
         "tests": [

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "tensorflow-datasets",
         "keras-core",
         "kagglehub",
+        "keras_nlp"
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
# What does this PR do?

Fixes #2400 by adding the keras_nlp and tensorflow_text dependencies as direct requirements for the keras_cv repo.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/keras-team/keras-cv/blob/master/.github/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
- [ ] If this adds a new model, can you run a few training steps on TPU in Colab to ensure that no XLA incompatible OP are used?
