### PR TITLE
Bug Fix for CenterNetBoxLoss

### DIFF
--- a/keras_cv/src/losses/centernet_box_loss.py
+++ b/keras_cv/src/losses/centernet_box_loss.py
@@ -66,13 +66,11 @@ class CenterNetBoxLoss(keras.losses.Loss):
 
     def heading_regression_loss(self, heading_true, heading_pred):
         # Set the heading to within 0 -> 2pi
-        heading_true = ops.floor(ops.mod(heading_true, 2 * math.pi))
+        heading_true = ops.mod(heading_true, 2 * math.pi)
 
         # Divide 2pi into bins. shifted by 0.5 * angle_per_class.
         angle_per_class = (2 * math.pi) / self.num_heading_bins
-        shift_angle = ops.floor(
-            ops.mod(heading_true + angle_per_class / 2, 2 * math.pi)
-        )
+        shift_angle = ops.mod(heading_true + angle_per_class / 2, 2 * math.pi)
 
         heading_bin_label_float = ops.floor(
             ops.divide(shift_angle, angle_per_class)

--- a/keras_cv/src/losses/centernet_box_loss.py
+++ b/keras_cv/src/losses/centernet_box_loss.py
@@ -65,6 +65,8 @@ class CenterNetBoxLoss(keras.losses.Loss):
         self.anchor_size = anchor_size
 
     def heading_regression_loss(self, heading_true, heading_pred):
+        heading_pred = ops.convert_to_tensor(heading_pred)
+
         # Set the heading to within 0 -> 2pi
         heading_true = ops.mod(heading_true, 2 * math.pi)
 

--- a/keras_cv/src/losses/centernet_box_loss_test.py
+++ b/keras_cv/src/losses/centernet_box_loss_test.py
@@ -42,3 +42,30 @@ class CenterNetBoxLoss(TestCase):
             y_pred=np.random.uniform(size=(2, 10, 6 + 2 * 4)),
         )
         self.assertEqual(result.shape, target_size)
+
+    def test_heading_regression_loss(self):
+        num_heading_bins = 4
+        loss = keras_cv.losses.CenterNetBoxLoss(
+            num_heading_bins=num_heading_bins, anchor_size=[1.0, 1.0, 1.0]
+        )
+        heading_true = np.array(
+            [[0, (1 / 2.0) * np.pi, np.pi, (3.0 / 2.0) * np.pi]]
+        )
+        heading_pred = np.array(
+            [
+                [
+                    [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                ]
+            ]
+        )
+
+        heading_loss = loss.heading_regression_loss(
+            heading_true=heading_true, heading_pred=heading_pred
+        )
+
+        ce_loss = -np.log(np.exp(1) / np.exp([1, 0, 0, 0]).sum())
+        loss = ce_loss * heading_pred.shape[1]
+        self.assertAllClose(np.sum(heading_loss), loss)

--- a/keras_cv/src/losses/centernet_box_loss_test.py
+++ b/keras_cv/src/losses/centernet_box_loss_test.py
@@ -65,5 +65,5 @@ class CenterNetBoxLoss(TestCase):
             heading_true=heading_true, heading_pred=heading_pred
         )
         ce_loss = -np.log(np.exp(1) / np.exp([1, 0, 0, 0]).sum())
-        expected_loss = ce_loss * heading_pred.shape[1]
+        expected_loss = ce_loss * num_heading_bins
         self.assertAllClose(np.sum(heading_loss), expected_loss)

--- a/keras_cv/src/losses/centernet_box_loss_test.py
+++ b/keras_cv/src/losses/centernet_box_loss_test.py
@@ -16,6 +16,7 @@ import numpy as np
 from absl.testing import parameterized
 
 import keras_cv
+from keras_cv.src.backend import ops
 from keras_cv.src.tests.test_case import TestCase
 
 
@@ -66,4 +67,4 @@ class CenterNetBoxLoss(TestCase):
         )
         ce_loss = -np.log(np.exp(1) / np.exp([1, 0, 0, 0]).sum())
         expected_loss = ce_loss * num_heading_bins
-        self.assertAllClose(np.sum(heading_loss), expected_loss)
+        self.assertAllClose(ops.sum(heading_loss), expected_loss)

--- a/keras_cv/src/losses/centernet_box_loss_test.py
+++ b/keras_cv/src/losses/centernet_box_loss_test.py
@@ -61,11 +61,9 @@ class CenterNetBoxLoss(TestCase):
                 ]
             ]
         )
-
         heading_loss = loss.heading_regression_loss(
             heading_true=heading_true, heading_pred=heading_pred
         )
-
         ce_loss = -np.log(np.exp(1) / np.exp([1, 0, 0, 0]).sum())
-        loss = ce_loss * heading_pred.shape[1]
-        self.assertAllClose(np.sum(heading_loss), loss)
+        expected_loss = ce_loss * heading_pred.shape[1]
+        self.assertAllClose(np.sum(heading_loss), expected_loss)


### PR DESCRIPTION
I am currently doing some experiments with the Waymo 3D Object Detector **Centernet** and found out that there is a bug in the [CenterNetBoxLoss](https://github.com/keras-team/keras-cv/blob/7136ceb3c05335c90670651cc4f5a2ebc1a645ac/keras_cv/src/losses/centernet_box_loss.py#L37) function. 

I trained the model for 2 epochs with the **original loss** function which results in the following predictions on the val set:
![waymo_open_dataset_0](https://github.com/keras-team/keras-cv/assets/5880684/fcfefbbf-176a-4b47-bcb5-ae9e11a4eac1)

Notably there is a constant yaw offset caused by the false `ops.floor()` operation in the loss function applied on the gt heading. 


This PR fixes this issue. The following image depicts the predictions after 2 epochs using the fixed loss function.
![waymo_open_dataset_0](https://github.com/keras-team/keras-cv/assets/5880684/416a5482-f358-4017-9d47-8f7829352478)
(Note, that the network has not converged and no NMS has been applied)

The problem probably raised during the conversion from the Tensorflow op [tf.math.floormod](https://www.tensorflow.org/api_docs/python/tf/math/floormod) to Keras ops. However, 
`tf.math.floormod(a, b)` != `ops.floor(ops.mod(a, b))`
but
`tf.math.floormod(a, b)` = `ops.mod(a, b)`

Hence `ops.floor()` simply removes the accuracy of the gt heading during loss computation.

Additionally, I implemented a test case for the heading classification (+regression) part of the `CenterNetBoxLoss`.



Frameworks & Versions:
- keras-cv==0.8.2
- keras==3.2.0
- tensorflow==2.16.1


@divyashreepathihalli  @sampathweb