### PR TITLE
Add keras-nlp to nightly action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
           python -m pip install --upgrade pip setuptools
           pip install twine
           pip install -r requirements.txt --progress-bar off
+          pip install keras-nlp-nightly
       - name: Build wheel file
         run: |
           export BUILD_WITH_CUSTOM_OPS=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
             pip install -r requirements.txt --progress-bar off
+            pip install keras-nlp
       - name: Build a binary wheel and a source tarball
         run: |
           export BUILD_WITH_CUSTOM_OPS=false


### PR DESCRIPTION
Nightly Wheel files are failing since Feb because the dependency on `keras-nlp` was missing in Nightly wheel action.