### PR TITLE
Correct docstring contradicting class signature

### DIFF
--- a/keras_cv/src/models/stable_diffusion/stable_diffusion.py
+++ b/keras_cv/src/models/stable_diffusion/stable_diffusion.py
@@ -380,7 +380,7 @@ class StableDiffusion(StableDiffusionBase):
             rounded to the nearest valid value. Defaults to 512.
         jit_compile: bool, whether to compile the underlying models to XLA.
             This can lead to a significant speedup on some systems. Defaults to
-            False.
+            True.
 
     Example:
 
@@ -466,7 +466,8 @@ class StableDiffusionV2(StableDiffusionBase):
             rounded to the nearest valid value. Defaults to 512.
         jit_compile: bool, whether to compile the underlying models to XLA.
             This can lead to a significant speedup on some systems. Defaults to
-            False.
+            True.
+
     Example:
 
     ```python


### PR DESCRIPTION
Default parameters contradicted docstring

# What does this PR do?
- This PR fixes a typo or improves the docs

Current behaviour:
```
ipython3
import keras_cv
keras_cv.models.StableDiffusionV2?

Init signature:
keras_cv.models.StableDiffusionV2(
    img_height=512,
    img_width=512,
    jit_compile=True,
)
Docstring:     
Keras implementation of Stable Diffusion v2.
...
    jit_compile: bool, whether to compile the underlying models to XLA.
        This can lead to a significant speedup on some systems. Defaults to
        False.
```

The current function signature contradicts the docstring. This has been fixed with this PR.